### PR TITLE
Errors for Field and LineIntegral

### DIFF
--- a/morpho5/docs/mesh.md
+++ b/morpho5/docs/mesh.md
@@ -32,7 +32,7 @@ Retrieves the position of a vertex given an id:
 
     print m.vertexposition(id)
 
-## Setertexposition
+## Setvertexposition
 [tagsetvertexposition]: # (setvertexposition)
 
 Sets the position of a vertex given an id and a position vector:

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -42,6 +42,9 @@
 #define FIELD_OPRETURN                   "FldOpFn"
 #define FIELD_OPRETURN_MSG               "Could not construct a Field from the return value of the function passed to 'op'."
 
+#define FIELD_MESHARG                    "FldMshArg"
+#define FIELD_MESHARG_MSG                "Field expects a mesh as its first argurment"
+
 void field_zero(objectfield *field);
 
 bool field_getelement(objectfield *field, grade grade, elementid el, int indx, value *out);

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -88,6 +88,7 @@ bool functional_validateargs(vm *v, int nargs, value *args, functional_mapinfo *
             if (info->field) info->mesh = (info->field->mesh); // Retrieve the mesh from the field
         }
     }
+
     
     if (info->mesh) return true;
     morpho_runtimeerror(v, FUNC_INTEGRAND_MESH);
@@ -2344,6 +2345,10 @@ value LineIntegral_init(vm *v, int nargs, value *args) {
         /* Remaining arguments should be fields */
         objectlist *list = object_newlist(nargs-1, & MORPHO_GETARG(args, 1));
         if (!list) { morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED); return MORPHO_NIL; }
+        if (!MORPHO_ISFIELD(MORPHO_GETARG(args, 1))){
+            // if one remaining arguments in not a field throw an error
+            morpho_runtimeerror(v,LINEINTEGRAL_ARGS);
+        }
         value field = MORPHO_OBJECT(list);
         objectinstance_setproperty(self, functional_fieldproperty, field);
         morpho_bindobjects(v, 1, &field);
@@ -2494,5 +2499,6 @@ void functional_initialize(void) {
     morpho_defineerror(NEMATIC_ARGS, ERROR_HALT, NEMATIC_ARGS_MSG);
     morpho_defineerror(NEMATICELECTRIC_ARGS, ERROR_HALT, NEMATICELECTRIC_ARGS_MSG);
     morpho_defineerror(FUNCTIONAL_ARGS, ERROR_HALT, FUNCTIONAL_ARGS_MSG);
+    morpho_defineerror(LINEINTEGRAL_ARGS, ERROR_HALT, LINEINTEGRAL_ARGS_MSG);
 }
  

--- a/morpho5/geometry/functional.h
+++ b/morpho5/geometry/functional.h
@@ -64,6 +64,9 @@
 #define SCALARPOTENTIAL_FNCLLBL        "SclrPtFnCllbl"
 #define SCALARPOTENTIAL_FNCLLBL_MSG    "ScalarPotential function is not callable."
 
+#define LINEINTEGRAL_ARGS              "LnIntArgs"
+#define LINEINTEGRAL_ARGS_MSG          "LineIntegral requires a field as the argument."
+
 #define LINEARELASTICITY_REF           "LnElstctyRef"
 #define LINEARELASTICITY_REF_MSG       "LinearElasticity requires a mesh as the argument."
 

--- a/test/field/badfnin.morpho
+++ b/test/field/badfnin.morpho
@@ -1,0 +1,3 @@
+var m = Mesh("square.mesh")
+var f = Field(m,fn(x,y,z) [1,2])
+// expect error: 'FldOpFn'

--- a/test/field/neg_nilMesh.morpho
+++ b/test/field/neg_nilMesh.morpho
@@ -1,0 +1,2 @@
+Field(nil,Matrix([1,0,0]))
+//expect error 'FldMshArg'

--- a/test/functionals/lineintegral/lineintegral.morpho
+++ b/test/functionals/lineintegral/lineintegral.morpho
@@ -22,3 +22,6 @@ print lcf.integrand(m)
 
 print lcf.total(m)
 // expect: 0.0333333
+
+var badLiField = LineIntegral(fn (x,f) (f*(1-f))^2, nil)
+// expect error 'LnIntArgs'


### PR DESCRIPTION
added errors for constructor failures.
Instead of just returning a nil they now throw and error

This change fixes #14 

Added 3 new errors
1. if a Field fails to field_setelement from the function is constructed with it now throws an error 
2. if a Field is fed a bad mesh its now throws an error
3. if a LineIntergral is not fed a field as its last argument it throws an error 

Fixed a small typo in the doc

I'm unsure if the LineIntegral check I put in the the right way to do it. Could you please double check I used the preferred method there? (I was expecting the field variable to be the field but it that returned false with MORPHO_ISFIELD)  

Finally I've added a test task to make check all the constructors for silent failures. https://wikis.uit.tufts.edu/confluence/x/9wJDC