### PR TITLE
Added `transmit` and `filter` options for Graphics objects, to be used by POV-Ray 

### DIFF
--- a/examples/povray/testpovraytransmitfilter.morpho
+++ b/examples/povray/testpovraytransmitfilter.morpho
@@ -6,48 +6,44 @@ import constants
 import color
 import plot
 import povray
+import meshtools
 
 var transmit = 0.5
 var filter = 0.5
 
-var icos = [[-0.688191, 0, 0.131433], [0.688191,
-    0, -0.131433], [-0.212663, -0.654508, 0.131433], [-0.212663,
-    0.654508, 0.131433], [0.556758, -0.404508, 0.131433], [0.556758,
-    0.404508, 0.131433], [-0.131433, -0.404508, 0.556758], [-0.131433,
-    0.404508, 0.556758], [-0.344095, -0.25, -0.556758], [-0.344095,
-    0.25, -0.556758], [0.344095, -0.25, 0.556758], [0.344095, 0.25,
-    0.556758], [0.425325,
-    0, -0.556758], [-0.556758, -0.404508, -0.131433], [-0.556758,
-    0.404508, -0.131433], [-0.425325, 0.,
-    0.556758], [0.131433, -0.404508, -0.556758], [0.131433,
-    0.404508, -0.556758], [0.212663, -0.654508, -0.131433], [0.212663,
-    0.654508, -0.131433]]
-
-var faces = [[14, 9, 8, 13, 0], [1, 5, 11, 10, 4], [4, 10, 6, 2, 18], [10, 11, 7,
-    15, 6], [11, 5, 19, 3, 7], [5, 1, 12, 17, 19], [1, 4, 18, 16,
-    12], [3, 19, 17, 9, 14], [17, 12, 16, 8, 9], [16, 18, 2, 13, 8], [2,
-    6, 15, 0, 13], [15, 7, 3, 14, 0]]
-
-
 fn demo() {
-    var p = PolyhedronMesh(icos, faces)
-    var f = Field(p, fn(x, y, z) x)
-    var g = plotfield(f, style = "interpolate")
 
-    for (i in 0...30) {
-        var xx = Matrix([2 * (random() - 1 / 2), 2 * (random() - 1 / 2), 2 * (random() - 1 / 2)])
-        while (xx.norm() < 0.7) xx = Matrix([2 * (random() - 1 / 2), 2 * (random() - 1 / 2), 2 * (random() - 1 / 2)])
-        g.display(Sphere(xx, 0.05 * (1 + random()), color = Color(random(), random(), random()), transmit = transmit, filter = filter))
-    }
-    g.display(Cylinder([-1, -1, -1], [1, 1, 1], aspectratio = 0.01, color = Gray(0.3), transmit = 0.5))
-    g.display(Arrow([-1, -1, -1], [-0.5, -1, -1], aspectratio = 0.05, color = Red, transmit = transmit, filter = filter))
-    g.display(Arrow([-1, -1, -1], [-1, -0.5, -1], aspectratio = 0.05, color = Green, transmit = transmit, filter = filter))
-    g.display(Arrow([-1, -1, -1], [-1, -1, -0.5], aspectratio = 0.05, color = Blue, transmit = transmit, filter = filter))
+    var m1 = AreaMesh(fn (u,v) [u,v,-1], -1..1:0.5, -1..1:0.5)
+    var m2 = AreaMesh(fn (u,v) [u,1,v], -1..1:0.2, -1..1:0.2)
 
-    var c = []
-    for (t in 0...2 * Pi: 2 * Pi / 40) c.append([cos(t), sin(t), 0])
-    g.display(Tube(c, 0.05, color = Gray(0.5), closed = true, transmit = transmit, filter = filter))
+    var gauss = Field(m2, fn(x,y,z) exp(-x^2-z^2))
+    var g = plotmesh(m1)
+    g = g + plotfield(gauss, style="interpolate")
 
+    // Plot Blue spheres with increasing transmit values
+    g.display(Sphere(Matrix([-0.45,0.8,-0.8]), 0.1, color=Blue))
+    g.display(Sphere(Matrix([-0.15,0.8,-0.8]), 0.1, color=Blue, transmit=0.1))
+    g.display(Sphere(Matrix([0.15,0.8,-0.8]), 0.1, color = Blue, transmit = 0.4))
+    g.display(Sphere(Matrix([0.45, 0.8, -0.8]), 0.1, color = Blue, transmit = 0.7))
+    
+    // Plot Blue spheres with increasing filter values.
+    // Note the difference in the color of the shadow from the transmit ones.
+    g.display(Sphere(Matrix([-0.45,0.4,-0.8]), 0.1, color=Red))
+    g.display(Sphere(Matrix([-0.15,0.4,-0.8]), 0.1, color=Red, filter = 0.1))
+    g.display(Sphere(Matrix([0.15,0.4,-0.8]), 0.1, color = Red, filter = 0.4))
+    g.display(Sphere(Matrix([0.45, 0.4, -0.8]), 0.1, color = Red, filter = 0.7))
+    
+    // Test all the other Graphics objects with transmit and filter
+    g.display(Arrow([-0.5, 0.0, -0.8], [-0.1, 0.0, -0.8], color = Blue, transmit = 0.75))
+    g.display(Arrow([0.1, 0.0, -0.8], [0.5, 0.0, -0.8], color = Red, filter = 0.75))
+    
+    g.display(Cylinder([-0.5, -0.4, -0.8], [-0.1, -0.4, -0.8], color = Blue, transmit = 0.75))
+    g.display(Cylinder([0.1, -0.4, -0.8], [0.5, -0.4, -0.8], color = Red, filter = 0.75))
+        
+    var pts1 = [[-0.3, -0.75, -0.8], [-0.4, -0.85, -0.8], [-0.2, -0.85, -0.8], [-0.3, -0.75, -0.8]]
+    var pts2 = [[0.3, -0.75, -0.8], [0.2, -0.85, -0.8], [0.4, -0.85, -0.8], [0.3, -0.75, -0.8]]
+    g.display(Tube(pts1, 0.02, color=Blue, transmit = 0.75) )
+    g.display(Tube(pts2, 0.02, color=Red, filter = 0.75) )
     g.background = White
 
     return g
@@ -56,9 +52,10 @@ fn demo() {
 var g = demo()
 
 var pov = POVRaytracer(g)
-pov.viewpoint = Matrix([0, 0, -5])
+pov.viewpoint = Matrix([1.2, 6, -3.6])
 pov.viewangle = 35
-pov.light = [Matrix([10, 10, 10]), Matrix([-10, -10, 10])]
+// pov.light = [Matrix([10, 10, 10]), Matrix([-10, -10, 10])]
+pov.light =[Matrix([-10, -10, 10])]
 pov.render("out.pov")
 
 Show(g)

--- a/examples/povray/testpovraytransmitfilter.morpho
+++ b/examples/povray/testpovraytransmitfilter.morpho
@@ -1,0 +1,64 @@
+// Demonstrate use of the povray module to raytrace graphics.
+// Additionally, demonstrate the use of the transmit and filter
+// attributes in the Graphics objects. These attributes are used by
+// povray to make the graphics transparent.
+import constants
+import color
+import plot
+import povray
+
+var transmit = 0.5
+var filter = 0.5
+
+var icos = [[-0.688191, 0, 0.131433], [0.688191,
+    0, -0.131433], [-0.212663, -0.654508, 0.131433], [-0.212663,
+    0.654508, 0.131433], [0.556758, -0.404508, 0.131433], [0.556758,
+    0.404508, 0.131433], [-0.131433, -0.404508, 0.556758], [-0.131433,
+    0.404508, 0.556758], [-0.344095, -0.25, -0.556758], [-0.344095,
+    0.25, -0.556758], [0.344095, -0.25, 0.556758], [0.344095, 0.25,
+    0.556758], [0.425325,
+    0, -0.556758], [-0.556758, -0.404508, -0.131433], [-0.556758,
+    0.404508, -0.131433], [-0.425325, 0.,
+    0.556758], [0.131433, -0.404508, -0.556758], [0.131433,
+    0.404508, -0.556758], [0.212663, -0.654508, -0.131433], [0.212663,
+    0.654508, -0.131433]]
+
+var faces = [[14, 9, 8, 13, 0], [1, 5, 11, 10, 4], [4, 10, 6, 2, 18], [10, 11, 7,
+    15, 6], [11, 5, 19, 3, 7], [5, 1, 12, 17, 19], [1, 4, 18, 16,
+    12], [3, 19, 17, 9, 14], [17, 12, 16, 8, 9], [16, 18, 2, 13, 8], [2,
+    6, 15, 0, 13], [15, 7, 3, 14, 0]]
+
+
+fn demo() {
+    var p = PolyhedronMesh(icos, faces)
+    var f = Field(p, fn(x, y, z) x)
+    var g = plotfield(f, style = "interpolate")
+
+    for (i in 0...30) {
+        var xx = Matrix([2 * (random() - 1 / 2), 2 * (random() - 1 / 2), 2 * (random() - 1 / 2)])
+        while (xx.norm() < 0.7) xx = Matrix([2 * (random() - 1 / 2), 2 * (random() - 1 / 2), 2 * (random() - 1 / 2)])
+        g.display(Sphere(xx, 0.05 * (1 + random()), color = Color(random(), random(), random()), transmit = transmit, filter = filter))
+    }
+    g.display(Cylinder([-1, -1, -1], [1, 1, 1], aspectratio = 0.01, color = Gray(0.3), transmit = 0.5))
+    g.display(Arrow([-1, -1, -1], [-0.5, -1, -1], aspectratio = 0.05, color = Red, transmit = transmit, filter = filter))
+    g.display(Arrow([-1, -1, -1], [-1, -0.5, -1], aspectratio = 0.05, color = Green, transmit = transmit, filter = filter))
+    g.display(Arrow([-1, -1, -1], [-1, -1, -0.5], aspectratio = 0.05, color = Blue, transmit = transmit, filter = filter))
+
+    var c = []
+    for (t in 0...2 * Pi: 2 * Pi / 40) c.append([cos(t), sin(t), 0])
+    g.display(Tube(c, 0.05, color = Gray(0.5), closed = true, transmit = transmit, filter = filter))
+
+    g.background = White
+
+    return g
+}
+
+var g = demo()
+
+var pov = POVRaytracer(g)
+pov.viewpoint = Matrix([0, 0, -5])
+pov.viewangle = 35
+pov.light = [Matrix([10, 10, 10]), Matrix([-10, -10, 10])]
+pov.render("out.pov")
+
+Show(g)

--- a/morpho5/docs/graphics.md
+++ b/morpho5/docs/graphics.md
@@ -52,6 +52,15 @@ To create one, call the constructor with the following arguments:
 * `colors` is the color of the object.
 * `connectivity` is a `Sparse` matrix where each column represents a triangle and rows correspond to vertices.
 
+You can also provide optional arguments:
+
+* `transmit` sets the transparency of the object. This parameter is only
+used by the povray module as of now. Default is 0.
+* `filter` sets the transparency of the object using a filter effect.
+This parameter is only used by the povray module as of now. Default is 0. For the difference between `transmit` and `filter`, checkout the 
+[POVRay documentation](http://xahlee.info/3d/povray-glassy.html).
+
+
 Add to a `Graphics` object using the `display` method.
 
 ## Arrow
@@ -68,6 +77,11 @@ You can also provide optional arguments:
 * `aspectratio` controls the width of the arrow relative to its length
 * `n` is an integer that controls the quality of the display. Higher `n` leads to a rounder arrow.
 * `color` is the color of the arrow. This can be a list of RGB values or a `Color` object
+* `transmit` sets the transparency of the arrow. This parameter is only
+used by the povray module as of now. Default is 0.
+* `filter` sets the transparency of the arrow using a filter effect.
+This parameter is only used by the povray module as of now. Default is 0. For the difference between `transmit` and `filter`, checkout the 
+[POVRay documentation](http://xahlee.info/3d/povray-glassy.html).
 
 Display an arrow:
 
@@ -89,6 +103,11 @@ You can also provide optional arguments:
 * `aspectratio` controls the width of the cylinder relative to its length.
 * `n` is an integer that controls the quality of the display. Higher `n` leads to a rounder cylinder.
 * `color` is the color of the cylinder. This can be a list of RGB values or a `Color` object.
+* `transmit` sets the transparency of the cylinder. This parameter is only
+used by the povray module as of now. Default is 0.
+* `filter` sets the transparency of the cylinder using a filter effect.
+This parameter is only used by the povray module as of now. Default is 0. For the difference between `transmit` and `filter`, checkout the 
+[POVRay documentation](http://xahlee.info/3d/povray-glassy.html).
 
 Display an cylinder:
 
@@ -111,6 +130,11 @@ You can also provide optional arguments:
 * `n` is an integer that controls the quality of the display. Higher `n` leads to a rounder tube.
 * `color` is the color of the tube. This can be a list of RGB values or a `Color` object.
 * `closed` is a `bool` that indicates whether the tube should be closed to form a loop.
+* `transmit` sets the transparency of the tube. This parameter is only
+used by the povray module as of now. Default is 0.
+* `filter` sets the transparency of the tube using a filter effect.
+This parameter is only used by the povray module as of now. Default is 0. For the difference between `transmit` and `filter`, checkout the 
+[POVRay documentation](http://xahlee.info/3d/povray-glassy.html).
 
 Draw a square:
 
@@ -131,6 +155,11 @@ The `Sphere` function creates a sphere.
 You can also provide an optional argument:
 
 * `color` is the color of the sphere. This can be a list of RGB values or a `Color` object.
+* `transmit` sets the transparency of the sphere. This parameter is only
+used by the povray module as of now. Default is 0.
+* `filter` sets the transparency of the sphere using a filter effect.
+This parameter is only used by the povray module as of now. Default is 0. For the difference between `transmit` and `filter`, checkout the 
+[POVRay documentation](http://xahlee.info/3d/povray-glassy.html).
 
 Draw some randomly sized spheres:
 

--- a/morpho5/modules/graphics.morpho
+++ b/morpho5/modules/graphics.morpho
@@ -48,11 +48,15 @@ fn randomalphanumstring(n) {
 /** TriangleComplexes are a basic graphical unit that draw a set of triangles
    from a given set of vertices. */
 class TriangleComplex {
-  init(position, normals, colors, connectivity) {
+  init(position, normals, colors, connectivity, filter=nil, transmit=nil) {
     self.position=position /* Vertex position matrix */
     self.normals=normals /* Matrix of normal vectors */
     self.colors=colors /* Color */
     self.connectivity=connectivity /* Connectivity matrix; columns are triangles */
+    
+    /* Optional arguments to be used by povray*/
+    self.filter = filter 
+    self.transmit = transmit
   }
 
 	/* Serialize the triangle complex to morphoview format */
@@ -120,12 +124,16 @@ class GraphicsPrimitive {
   @param[in] n - number of faces to use
   @param[in] color - Color of the sphere */
 class Cylinder < GraphicsPrimitive {
-  init(start, end, aspectratio=0.1, n=10, color=nil) {
+  init(start, end, aspectratio=0.1, n=10, color=nil, filter=nil, transmit=nil) {
     self.start = Matrix(start)
     self.end = Matrix(end)
     self.aspectratio = aspectratio
     self.n = n
     self.color = color
+
+    /* Optional arguments to be used by povray*/
+    self.filter = filter 
+    self.transmit = transmit
   }
 
   totrianglecomplex() {
@@ -203,7 +211,7 @@ class Cylinder < GraphicsPrimitive {
       conn[n+i+1,3*n+i]=1
     }
 
-    return TriangleComplex(vertices, normals, col, conn)
+      return TriangleComplex(vertices, normals, col, conn)
   }
 
   accept(visitor, out) {
@@ -236,11 +244,15 @@ var sphere = [ PolyhedronMesh(
   @param[in] r - radius
   @param[in] color - Color of the sphere */
 class Sphere < GraphicsPrimitive {
-  init(center, r, color=nil, maxrefine = 3) {
+  init(center, r, color=nil, maxrefine = 3, filter=nil, transmit=nil) {
     self.center = center
     self.r = r
     self.color = color
     self.maxrefine = maxrefine
+
+    /* Optional arguments to be used by povray*/
+    self.filter = filter 
+    self.transmit = transmit
   }
 
   totrianglecomplex () {
@@ -287,12 +299,16 @@ class Sphere < GraphicsPrimitive {
   @param[in] n - number of faces to use
   @param[in] color - Color of the sphere */
 class Arrow < GraphicsPrimitive {
-  init(start, end, aspectratio=0.1, n=10, color=nil) {
+  init(start, end, aspectratio=0.1, n=10, color=nil, filter=nil, transmit=nil) {
     self.start = Matrix(start)
     self.end = Matrix(end)
     self.aspectratio = aspectratio
     self.n = n
     self.color = color
+
+    /* Optional arguments to be used by povray*/
+    self.filter = filter 
+    self.transmit = transmit
   }
 
   totrianglecomplex () {
@@ -406,12 +422,16 @@ class Tube < GraphicsPrimitive {
     return out
   }
 
-  init(pts, rad, n=10, color=nil, closed=false) {
+    init(pts, rad, n=10, color=nil, closed=false, filter=nil, transmit=nil) {
     self.pts = pts
     self.radius = rad
     self.n = n
     self.closed = closed
     self.color = color
+
+    /* Optional arguments to be used by povray*/
+    self.filter = filter
+    self.transmit = transmit
   }
 
   totrianglecomplex() {
@@ -524,7 +544,7 @@ class Tube < GraphicsPrimitive {
   		}
   	}
 
-    return TriangleComplex(vertices, normals, col, conn)
+      return TriangleComplex(vertices, normals, col, conn, filter=nil, transmit=nil)
   }
 
   accept(visitor, out) {

--- a/morpho5/modules/graphics.morpho
+++ b/morpho5/modules/graphics.morpho
@@ -544,7 +544,7 @@ class Tube < GraphicsPrimitive {
   		}
   	}
 
-      return TriangleComplex(vertices, normals, col, conn, filter=nil, transmit=nil)
+      return TriangleComplex(vertices, normals, col, conn, filter=self.filter, transmit=self.transmit)
   }
 
   accept(visitor, out) {

--- a/morpho5/modules/plot.morpho
+++ b/morpho5/modules/plot.morpho
@@ -55,7 +55,7 @@ fn plotcolortomatrix(color) {
                       can be a single color
                       a matrix with columns corresponding to elements
                       a list of such matrices for each grade */
-fn plotmesh(mesh, selection=nil, grade=nil, color=nil) {
+fn plotmesh(mesh, selection=nil, grade=nil, color=nil,  filter=nil, transmit=nil) {
   var g = Graphics()
   var glist = []
   if (isnil(grade)) glist.append(mesh.maxgrade())
@@ -78,7 +78,7 @@ fn plotmesh(mesh, selection=nil, grade=nil, color=nil) {
     for (i in 0...np) {
       if (isselection(selection) && !selection.isselected(0, i)) continue // Skip unselected components
 
-      g.display(Sphere(vert.column(i), 0.025, color=plotcolorforelement(vcol, i)))
+      g.display(Sphere(vert.column(i), 0.025, color=plotcolorforelement(vcol, i), filter=filter, transmit=transmit))
     }
   }
 
@@ -91,7 +91,7 @@ fn plotmesh(mesh, selection=nil, grade=nil, color=nil) {
         if (isselection(selection) && !selection.isselected(1, i)) continue // Skip unselected components
         var el = lines.rowindices(i)
         g.display(Cylinder(vert.column(el[0]), vert.column(el[1]),
-                          aspectratio=0.05, color=plotcolorforelement(lcol, i)))
+                          aspectratio=0.05, color=plotcolorforelement(lcol, i), filter=filter, transmit=transmit))
       }
     }
   }
@@ -146,7 +146,7 @@ fn plotmesh(mesh, selection=nil, grade=nil, color=nil) {
         nnt+=1
       }
 
-      g.display(TriangleComplex(nvert, norm, ncol, tri))
+      g.display(TriangleComplex(nvert, norm, ncol, tri, filter=filter, transmit=transmit))
     }
 
   }
@@ -158,7 +158,7 @@ fn plotmesh(mesh, selection=nil, grade=nil, color=nil) {
  * @param[in] mesh - mesh to plot
  * @param[in] selection - selection
  * @param[in] grade - Grades to show */
-fn plotselection(mesh, selection, grade=nil) {
+fn plotselection(mesh, selection, grade=nil, filter=nil, transmit=nil) {
   var ngrades = mesh.maxgrade()
   var col[ngrades+1]
 
@@ -183,7 +183,7 @@ fn plotselection(mesh, selection, grade=nil) {
     col[g]=cmat
   }
 
-  return plotmesh(mesh, grade=grade, color=col)
+  return plotmesh(mesh, grade=grade, color=col, filter=filter, transmit=transmit)
 }
 
 /** Visualizes a field
@@ -192,7 +192,7 @@ fn plotselection(mesh, selection, grade=nil) {
  * @param[in] colormap - Colormap to use
  * @param[in] style - style to use
  * @param[in] scale - whether or not to scale values */
-fn plotfield(field, grade=nil, colormap=nil, style=nil, scale=true) {
+fn plotfield(field, grade=nil, colormap=nil, style=nil, scale=true, filter=nil, transmit=nil) {
   var mesh = field.mesh()
   var shape = field.shape()
 
@@ -237,5 +237,5 @@ fn plotfield(field, grade=nil, colormap=nil, style=nil, scale=true) {
     }
   }
 
-  return plotmesh(mesh, grade=showgrades, color=col)
+  return plotmesh(mesh, grade=showgrades, color=col, filter=filter, transmit=transmit)
 }

--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -21,20 +21,38 @@ class POVRaytracer {
     else return self.vector(c.rgb(0))
   }
 
+  optionalarg(item){
+    
+    var arg = ""
+  
+    if(isnil(item.filter) && !isnil(item.transmit)){
+      arg = "transmit ${item.transmit}"
+    }
+    else if(!isnil(item.filter) && isnil(item.transmit)){
+      arg = "filter ${item.filter}"
+    }
+    else if(!isnil(item.filter) && !isnil(item.transmit)){
+      arg = "filter ${item.filter} transmit ${item.transmit}"
+    }
+    return arg
+  }
+
   visitsphere(item, out) {
+    var arg = self.optionalarg(item)
     out.write("sphere {"+
               " ${self.vector(item.center)}, ${item.r}"+
               " texture { "+
-              " pigment { rgb ${self.color(item.color)}"+
+              " pigment { rgb ${self.color(item.color)} ${arg}"+
               "} } }")
   }
 
   visitcylinder(item, out) {
     var radius = 0.5*(item.end - item.start).norm()*item.aspectratio
+    var arg = self.optionalarg(item)
     out.write("cylinder {"+
               " ${self.vector(item.start)}, ${self.vector(item.end)}, ${radius}"+
               " texture { "+
-              " pigment { rgb ${self.color(item.color)} "+
+              " pigment { rgb ${self.color(item.color)} ${arg}"+
               "} } }")
   }
 
@@ -42,15 +60,16 @@ class POVRaytracer {
     var dx = (item.end - item.start).norm()
     var radius = 0.5*dx*item.aspectratio
     var cylend = item.start + (item.end - item.start)*(1-item.aspectratio)
+    var arg = self.optionalarg(item)
     out.write("cylinder {"+
               " ${self.vector(item.start)}, ${self.vector(cylend)}, ${radius}"+
               " texture { "+
-              " pigment { rgb ${self.color(item.color)} "+
+              " pigment { rgb ${self.color(item.color)} ${arg} "+
               "} } }")
     out.write("cone {"+
               " ${self.vector(cylend)}, ${2*radius}, ${self.vector(item.end)}, 0"+
               " texture { "+
-              " pigment { rgb ${self.color(item.color)} "+
+              " pigment { rgb ${self.color(item.color)} ${arg} "+
               "} } }")
   }
 
@@ -59,6 +78,9 @@ class POVRaytracer {
   }
 
   visittrianglecomplex(item, out) {
+
+    var arg = self.optionalarg(item)
+
     out.write("mesh2 {");
 
     var nv=item.position.dimensions()[1]
@@ -83,7 +105,7 @@ class POVRaytracer {
     if (individualcolors) {
       out.write("texture_list { ${nv}, ")
       for (i in 0...nv) {
-        var s = "texture{ pigment{ rgb ${self.vector(item.colors.column(i))} } }"
+        var s = "texture{ pigment{ rgb ${self.vector(item.colors.column(i))} ${arg} } }"
         if (i<nv-1) s+=", "
         out.write(s)
       }
@@ -103,7 +125,7 @@ class POVRaytracer {
 
     if (!individualcolors) {
       out.write(" texture { "+
-                " pigment { rgb ${self.color(item.colors)} "+
+                " pigment { rgb ${self.color(item.colors)} ${arg} "+
                 "} }")
     }
 


### PR DESCRIPTION
The POV-Ray library provides a couple parameters to make objects transparent, namely `transmit` and `filter` (see [here](http://xahlee.info/3d/povray-glassy.html) for the POV-Ray documentation). This PR would allow users to pass these as arguments to `Graphics` objects like `Sphere`, `Cylinder`, etc. and the effect would show up in the corresponding `POVRaytracer` output. For example,

`var g = Graphics()`
`g.display(Sphere(Matrix([0,0,0]), 1, transmit=0.75))`

These arguments can also be passed to `plotmesh`, `plotselection` and `plotfield`. The effect is currently not visible in the `morphoview` application. 

As an example / test of this, another file is added under `examples/povray` that generates objects with varying values of the `transmit` and `filter` parameters. Here is the output of that example. The blue objects are made transparent using the `transmit` option while the red ones using the `filter` option (the red ones cast a red shadow). The two squares are meshes and the top one has a Gaussian field living on it. These are added so as to give a surface to test the transparency / shadows of the objects and to optionally test the transparency on `plotmesh` and `plotfield`.

![out](https://user-images.githubusercontent.com/16670570/149210071-7dd526b9-015a-4a2e-8990-7f2cb75c2eaf.png)

