### PR TITLE
Safer Integrad Evaluation

### DIFF
--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -2499,20 +2499,20 @@ bool integral_prepareref(objectinstance *self, objectmesh *mesh, grade g, object
     return success;
 }
 
-double integral_integrandfn(unsigned int dim, double *t, double *x, unsigned int nquantity, value *quantity, void *ref) {
+bool integral_integrandfn(unsigned int dim, double *t, double *x, unsigned int nquantity, value *quantity, void *ref, double *fout) {
     integralref *iref = ref;
     objectmatrix posn = MORPHO_STATICMATRIX(x, dim, 1);
     value args[nquantity+1], out;
-    double ret = 0;
-    
+        
     args[0]=MORPHO_OBJECT(&posn);
     for (unsigned int i=0; i<nquantity; i++) args[i+1]=quantity[i];
     
     if (morpho_call(iref->v, iref->integrand, nquantity+1, args, &out)) {
-        morpho_valuetofloat(out, &ret);
+        morpho_valuetofloat(out,fout);
+        return true;
     }
     
-    return ret;
+    return false;
 }
 
 /** Integrate a function over a line */

--- a/morpho5/geometry/integrate.c
+++ b/morpho5/geometry/integrate.c
@@ -107,13 +107,19 @@ bool integrate_lineint(integrandfunction *function, unsigned int dim, double *x[
     double af=pow(0.5, (double) recursiondepth); // Length of whole line from recursion depth
     unsigned int i;
     bool success=false;
+    double fout = 0;
     
     /* Try low order method for rapid results on low order functions */
     for (unsigned int i=0; i<gknpts; i++) {
         double tt=0.5*(1.0+gk[3*i]); // Convert [-1,1] to [0,1]
         integrate_interpolatepositionline(dim, x, tt, xx);
         if (nquantity)  integrate_interpolatequantitiesline(dim, tt, nquantity, quantity, q);
-        r[i] = (*function) (dim, &tt, xx, nquantity, q, ref);
+        if ((*function) (dim, &tt, xx, nquantity, q, ref,&fout)){
+            r[i] = fout;
+        }
+        else {
+            return false;
+        }
     }
     
     for (i=0; i<gk1; i++) {
@@ -273,13 +279,18 @@ bool integrate_areaint(integrandfunction *function, unsigned int dim, double *x[
     double xx[dim], gest=ge;
     double af=pow(0.25, (double) recursiondepth); // Area of total triangle covered from recursion depth
     bool success=false;
-    
+    double fout = 0;
     /* Try low order method for rapid results on low order functions */
     for (unsigned int i=0; i<npts1; i++) {
         double *lambda=pts+3*i;
         integrate_interpolatepositiontri(dim, x, lambda, xx);
         if (nquantity)  integrate_interpolatequantitiestri(dim, lambda, nquantity, quantity, q);
-        r[i] = (*function) (dim, lambda, xx, nquantity, q, ref);
+        if ((*function) (dim, lambda, xx, nquantity, q, ref, &fout)){
+            r[i] = fout;
+        } else{
+            return false;
+        }
+        
     }
     rr=(r[1]+r[2]+r[3]);
     rr2=(r[4]+r[5]+r[6]+r[7]+r[8]+r[9]);
@@ -302,7 +313,11 @@ bool integrate_areaint(integrandfunction *function, unsigned int dim, double *x[
         double *lambda=pts+3*i;
         integrate_interpolatepositiontri(dim, x, lambda, xx);
         if (nquantity)  integrate_interpolatequantitiestri(dim, lambda, nquantity, quantity, q);
-        r[i] = (*function) (dim, lambda, xx, nquantity, q, ref);
+        if ((*function) (dim, lambda, xx, nquantity, q, ref, &fout)){
+            r[i] = fout;
+        } else{
+            return false;
+        }
     }
     rr3=(r[10]+r[11]+r[12]+r[13]+r[14]+r[15]+r[16]+r[17]+r[18]+r[19]);
     r3 = wts3[0]*r[0] + wts3[1]*rr + wts3[2]*rr2 + wts3[3]*rr3;

--- a/morpho5/geometry/integrate.h
+++ b/morpho5/geometry/integrate.h
@@ -22,7 +22,7 @@
  * @param[in] ref             - A reference passed by the caller (typically things constant over the domain
  * @returns value of the integrand at the appropriate point with interpolated quantities.
  */
-typedef double (integrandfunction) (unsigned int dim, double *lambda, double *x, unsigned int nquantity, value *quantity, void *ref);
+typedef bool (integrandfunction) (unsigned int dim, double *lambda, double *x, unsigned int nquantity, value *quantity, void *ref, double *fout);
 
 bool integrate_integrate(integrandfunction *integrand, unsigned int dim, unsigned int grade, double **x, unsigned int nquantity, value **quantity, void *ref, double *out);
 

--- a/test/functionals/err_integrand.morpho
+++ b/test/functionals/err_integrand.morpho
@@ -1,0 +1,22 @@
+import meshtools
+import plot
+import functionals
+
+var L = 1.0
+var dx = 0.1
+
+var m = AreaMesh(fn (u, v) [u, v, 0], -L/2..L/2:dx, -L/2..L/2:dx)
+m.addgrade(1)
+
+fn mhdgrad(x,y,z,x0,y0,varphi){
+return Matrix([(y-y0)/((x-x0)^2+(y-y0)^2)/2,-(x-x0)/((x-x0)^2+(y-y0)^2)/2])
+}
+fn phdgrad(x,y,z,x0,y0,varphi){
+return Matrix([-(y-y0)/((x-x0)^2+(y-y0)^2)/2,(x-x0)/((x-x0)^2+(y-y0)^2)/2])
+}
+var defectsGrad = Field(m, fn(x,y,z) phdgrad(x, y, z, 0.25, 0, 0)+mhdgrad(x, y, z, -0.25, 0, 0) )
+
+var directorIntegral = LineIntegral(fn (x,n) 1/(2*Pi) * n.inner(tangent()), defectsGrad)
+
+var fe = directorIntegral.integrand(m)
+//expect error 'MtrxIncmptbl'


### PR DESCRIPTION
changed integrandfunction to output a success bool (the return value is now returned by reference via fout)

This now lets the integrator error out if its integrand does not evaluate.

Fixes #16 

Added test test/functionals/err_integrand.morpho