### PR TITLE
Adding grade 0 to a mesh should now do nothing. Added test.

### DIFF
--- a/morpho5/geometry/mesh.c
+++ b/morpho5/geometry/mesh.c
@@ -177,6 +177,7 @@ objectsparse *mesh_newconnectivityelement(objectmesh *mesh, unsigned int row, un
 
 /** Sets a connectivity element */
 bool mesh_setconnectivityelement(objectmesh *mesh, unsigned int row, unsigned int col, objectsparse *el) {
+    if (row==col) return false;
     value indx[2]={MORPHO_INTEGER(row),MORPHO_INTEGER(col)};
     if (mesh_checkconnectivity(mesh)) {
         value old = MORPHO_NIL;
@@ -993,7 +994,7 @@ value Mesh_addgrade(vm *v, int nargs, value *args) {
 
     if (nargs==1 && MORPHO_ISINTEGER(MORPHO_GETARG(args, 0))) {
         unsigned int g=MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
-
+        if (g==0) return MORPHO_NIL;
         objectsparse *s=mesh_getconnectivityelement(m, 0, g);
         if (!s) {
             s=mesh_addgrade(m, g);

--- a/test/mesh/addgradezero.morpho
+++ b/test/mesh/addgradezero.morpho
@@ -1,0 +1,4 @@
+import meshtools
+var m = LineMesh(fn (t) [t,0,0], -1..1:1)
+m.addgrade(0)
+print m.connectivitymatrix(0,0) // expect: nil

--- a/test/mesh/addgradezero.morpho
+++ b/test/mesh/addgradezero.morpho
@@ -1,4 +1,14 @@
+// Test to confirm that adding grade 0 to a mesh doesn't change anything.
 import meshtools
+import symmetry
 var m = LineMesh(fn (t) [t,0,0], -1..1:1)
 m.addgrade(0)
 print m.connectivitymatrix(0,0) // expect: nil
+var s = Selection(m, fn (x,y,z) x<-0.5 || x>0.5)
+var t = Translate(Matrix([2,0,0]))
+m.addsymmetry(t, s)
+m.addgrade(0)
+print m.connectivitymatrix(0,0)
+// expect: [ 0 0 <Translate> ]
+// expect: [ 0 0 0 ]
+// expect: [ 0 0 0 ]


### PR DESCRIPTION
Adding grade 0 elements to a mesh should do nothing since all meshes are required to have them. However, upon calling `addgrade(0)` on a mesh, the connectivity matrix for (0,0) was being set equal to the connectivity matrix of (0,1), causing unwanted problems. (This was probably happening at line 327 in the function `mesh_addgrade`.)

With this fix, the `Mesh_addgrade` function returns `MORPHO_NIL` if grade is 0. Additionally, the `mesh_setconnectivityelement` function now returns `false` if `row` and `col` are same, making sure that the diagonal connectivity matrices are untouched. (Assuming those are always supposed to be `nil`.)

A new test `test/mesh/addgradezero.morpho` ensures that the connectivitymatrix(0,0) remains `nil` upon adding grade 0.

This should resolve #50.

Co-Authored-By: Matt Peterson <matthew.se.peterson@gmail.com>