### PR TITLE
Boundary selection now has guaranteed grade 0 elements. Updated test.

### DIFF
--- a/morpho5/geometry/selection.c
+++ b/morpho5/geometry/selection.c
@@ -192,6 +192,8 @@ void selection_selectboundary(vm *v, objectselection *sel) {
             }
         }
     }
+    // Add vertices if the boundary elements are higher in grade than vertices
+    if (bnd!=0) {selection_addgradelower(sel, 0); }
 }
 
 /** Selects an element */

--- a/test/selection/boundary.morpho
+++ b/test/selection/boundary.morpho
@@ -10,7 +10,6 @@ lst.sort()
 print lst
 // expect: [ 0, 1, 3, 4 ]
 
-s.addgrade(0)
 lst = s.idlistforgrade(0)
 lst.sort()
 


### PR DESCRIPTION
My attempt at making sure that the boundary selection has grade 0 elements. I noticed that Selections made using anonymous functions do have grade 0 elements, but the ones made using `boundary=true` only have grade `(mesh.maxgrade()-1)` elements. I added a simple line to `selection_selectboundary` to add grade 0 elements if it's not a 1D mesh. I have also updated the boundary.morpho test which now returns the correct `idlistforgrade(0)` of the selection even without adding grade 0 explicitly.

Not sure whether this is the ideal way of solving the problem though.