### PR TITLE
Minorfixes

### DIFF
--- a/morpho5/builtin/functions.c
+++ b/morpho5/builtin/functions.c
@@ -277,11 +277,11 @@ typedef struct {
 static bool minmaxfn(vm *v, indx i, value val, void *ref) {
     minmaxstruct *m=(minmaxstruct *) ref;
     value l=m->min, r=val;
-    MORPHO_CHECKCMPTYPE(l, r)
+    MORPHO_CMPPROMOTETYPE(l, r);
     if (i==0 || morpho_comparevalue(l, r)<0) m->min=val;
     
     l=m->max; r=val;
-    MORPHO_CHECKCMPTYPE(l, r)
+    MORPHO_CMPPROMOTETYPE(l, r);
     if (i==0 || morpho_comparevalue(l, r)>0) m->max=val;
     
     return true;

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -679,7 +679,7 @@ bool list_getelement(objectlist *list, int i, value *out) {
 /** Sort function for list_sort */
 int list_sortfunction(const void *a, const void *b) {
     value l=*(value *) a, r=*(value *) b;
-    MORPHO_CHECKCMPTYPE(l, r)
+    MORPHO_CMPPROMOTETYPE(l, r);
     return -morpho_comparevalue(l, r);
 }
 

--- a/morpho5/interface/cli.c
+++ b/morpho5/interface/cli.c
@@ -207,11 +207,11 @@ void cli_help (lineditor *edit, char *query, error *err, bool avail) {
 void cli(clioptions opt) {
     #ifdef MORPHO_LONG_BANNER
         printf(BLU " ___   ___ \n" RESET);
-        printf(BLU "(" CYN " @ " GRY"\\Y/" CYN " @ " BLU ") " RESET "  |  morpho 0.5.0  | \U0001F44B Type 'help' or '?' for help\n");
+        printf(BLU "(" CYN " @ " GRY"\\Y/" CYN " @ " BLU ") " RESET "  |  morpho 0.5.1  | \U0001F44B Type 'help' or '?' for help\n");
         printf(BLU " \\" CYN"__" GRY"+|+" CYN"__" BLU"/  " RESET "  |  Documentation: https://morpho-lang.readthedocs.io/en/latest/ \n");
         printf(BLU"  {" CYN"_" BLU "/ \\" CYN "_" BLU"}   " RESET "  |  Code: https://github.com/Morpho-lang/morpho \n\n");
     #else
-        printf("\U0001F98B morpho 0.5.0  | \U0001F44B Type 'help' or '?' for help\n");
+        printf("\U0001F98B morpho 0.5.1  | \U0001F44B Type 'help' or '?' for help\n");
     #endif
     // Original ASCII art source - https://www.asciiart.eu/animals/insects/butterflies
     cli_file=NULL;

--- a/morpho5/utils/common.h
+++ b/morpho5/utils/common.h
@@ -25,10 +25,10 @@
  * Functions and macros for comparing values
  * ----------------------------------------- */
 
-/** @brief Compares two values
+/** @brief Promotes l and r to types that can be compared
  * @param l value to compare
  * @param r value to compare */
-#define MORPHO_CHECKCMPTYPE(l, r) \
+#define MORPHO_CMPPROMOTETYPE(l, r) \
     if (!morpho_ofsametype(l, r)) { \
         if (MORPHO_ISINTEGER(l) && MORPHO_ISFLOAT(r)) { \
             l = MORPHO_INTEGERTOFLOAT(l); \

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1094,7 +1094,7 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
             left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
             right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
 
-            MORPHO_CHECKCMPTYPE(left,right);
+            MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)==0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
             DISPATCH();
 
@@ -1103,7 +1103,7 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
             left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
             right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
 
-            MORPHO_CHECKCMPTYPE(left,right);
+            MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)!=0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
             DISPATCH();
 
@@ -1117,7 +1117,7 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
                 OPERROR("Compare");
             }
 
-            MORPHO_CHECKCMPTYPE(left,right);
+            MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)>0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
             DISPATCH();
 
@@ -1131,7 +1131,7 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
                 OPERROR("Compare");
             }
 
-            MORPHO_CHECKCMPTYPE(left,right);
+            MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)>=0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
             DISPATCH();
 


### PR DESCRIPTION
Fixes #72. morpho_comparevalue has been documented with a warning about using to order values. MORPHO_CHECKCMPTYPE now provided. 

min, max and List.sort all fixed that demonstrated erroneous behavior

I added a test. 