### PR TITLE
Added optional flag to turn off display in POVRaytracer render 

### DIFF
--- a/morpho5/docs/povray.md
+++ b/morpho5/docs/povray.md
@@ -20,6 +20,8 @@ Create, render and display a scene using POVRay:
 
     pov.render("out.pov")
 
+This also creates the .png file for the scene.
+
 The `POVRaytracer` constructor supports a number of optional arguments:
 
 * `antialias` - whether to antialias the output or not
@@ -27,3 +29,8 @@ The `POVRaytracer` constructor supports a number of optional arguments:
 * `height` - image height
 * `viewangle` - camera angle (higher means wider view)
 * `viewpoint` - position of camera
+
+The `render` method supports two optional boolean arguments:
+
+* `quiet` - whether to suppress the parser and render statistics from `povray` or not (`false` by default)
+* `display` - whether to turn on the graphic display while rendering or not (`true` by default) 

--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -141,6 +141,6 @@ class POVRaytracer {
     if (!display) disp = "-D"
     system("povray ${path} ${disp} +A +W${self.width} +H${self.height} ${silent}")
     var out = path.split(".")[0]
-    if (!quiet) system("open ${out}.png")
+    if (!quiet && display) system("open ${out}.png")
   }
 }

--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -133,11 +133,13 @@ class POVRaytracer {
     return out.relativepath()
   }
 
-  render(file, quiet=false) {
+  render(file, quiet=false, display=true) {
     var path = self.write(file)
     var silent = ""
     if (quiet) silent = "&> /dev/null"
-    system("povray ${path} +A +W${self.width} +H${self.height} ${silent}")
+    var disp = ""
+    if (!display) disp = "-D"
+    system("povray ${path} ${disp} +A +W${self.width} +H${self.height} ${silent}")
     var out = path.split(".")[0]
     if (!quiet) system("open ${out}.png")
   }


### PR DESCRIPTION
When rendering `POVRaytracer` objects in a loop, one might want to turn graphic display off. I added an optional `display=true` flag to the `render` method that achieves this, while not affecting the default behavior. When `display=false`, an optional flag of `-D` is added to the `povray` system call, which turns off the graphic display.

I am not sure how to add an automated test for this, but here is a MWE that generates `test.pov` and `test.png` without opening up the graphic display:

`import meshtools`
`import plot`
`import povray`

`var m = LineMesh(fn (t) [t,0,0], -1..1:0.2)`

`var g = plotmesh(m)`
`var pov = POVRaytracer(g)`
`pov.render("test.pov", display=false)`

Removing the `display` flag or setting it to `true` should result in the default behavior. Tested on Ubuntu 20.04 and on WSL-Ubuntu on Windows.