### PR TITLE
Check both operands for float type before checking type tag

### DIFF
--- a/morpho5/datastructures/value.h
+++ b/morpho5/datastructures/value.h
@@ -91,8 +91,8 @@ static inline double valuetodouble(value v) {
 #define MORPHO_GETOBJECT(v)         ((object *) (uintptr_t) ((v) & ~(TAG_OBJ | QNAN)))
 
 static inline bool morpho_ofsametype(value a, value b) {
-    if (MORPHO_ISFLOAT(a)) {
-        return MORPHO_ISFLOAT(b);
+    if (MORPHO_ISFLOAT(a) || MORPHO_ISFLOAT(b)) {
+        return MORPHO_ISFLOAT(a) && MORPHO_ISFLOAT(b);
     } else {
         if ((a & TYPE_BITS)==(b & TYPE_BITS)) {
             return true;

--- a/test/operator/more_comparison.morpho
+++ b/test/operator/more_comparison.morpho
@@ -6,6 +6,8 @@ print 1==2 // expect: false
 print 1.0==1 // expect: true
 print 1==1.000000001 // expect: false
 print 1==1.000000000000001 // expect: false
+print 0==0.4 // expect: false
+print 0.4==0 // expect: false
 print "Eggs"=="Eggs" // expect: true
 print "Eggs"=="Bacon" // expect: false
 
@@ -14,6 +16,8 @@ print "-" // expect: -
 // Neq
 print 1!=1 // expect: false
 print 1!=2 // expect: true
+print 0!=0.4 // expect: true
+print 0.4!=0 // expect: true
 print "Eggs"!="Eggs" // expect: false
 print "Eggs"!="Bacon" // expect: true
 
@@ -26,6 +30,8 @@ print 2<1 // expect: false
 print 1<1.000000001 // expect: true
 print 1.000000001<1.000000001 // expect: false
 print 1.000000002<1.000000001 // expect: false
+print 0<0.4 // expect: true
+print 0.4<0 // expect: false
 
 print "-" // expect: -
 
@@ -36,6 +42,8 @@ print 2<=1 // expect: false
 print 1<=1.000000001 // expect: true
 print 1.000000001<=1.000000001 // expect: true
 print 1.000000002<=1.000000001 // expect: false
+print 0<=0.4 // expect: true
+print 0.4<=0 // expect: false
 
 print "-" // expect: -
 
@@ -46,6 +54,8 @@ print 2>1 // expect: true
 print 1>1.000000001 // expect: false
 print 1.000000001>1.000000001 // expect: false
 print 1.000000002>1.000000001 // expect: true
+print 0>0.4 // expect: false
+print 0.4>0 // expect: true
 
 print "-" // expect: -
 
@@ -57,3 +67,5 @@ print 1>=1.000000001 // expect: false
 print 1.000000001>=1.000000001 // expect: true
 print 1.000000002>=1.000000001 // expect: true
 print 1.000000001>=1.000000002 // expect: false
+print 0>=0.4 // expect: false
+print 0.4>=0 // expect: true


### PR DESCRIPTION
In the function `morpho_ofsametype`, if the operand `a` is not a float, then the type tag bits for both `a` and `b` are checked. However, if `b` is a float, then we have a problem as valid floating point values will have the type bits set, leading to an incorrect result that both types are the same even when they are not. This can be resolved by checking if either operand is a float first, and only moving to the second branch if neither operand is a float.

This should resolve #41.