### PR TITLE
Allow slice indexing of arrays and lists

### DIFF
--- a/manual/src/Reference/array.tex
+++ b/manual/src/Reference/array.tex
@@ -16,6 +16,13 @@ Values can be retrieved with appropriate indices:
 print a[0,0]
 \end{lstlisting}
 
+Array can be indexed with slices:
+
+\being{lstlisting}
+print a[[0,2,4],2]
+print a[1,0..2]
+\end
+
 Any morpho value can be stored in an array element
 
 \begin{lstlisting}

--- a/manual/src/Reference/list.tex
+++ b/manual/src/Reference/list.tex
@@ -16,6 +16,14 @@ Lookup values using index notation:
 list[0]
 \end{lstlisting}
 
+Indexing can also be done with slices:
+
+\begin{lstlisting}
+list[0..2]
+list[[0,1,3]]
+\end{lstlisting}
+	
+
 You can change list entries like this:
 
 \begin{lstlisting}

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -1746,7 +1746,7 @@ void veneer_initialize(void) {
     morpho_defineerror(LIST_ENTRYNTFND, ERROR_HALT, LIST_ENTRYNTFND_MSG);
     morpho_defineerror(LIST_ADDARGS, ERROR_HALT, LIST_ADDARGS_MSG);
     morpho_defineerror(LIST_SRTFN, ERROR_HALT, LIST_SRTFN_MSG);
-	morpho_defineerror(LIST_ARGS, ERROR_HALT, LIST_ARGS_MSG);
+    morpho_defineerror(LIST_ARGS, ERROR_HALT, LIST_ARGS_MSG);
     morpho_defineerror(LIST_NUMARGS, ERROR_HALT, LIST_NUMARGS_MSG);
     morpho_defineerror(ERROR_ARGS, ERROR_HALT, ERROR_ARGS_MSG);
 }

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -504,9 +504,9 @@ objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned in
  * @param[in] slices - a set of indices that can be lists ranges or ints.
  * @param[out] out - returns the requeted slice of a.
 */
-objectarrayerror getslice(value *a, bool *dimFcn(value *,unsigned int),\
-						  value *constuctor(unsigned int *,unsigned int,value *),\
-						  objectarrayerror* copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
+objectarrayerror getslice(value *a, bool dimFcn(value *,unsigned int),\
+						  void constuctor(unsigned int *,unsigned int,value *),\
+						  objectarrayerror copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
 						  unsigned int ndim, value *slices, value *out){
 	//dimenation checking
 	if (!(*dimFcn)(a,ndim)) return ARRAY_WRONGDIM;
@@ -544,7 +544,7 @@ objectarrayerror getslice(value *a, bool *dimFcn(value *,unsigned int),\
  * @param[in] newindx - the place in out to put the data copied from a
  * @param[in] slices - a set of indices that can be lists ranges or ints.
 */
-objectarrayerror setslicerecursive(value* a, value* out,objectarrayerror *copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
+objectarrayerror setslicerecursive(value* a, value* out,objectarrayerror copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
 								   unsigned int ndim, unsigned int curdim, unsigned int *indx,unsigned int *newindx, value *slices){
 	// this gets given an array and out and a list of slices,
 	// we resolve the top slice to a number and add it to a list
@@ -741,20 +741,6 @@ objectarrayerror arraySliceCopy(value * a,value * out, unsigned int ndim, unsign
 	return arrayerr;
 
 }
-// objectarrayerror arraySliceSet(value *a,value *in, unsigned int ndim, unsigned int *indx,unsigned int *newindx){
-// 	value data;
-// 	objectarrayerror arrayerr;
-// 	if (MORPHO_ISFLOAT(*in)||MORPHO_ISINTEGER(*in)){
-// 		arrayerr=array_setelement(MORPHO_GETARRAY(*a), ndim, newindx, *in); // write the data
-
-// 	} else {
-// 		arrayerr = array_getelement(MORPHO_GETARRAY(*in),ndim,indx,&data); // read the data
-// 		if (arrayerr!=ARRAY_OK) return arrayerr;
-
-// 		arrayerr=array_setelement(MORPHO_GETARRAY(*a), ndim, newindx, data); // write the data
-// 	}
-// 	return arrayerr;
-// }
 
 
 /** Gets the array element with given indices */

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -766,9 +766,9 @@ value Array_setindex(vm *v, int nargs, value *args) {
     if (array_valuelisttoindices(nargs-1, &MORPHO_GETARG(args, 0), indx)) {
         objectarrayerror err=array_setelement(array, nargs-1, indx, MORPHO_GETARG(args, nargs-1));
         if (err!=ARRAY_OK) MORPHO_RAISE(v, array_error(err) );
-	} else MORPHO_RAISE(v, VM_NONNUMINDX);
-	
-	return MORPHO_NIL;
+    } else MORPHO_RAISE(v, VM_NONNUMINDX);
+    
+    return MORPHO_NIL;
 }
 
 /** Print an array */

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -105,14 +105,25 @@ errorid array_to_list_error(objectarrayerror err);
 bool array_valuelisttoindices(unsigned int ndim, value *in, unsigned int *out);
 objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned int *indx, value *out);
 objectarrayerror array_setelement(objectarray *a, unsigned int ndim, unsigned int *indx, value in);
-objectarrayerror setslicerecursive(value* a, value* out,unsigned int ndim, unsigned int curdim, unsigned int *indx,unsigned int *newindx, value *slices);
-objectarrayerror getslice(value *a, unsigned int ndim, value *slices, value *out);
+objectarrayerror setslicerecursive(value* a, value* out,objectarrayerror *copy(value * ,value *,\
+									unsigned int, unsigned int *,unsigned int *),unsigned int ndim,\
+									unsigned int curdim, unsigned int *indx,unsigned int *newindx, value *slices);
+objectarrayerror getslice(value *a, bool *dimFcn(value *,unsigned int),\
+						  value *constuctor(unsigned int *,unsigned int,value *),\
+						  objectarrayerror* copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
+						  unsigned int ndim, value *slices, value *out);
+objectarrayerror arraySliceCopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx);
+void arraySliceConstructor(unsigned int *slicesize,unsigned int ndim,value* out);
+bool arraySliceDimentionCheck(value * a, unsigned int ndim);
+
 bool list_resize(objectlist *list, int size);
 void list_append(objectlist *list, value v);
 unsigned int list_length(objectlist *list);
 bool list_getelement(objectlist *list, int i, value *out);
 void list_sort(objectlist *list);
 objectlist *list_clone(objectlist *list);
+
+
 
 void veneer_initialize(void);
 value range_iterate(objectrange *range, unsigned int i);

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -112,18 +112,18 @@ objectarrayerror getslice(value *a, bool dimFcn(value *,unsigned int),\
 						  void constuctor(unsigned int *,unsigned int,value *),\
 						  objectarrayerror copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
 						  unsigned int ndim, value *slices, value *out);
-objectarrayerror arraySliceCopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx);
-void arraySliceConstructor(unsigned int *slicesize,unsigned int ndim,value* out);
-bool arraySliceDimentionCheck(value * a, unsigned int ndim);
-
+objectarrayerror array_slicecopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx);
+void array_sliceconstructor(unsigned int *slicesize,unsigned int ndim,value* out);
+bool array_slicedim(value * a, unsigned int ndim);
 bool list_resize(objectlist *list, int size);
 void list_append(objectlist *list, value v);
 unsigned int list_length(objectlist *list);
 bool list_getelement(objectlist *list, int i, value *out);
 void list_sort(objectlist *list);
 objectlist *list_clone(objectlist *list);
-
-void veneer_initialize(void);
 value range_iterate(objectrange *range, unsigned int i);
 int range_count(objectrange *range);
+
+void veneer_initialize(void);
+
 #endif /* veneer_h */

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -71,6 +71,9 @@
 #define LIST_SRTFN                        "LstSrtFn"
 #define LIST_SRTFN_MSG                    "List sort function must return an integer."
 
+#define LIST_NUMARGS                      "LstNumArgs"
+#define LIST_NUMARGS_MSG                  "List can only be indexed with one argument."
+
 #define STRING_IMMTBL                     "StrngImmtbl"
 #define STRING_IMMTBL_MSG                 "Strings are immutable."
 

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -105,12 +105,12 @@ errorid array_to_list_error(objectarrayerror err);
 bool array_valuelisttoindices(unsigned int ndim, value *in, unsigned int *out);
 objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned int *indx, value *out);
 objectarrayerror array_setelement(objectarray *a, unsigned int ndim, unsigned int *indx, value in);
-objectarrayerror setslicerecursive(value* a, value* out,objectarrayerror *copy(value * ,value *,\
+objectarrayerror setslicerecursive(value* a, value* out,objectarrayerror copy(value * ,value *,\
 									unsigned int, unsigned int *,unsigned int *),unsigned int ndim,\
 									unsigned int curdim, unsigned int *indx,unsigned int *newindx, value *slices);
-objectarrayerror getslice(value *a, bool *dimFcn(value *,unsigned int),\
-						  value *constuctor(unsigned int *,unsigned int,value *),\
-						  objectarrayerror* copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
+objectarrayerror getslice(value *a, bool dimFcn(value *,unsigned int),\
+						  void constuctor(unsigned int *,unsigned int,value *),\
+						  objectarrayerror copy(value * ,value *, unsigned int, unsigned int *,unsigned int *),\
 						  unsigned int ndim, value *slices, value *out);
 objectarrayerror arraySliceCopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx);
 void arraySliceConstructor(unsigned int *slicesize,unsigned int ndim,value* out);

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -8,6 +8,7 @@
 #define veneer_h
 
 #include "builtin.h"
+#include "matrix.h"
 
 /* ---------------------------
  * Veneer classes
@@ -96,8 +97,8 @@ errorid array_error(objectarrayerror err);
 bool array_valuelisttoindices(unsigned int ndim, value *in, unsigned int *out);
 objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned int *indx, value *out);
 objectarrayerror array_setelement(objectarray *a, unsigned int ndim, unsigned int *indx, value in);
-objectarrayerror array_setslicerecurive(objectarray* a, objectarray* out,unsigned int ndim, unsigned int curdim, unsigned int *indx, value *slices);
-
+objectarrayerror setslicerecursive(value* a, value* out,unsigned int ndim, unsigned int curdim, unsigned int *indx,unsigned int *newindx, value *slices);
+objectarrayerror getslice(value *a, unsigned int ndim, value *slices, value *out);
 bool list_resize(objectlist *list, int size);
 void list_append(objectlist *list, value v);
 unsigned int list_length(objectlist *list);

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -71,8 +71,11 @@
 #define LIST_SRTFN                        "LstSrtFn"
 #define LIST_SRTFN_MSG                    "List sort function must return an integer."
 
+#define LIST_ARGS                         "LstArgs"
+#define LIST_ARGS_MSG                     "Lists must be called with integer dimensions as arguments."
+
 #define LIST_NUMARGS                      "LstNumArgs"
-#define LIST_NUMARGS_MSG                  "List can only be indexed with one argument."
+#define LIST_NUMARGS_MSG                  "Lists can only be indexed with one argument."
 
 #define STRING_IMMTBL                     "StrngImmtbl"
 #define STRING_IMMTBL_MSG                 "Strings are immutable."
@@ -96,6 +99,8 @@ int string_countchars(objectstring *s);
 char *string_index(objectstring *s, int i);
 
 errorid array_error(objectarrayerror err);
+errorid array_to_matrix_error(objectarrayerror err);
+errorid array_to_list_error(objectarrayerror err);
 
 bool array_valuelisttoindices(unsigned int ndim, value *in, unsigned int *out);
 objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned int *indx, value *out);

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -86,7 +86,7 @@
 #define ERROR_ARGS_MSG                    "Error much be called with a tag and a default message as arguments."
 
 /* Public interfaces to various data structures */
-typedef enum { ARRAY_OK, ARRAY_WRONGDIM, ARRAY_OUTOFBOUNDS } objectarrayerror;
+typedef enum { ARRAY_OK, ARRAY_WRONGDIM, ARRAY_OUTOFBOUNDS,ARRAY_NONINTINDX } objectarrayerror;
 
 int string_countchars(objectstring *s);
 char *string_index(objectstring *s, int i);
@@ -96,6 +96,7 @@ errorid array_error(objectarrayerror err);
 bool array_valuelisttoindices(unsigned int ndim, value *in, unsigned int *out);
 objectarrayerror array_getelement(objectarray *a, unsigned int ndim, unsigned int *indx, value *out);
 objectarrayerror array_setelement(objectarray *a, unsigned int ndim, unsigned int *indx, value in);
+objectarrayerror array_setslicerecurive(objectarray* a, objectarray* out,unsigned int ndim, unsigned int curdim, unsigned int *indx, value *slices);
 
 bool list_resize(objectlist *list, int size);
 void list_append(objectlist *list, value v);
@@ -105,5 +106,6 @@ void list_sort(objectlist *list);
 objectlist *list_clone(objectlist *list);
 
 void veneer_initialize(void);
-
+value range_iterate(objectrange *range, unsigned int i);
+int range_count(objectrange *range);
 #endif /* veneer_h */

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -123,8 +123,6 @@ bool list_getelement(objectlist *list, int i, value *out);
 void list_sort(objectlist *list);
 objectlist *list_clone(objectlist *list);
 
-
-
 void veneer_initialize(void);
 value range_iterate(objectrange *range, unsigned int i);
 int range_count(objectrange *range);

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -968,8 +968,6 @@ value Matrix_dimensions(vm *v, int nargs, value *args) {
     return out;
 }
 
-
-
 /** Clones a matrix */
 value Matrix_clone(vm *v, int nargs, value *args) {
     value out=MORPHO_NIL;

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -522,7 +522,23 @@ value matrix_constructor(vm *v, int nargs, value *args) {
     
     return out;
 }
+bool matrixSliceDimentionCheck(value * a, unsigned int ndim){
+	if (ndim>2||ndim<0) return false;
+	return true;
+}
 
+
+void matrixSliceConstructor(unsigned int *slicesize,unsigned int ndim,value* out){
+	*out = MORPHO_OBJECT(object_newmatrix(slicesize[0],slicesize[1],false));
+}
+objectarrayerror matrixSliceCopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx){
+	double num; // matrices only store doubles not values
+	if (!(matrix_getelement(MORPHO_GETMATRIX(*a),indx[0],indx[1],&num)&&
+		matrix_setelement(MORPHO_GETMATRIX(*out),newindx[0],newindx[1],num))){
+		return ARRAY_OUTOFBOUNDS;
+	}
+	return ARRAY_OK;
+}
 /** Gets the matrix element with given indices */
 value Matrix_getindex(vm *v, int nargs, value *args) {
     objectmatrix *m=MORPHO_GETMATRIX(MORPHO_SELF(args));
@@ -541,7 +557,7 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
             out = MORPHO_FLOAT(outval);
         }
     } else{ // now try to get a slice
-		objectarrayerror err = getslice(&MORPHO_SELF(args), nargs, &MORPHO_GETARG(args,0), &out);
+		objectarrayerror err = getslice(&MORPHO_SELF(args), &matrixSliceDimentionCheck, &matrixSliceConstructor, &matrixSliceCopy, nargs, &MORPHO_GETARG(args,0), &out);
 		if (err!=ARRAY_OK) MORPHO_RAISE(v, array_to_matrix_error(err) );
 		if (out!=MORPHO_NIL){
 			morpho_bindobjects(v,1,&out);

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -531,13 +531,25 @@ bool matrix_slicedim(value * a, unsigned int ndim){
 
 /** Constucts a new matrix with a generic interface */
 void matrix_sliceconstructor(unsigned int *slicesize,unsigned int ndim,value* out){
-	*out = MORPHO_OBJECT(object_newmatrix(slicesize[0],slicesize[1],false));
+	unsigned int numcol = 1;
+	if (ndim == 2) {
+		numcol = slicesize[1];
+	}
+	*out = MORPHO_OBJECT(object_newmatrix(slicesize[0],numcol,false));
 }
 /** Copies data from a at indx to out at newindx with a generic interface */
 objectarrayerror matrix_slicecopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx){
-	double num; // matrices only store doubles not values
-	if (!(matrix_getelement(MORPHO_GETMATRIX(*a),indx[0],indx[1],&num)&&
-		matrix_setelement(MORPHO_GETMATRIX(*out),newindx[0],newindx[1],num))){
+	double num; // matrices store doubles;
+	unsigned int colindx = 0;
+	unsigned int colnewindx = 0;	
+	
+	if (ndim == 2) {
+		colindx = indx[1];
+		colnewindx = newindx[1];
+	}
+
+	if (!(matrix_getelement(MORPHO_GETMATRIX(*a),indx[0],colindx,&num)&&
+		matrix_setelement(MORPHO_GETMATRIX(*out),newindx[0],colnewindx,num))){
 		return ARRAY_OUTOFBOUNDS;
 	}
 	return ARRAY_OK;

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -522,16 +522,19 @@ value matrix_constructor(vm *v, int nargs, value *args) {
     
     return out;
 }
-bool matrixSliceDimentionCheck(value * a, unsigned int ndim){
+
+/** Checks that a matrix is indexed with 2 indices with a generic interface */
+bool matrix_slicedim(value * a, unsigned int ndim){
 	if (ndim>2||ndim<0) return false;
 	return true;
 }
 
-
-void matrixSliceConstructor(unsigned int *slicesize,unsigned int ndim,value* out){
+/** Constucts a new matrix with a generic interface */
+void matrix_sliceconstructor(unsigned int *slicesize,unsigned int ndim,value* out){
 	*out = MORPHO_OBJECT(object_newmatrix(slicesize[0],slicesize[1],false));
 }
-objectarrayerror matrixSliceCopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx){
+/** Copies data from a at indx to out at newindx with a generic interface */
+objectarrayerror matrix_slicecopy(value * a,value * out, unsigned int ndim, unsigned int *indx,unsigned int *newindx){
 	double num; // matrices only store doubles not values
 	if (!(matrix_getelement(MORPHO_GETMATRIX(*a),indx[0],indx[1],&num)&&
 		matrix_setelement(MORPHO_GETMATRIX(*out),newindx[0],newindx[1],num))){
@@ -539,6 +542,7 @@ objectarrayerror matrixSliceCopy(value * a,value * out, unsigned int ndim, unsig
 	}
 	return ARRAY_OK;
 }
+
 /** Gets the matrix element with given indices */
 value Matrix_getindex(vm *v, int nargs, value *args) {
     objectmatrix *m=MORPHO_GETMATRIX(MORPHO_SELF(args));
@@ -556,12 +560,12 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
         } else {
             out = MORPHO_FLOAT(outval);
         }
-    } else{ // now try to get a slice
-		objectarrayerror err = getslice(&MORPHO_SELF(args), &matrixSliceDimentionCheck, &matrixSliceConstructor, &matrixSliceCopy, nargs, &MORPHO_GETARG(args,0), &out);
+    } else { // now try to get a slice
+		objectarrayerror err = getslice(&MORPHO_SELF(args), &matrix_slicedim, &matrix_sliceconstructor, &matrix_slicecopy, nargs, &MORPHO_GETARG(args,0), &out);
 		if (err!=ARRAY_OK) MORPHO_RAISE(v, array_to_matrix_error(err) );
 		if (out!=MORPHO_NIL){
 			morpho_bindobjects(v,1,&out);
-		}else morpho_runtimeerror(v, MATRIX_INVLDINDICES);
+		} else morpho_runtimeerror(v, MATRIX_INVLDINDICES);
 	}
     return out;
 }

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -528,6 +528,9 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
     objectmatrix *m=MORPHO_GETMATRIX(MORPHO_SELF(args));
     unsigned int indx[2]={0,0};
     value out = MORPHO_NIL;
+	if (nargs>2){
+		morpho_runtimeerror(v, MATRIX_INVLDNUMINDICES);
+	}
     
     if (array_valuelisttoindices(nargs, args+1, indx)) {
         double outval;
@@ -538,8 +541,8 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
         }
     } else{ // now try to get a slice
 		objectarrayerror err = getslice(&MORPHO_SELF(args), nargs, &MORPHO_GETARG(args,0), &out);
-		if (err!=ARRAY_OK) MORPHO_RAISE(v, array_error(err) );
-		if (out){
+		if (err!=ARRAY_OK) MORPHO_RAISE(v, array_to_matrix_error(err) );
+		if (out!=MORPHO_NIL){
 			morpho_bindobjects(v,1,&out);
 		}else morpho_runtimeerror(v, MATRIX_INVLDINDICES);
 	}
@@ -944,6 +947,8 @@ value Matrix_dimensions(vm *v, int nargs, value *args) {
     return out;
 }
 
+
+
 /** Clones a matrix */
 value Matrix_clone(vm *v, int nargs, value *args) {
     value out=MORPHO_NIL;
@@ -993,6 +998,7 @@ void matrix_initialize(void) {
     
     morpho_defineerror(MATRIX_INDICESOUTSIDEBOUNDS, ERROR_HALT, MATRIX_INDICESOUTSIDEBOUNDS_MSG);
     morpho_defineerror(MATRIX_INVLDINDICES, ERROR_HALT, MATRIX_INVLDINDICES_MSG);
+    morpho_defineerror(MATRIX_INVLDNUMINDICES, ERROR_HALT, MATRIX_INVLDNUMINDICES_MSG);
     morpho_defineerror(MATRIX_CONSTRUCTOR, ERROR_HALT, MATRIX_CONSTRUCTOR_MSG);
     morpho_defineerror(MATRIX_INVLDARRAYINIT, ERROR_HALT, MATRIX_INVLDARRAYINIT_MSG);
     morpho_defineerror(MATRIX_ARITHARGS, ERROR_HALT, MATRIX_ARITHARGS_MSG);

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -530,6 +530,7 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
     value out = MORPHO_NIL;
 	if (nargs>2){
 		morpho_runtimeerror(v, MATRIX_INVLDNUMINDICES);
+		return out;
 	}
     
     if (array_valuelisttoindices(nargs, args+1, indx)) {

--- a/morpho5/datastructures/matrix.c
+++ b/morpho5/datastructures/matrix.c
@@ -536,8 +536,13 @@ value Matrix_getindex(vm *v, int nargs, value *args) {
         } else {
             out = MORPHO_FLOAT(outval);
         }
-    } else morpho_runtimeerror(v, MATRIX_INVLDINDICES);
-    
+    } else{ // now try to get a slice
+		objectarrayerror err = getslice(&MORPHO_SELF(args), nargs, &MORPHO_GETARG(args,0), &out);
+		if (err!=ARRAY_OK) MORPHO_RAISE(v, array_error(err) );
+		if (out){
+			morpho_bindobjects(v,1,&out);
+		}else morpho_runtimeerror(v, MATRIX_INVLDINDICES);
+	}
     return out;
 }
 

--- a/morpho5/datastructures/matrix.h
+++ b/morpho5/datastructures/matrix.h
@@ -8,7 +8,7 @@
 #define matrix_h
 
 #include <stdio.h>
-
+#include "veneer.h"
 /** Use Apple's Accelerate library for LAPACK and BLAS */
 #ifdef __APPLE__
 #ifdef MORPHO_LINALG_USE_ACCELERATE
@@ -44,6 +44,9 @@
 
 #define MATRIX_INVLDINDICES               "MtrxInvldIndx"
 #define MATRIX_INVLDINDICES_MSG           "Matrix indices must be integers."
+
+#define MATRIX_INVLDNUMINDICES            "MtrxInvldNumIndx"
+#define MATRIX_INVLDNUMINDICES_MSG        "Matrix expects two arguments for indexing."
 
 #define MATRIX_CONSTRUCTOR                "MtrxCns"
 #define MATRIX_CONSTRUCTOR_MSG            "Matrix() constructor should be called either with dimensions or an array, list or matrix initializer."
@@ -100,6 +103,7 @@ objectmatrixerror matrix_identity(objectmatrix *a);
 double matrix_sum(objectmatrix *a);
 //objectmatrixerror matrix_det(objectmatrix *a, double *out);
 //objectmatrixerror matrix_eigensystem(objectmatrix *a, double *val, objectmatrix *vec);
+
 
 void matrix_print(objectmatrix *m);
 

--- a/morpho5/docs/array.md
+++ b/morpho5/docs/array.md
@@ -14,6 +14,11 @@ Values can be retrieved with appropriate indices:
 
     print a[0,0]
 
+Array can be indexed with slices:
+
+	print a[[0,2,4],2]
+	print a[1,0..2]
+
 Any morpho value can be stored in an array element
 
     a[0,0] = [1,2,3]

--- a/morpho5/docs/list.md
+++ b/morpho5/docs/list.md
@@ -14,6 +14,10 @@ Lookup values using index notation:
 
     list[0]
 
+Indexing can also be done with slices:
+	list[0..2]
+	list[[0,1,3]]
+
 You can change list entries like this:
 
     list[0] = "Hello"

--- a/morpho5/utils/parse.c
+++ b/morpho5/utils/parse.c
@@ -1001,7 +1001,12 @@ static syntaxtreeindx parse_arglist(parser *p, tokentype rightdelimiter, unsigne
     if (!parse_checktoken(p, rightdelimiter)) {
         do {
             if (parse_matchtoken(p, TOKEN_DOTDOTDOT)) {
-                if (varg) parse_error(p, true, PARSE_ONEVARPR);
+				// If we are trying to index something 
+				// then ... represents an open range
+				if (rightdelimiter == TOKEN_RIGHTSQBRACKET){
+					
+				}
+                else if (varg) parse_error(p, true, PARSE_ONEVARPR);
                 varg = true;
             } else if (varg) parse_error(p, true, PARSE_VARPRLST);
             

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1458,9 +1458,20 @@ callfunction: // Jump here if an instruction becomes a call
             if (MORPHO_ISARRAY(left)) {
                 unsigned int ndim = c-b+1;
                 unsigned int indx[ndim];
-                if (!array_valuelisttoindices(ndim, &reg[b], indx)) ERROR(VM_NONNUMINDX);
-                objectarrayerror err=array_getelement(MORPHO_GETARRAY(left), ndim, indx, &reg[b]);
-                if (err!=ARRAY_OK) ERROR( array_error(err) );
+				if (array_valuelisttoindices(ndim, &reg[b], indx)){
+					objectarrayerror err=array_getelement(MORPHO_GETARRAY(left), ndim, indx, &reg[b]);
+					if (err!=ARRAY_OK) ERROR( array_error(err) );
+				} else{
+					value newVal = MORPHO_NIL;
+					objectarrayerror err = getslice(&left,ndim,&reg[b],&newVal);
+					if (err!=ARRAY_OK) ERROR(array_error(err));
+					
+					if (newVal){
+						reg[b] = newVal;
+						vm_bindobject(v, reg[b]);
+					}
+					else  ERROR(VM_NONNUMINDX);
+				}
             } else {
                 if (!vm_invoke(v, left, indexselector, c-b+1, &reg[b], &reg[b])) {
                     ERROR(VM_NOTINDEXABLE);

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1463,8 +1463,8 @@ callfunction: // Jump here if an instruction becomes a call
 					if (err!=ARRAY_OK) ERROR( array_error(err) );
 				} else {
 					value newVal = MORPHO_NIL;
-					objectarrayerror err = getslice(&left,&arraySliceDimentionCheck,\
-													&arraySliceConstructor,&arraySliceCopy,ndim,&reg[b],&newVal);
+					objectarrayerror err = getslice(&left,&array_slicedim,&array_sliceconstructor,\
+													&array_slicecopy,ndim,&reg[b],&newVal);
 					if (err!=ARRAY_OK) ERROR(array_error(err));
 					
 					if (newVal) {

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1461,17 +1461,16 @@ callfunction: // Jump here if an instruction becomes a call
 				if (array_valuelisttoindices(ndim, &reg[b], indx)){
 					objectarrayerror err=array_getelement(MORPHO_GETARRAY(left), ndim, indx, &reg[b]);
 					if (err!=ARRAY_OK) ERROR( array_error(err) );
-				} else{
+				} else {
 					value newVal = MORPHO_NIL;
 					objectarrayerror err = getslice(&left,&arraySliceDimentionCheck,\
 													&arraySliceConstructor,&arraySliceCopy,ndim,&reg[b],&newVal);
 					if (err!=ARRAY_OK) ERROR(array_error(err));
 					
-					if (newVal){
+					if (newVal) {
 						reg[b] = newVal;
 						vm_bindobject(v, reg[b]);
-					}
-					else  ERROR(VM_NONNUMINDX);
+					} else  ERROR(VM_NONNUMINDX);
 				}
             } else {
                 if (!vm_invoke(v, left, indexselector, c-b+1, &reg[b], &reg[b])) {

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1463,7 +1463,8 @@ callfunction: // Jump here if an instruction becomes a call
 					if (err!=ARRAY_OK) ERROR( array_error(err) );
 				} else{
 					value newVal = MORPHO_NIL;
-					objectarrayerror err = getslice(&left,ndim,&reg[b],&newVal);
+					objectarrayerror err = getslice(&left,&arraySliceDimentionCheck,\
+													&arraySliceConstructor,&arraySliceCopy,ndim,&reg[b],&newVal);
 					if (err!=ARRAY_OK) ERROR(array_error(err));
 					
 					if (newVal){

--- a/test/matrix/nonnum_indices.morpho
+++ b/test/matrix/nonnum_indices.morpho
@@ -3,4 +3,4 @@
 var a = Matrix([[1,2], [3,4], [5,6]])
 
 print a["Hello", "Squirrel"]
-// expect error: 'MtrxInvldIndx'
+// expect error: 'NonNmIndx'

--- a/test/matrix/nonnum_indices.morpho
+++ b/test/matrix/nonnum_indices.morpho
@@ -3,4 +3,4 @@
 var a = Matrix([[1,2], [3,4], [5,6]])
 
 print a["Hello", "Squirrel"]
-// expect error: 'NonNmIndx'
+// expect error: 'MtrxInvldIndx'

--- a/test/slice/arraySlicing.morpho
+++ b/test/slice/arraySlicing.morpho
@@ -1,0 +1,113 @@
+var A = Array([[0,1,2,3],[4,5,6,7],[8,9,10,11]])
+// ranges
+print A[0..1,1..2] 
+// expect: [ [ 1, 2 ], [ 5, 6 ] ]
+
+// lists
+print A[[1,2,0,1],[0,0,0,2]]
+// expect: [ [ 4, 4, 4, 6 ], [ 8, 8, 8, 10 ], [ 0, 0, 0, 2 ], [ 4, 4, 4, 6 ] ]
+
+// mix of range and list
+print A[0..2,[0,0,0,2]]
+// expect: [ [ 0, 0, 0, 2 ], [ 4, 4, 4, 6 ], [ 8, 8, 8, 10 ] ]
+
+// mix of range and int
+print A[0..1,3]
+// expect: [ [ 3 ], [ 7 ] ]
+
+// mix of list and int
+print A[2,[0,1,2,1,2]]
+// expect: [ [ 8, 9, 10, 9, 10 ] ]
+
+// range out of bounds
+try{
+	print A[-1..2,1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[0..3,1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+
+// range is not int
+try{
+	print A[0.0..2,1..2] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+// list is out of bounds
+try{
+	print A[[-1,2,-1],1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[100],1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+// list is not int
+try{
+	print A[[1,2,1],[0.2,0.1]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[[1,2,1],[[1]]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+// int + list but int is out of bounds
+try{
+	print A[[0,2,1],-1] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[0,2,1],100] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[0,2,1],1.01] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+
+
+//wrong dim
+try{
+	print A[[1,2],[2,3],[0,1]] 
+} catch{
+	"ArrayDim": print "ArrayDim"
+// expect: ArrayDim
+}
+// garbage in 
+
+try{
+	print A[A] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[nil] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}

--- a/test/slice/listSlicing.morpho
+++ b/test/slice/listSlicing.morpho
@@ -24,8 +24,8 @@ try{
 try{
 	print A[0.0..2] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"LstArgs": print "LstArgs"
+// expect: LstArgs
 }
 
 // list is out of bounds
@@ -43,14 +43,14 @@ try{
 try{
 	print A[[0.2,0.1]] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"LstArgs": print "LstArgs"
+// expect: LstArgs
 }
 try{
 	print A[[[1]]] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"LstArgs": print "LstArgs"
+// expect: LstArgs
 }
 
 //wrong dim
@@ -67,12 +67,12 @@ try{
 try{
 	print A[A] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"LstArgs": print "LstArgs"
+// expect: LstArgs
 }
 try{
 	print A[nil] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"LstArgs": print "LstArgs"
+// expect: LstArgs
 }

--- a/test/slice/listSlicing.morpho
+++ b/test/slice/listSlicing.morpho
@@ -1,0 +1,78 @@
+var A = [[0,1,2,3],4,5,6,7,8,9,10,11]
+// ranges
+print A[0..1] 
+// expect: [ <List>, 4 ]
+
+// lists
+print A[[1,2,0,1]]
+// expect: [ 4, 5, <List>, 4 ]
+
+print A[-1..2] 
+// expect: [ 11, <List>, 4, 5 ]
+
+
+// range out of bounds
+try{
+	print A[0..100] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+
+// range is not int
+try{
+	print A[0.0..2] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+// list is out of bounds
+	print A[[-1,2,-1]] 
+// expect: [ 11, 5, 11 ]
+
+try{
+	print A[[100]] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+// list is not int
+try{
+	print A[[0.2,0.1]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[[[1]]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+//wrong dim
+try{
+	print A[[1],[2]] 
+} catch{
+	"LstNumArgs": print "LstNumArgs"
+// expect: LstNumArgs
+}
+
+
+// garbage in 
+
+try{
+	print A[A] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[nil] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}

--- a/test/slice/matrixSlicing.morpho
+++ b/test/slice/matrixSlicing.morpho
@@ -1,0 +1,120 @@
+var A = Matrix([[0,1,2,3],[4,5,6,7],[8,9,10,11]])
+// ranges
+print A[0..1,1..2] 
+// expect: [ 1 2 ]
+// expect: [ 5 6 ]
+
+// lists
+print A[[1,2,0,1],[0,0,0,2]]
+// expect: [ 4 4 4 6 ]
+// expect: [ 8 8 8 10 ]
+// expect: [ 0 0 0 2 ]
+// expect: [ 4 4 4 6 ]
+
+// mix of range and list
+print A[0..2,[0,0,0,2]]
+// expect: [ 0 0 0 2 ]
+// expect: [ 4 4 4 6 ]
+// expect: [ 8 8 8 10 ]
+
+// mix of range and int
+print A[0..1,3]
+// expect: [ 3 ]
+// expect: [ 7 ]
+
+// mix of list and int
+print A[2,[0,1,2,1,2]]
+// expect: [ 8 9 10 9 10 ]
+
+// range out of bounds
+try{
+	print A[-1..2,1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[0..3,1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+
+// range is not int
+try{
+	print A[0.0..2,1..2] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+// list is out of bounds
+try{
+	print A[[-1,2,-1],1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[100],1..2] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+
+// list is not int
+try{
+	print A[[1,2,1],[0.2,0.1]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[[1,2,1],[[1]]] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+// int + list but int is out of bounds
+try{
+	print A[[0,2,1],-1] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[0,2,1],100] 
+} catch{
+	"IndxBnds": print "IndxBnds"
+// expect: IndxBnds
+}
+try{
+	print A[[0,2,1],0.0] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+
+//wrong dim
+try{
+	print A[[1,2],[2,3],[0,1]] 
+} catch{
+	"ArrayDim": print "ArrayDim"
+// expect: ArrayDim
+}
+// garbage in 
+
+try{
+	print A[A] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}
+try{
+	print A[nil] 
+} catch{
+	"NonNmIndx": print "NonNmIndx"
+// expect: NonNmIndx
+}

--- a/test/slice/matrixSlicing.morpho
+++ b/test/slice/matrixSlicing.morpho
@@ -30,14 +30,14 @@ print A[2,[0,1,2,1,2]]
 try{
 	print A[-1..2,1..2] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 try{
 	print A[0..3,1..2] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 
 
@@ -45,76 +45,76 @@ try{
 try{
 	print A[0.0..2,1..2] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }
 
 // list is out of bounds
 try{
 	print A[[-1,2,-1],1..2] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 try{
 	print A[[100],1..2] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 
 // list is not int
 try{
 	print A[[1,2,1],[0.2,0.1]] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }
 try{
 	print A[[1,2,1],[[1]]] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }
 
 // int + list but int is out of bounds
 try{
 	print A[[0,2,1],-1] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 try{
 	print A[[0,2,1],100] 
 } catch{
-	"IndxBnds": print "IndxBnds"
-// expect: IndxBnds
+	"MtrxBnds": print "MtrxBnds"
+// expect: MtrxBnds
 }
 try{
 	print A[[0,2,1],0.0] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }
 
 //wrong dim
 try{
 	print A[[1,2],[2,3],[0,1]] 
 } catch{
-	"ArrayDim": print "ArrayDim"
-// expect: ArrayDim
+	"MtrxInvldNumIndx": print "MtrxInvldNumIndx"
+// expect: MtrxInvldNumIndx
 }
 // garbage in 
 
 try{
 	print A[A] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }
 try{
 	print A[nil] 
 } catch{
-	"NonNmIndx": print "NonNmIndx"
-// expect: NonNmIndx
+	"MtrxInvldIndx": print "MtrxInvldIndx"
+// expect: MtrxInvldIndx
 }

--- a/test/slice/matrixSlicing.morpho
+++ b/test/slice/matrixSlicing.morpho
@@ -26,6 +26,10 @@ print A[0..1,3]
 print A[2,[0,1,2,1,2]]
 // expect: [ 8 9 10 9 10 ]
 
+print A[0..1]
+// expect: [ 0 ]
+// expect: [ 4 ]
+
 // range out of bounds
 try{
 	print A[-1..2,1..2] 

--- a/test/slice/matrixSlicing.morpho
+++ b/test/slice/matrixSlicing.morpho
@@ -118,3 +118,9 @@ try{
 	"MtrxInvldIndx": print "MtrxInvldIndx"
 // expect: MtrxInvldIndx
 }
+try{
+	A[1,2,3,4,5]
+} catch{
+	"MtrxInvldNumIndx": print "MtrxInvldNumIndx"
+// expect: MtrxInvldNumIndx
+}


### PR DESCRIPTION
This submission adds slicing as a option for indexing 

for Lists, Arrays and Matrices you can use ranges and lists to specify which elements you want.

Next task it to add ... as an open range.

Are there any other objects that would benefit from slice indexing? sparse matrices? 

This code has been placed in veneer.c near the array handling do  you have better suggestions for its placement?

I also create an arrayerror -> matrixerror function to throw the correct kind of error depending on what the object being indexed is.