### PR TITLE
Language improvements to support meshgen

### DIFF
--- a/morpho5/builtin/functions.c
+++ b/morpho5/builtin/functions.c
@@ -405,7 +405,19 @@ static value builtin_sign(vm *v, int nargs, value *args){
 /** Apply a function to a list of arguments */
 value builtin_apply(vm *v, int nargs, value *args) {
     value ret = MORPHO_NIL;
-    morpho_call(v, MORPHO_GETARG(args, 0), nargs-1, &MORPHO_GETARG(args, 1), &ret);
+    
+    if (nargs<2) morpho_runtimeerror(v, APPLY_ARGS);
+        
+    value fn =  MORPHO_GETARG(args, 0);
+    value x =  MORPHO_GETARG(args, 1);
+    
+    if (nargs==2 && MORPHO_ISLIST(x)) {
+        objectlist *lst = MORPHO_GETLIST(x);
+        
+        morpho_call(v, fn, lst->val.count, lst->val.data, &ret);
+    } else {
+        morpho_call(v, fn, nargs-1, &MORPHO_GETARG(args, 1), &ret);
+    }
     
     return ret;
 }
@@ -514,6 +526,7 @@ void functions_initialize(void) {
     morpho_defineerror(MATH_ATANARGS, ERROR_HALT, MATH_ATANARGS_MSG);
     morpho_defineerror(TYPE_NUMARGS, ERROR_HALT, TYPE_NUMARGS_MSG);
     morpho_defineerror(MAX_ARGS, ERROR_HALT, MAX_ARGS_MSG);
+    morpho_defineerror(APPLY_ARGS, ERROR_HALT, APPLY_ARGS_MSG);
 }
 
 #undef BUILTIN_MATH

--- a/morpho5/builtin/functions.c
+++ b/morpho5/builtin/functions.c
@@ -301,46 +301,68 @@ static bool builtin_minmax(vm *v, value obj, value *min, value *max) {
     return true;
 }
 
+bool builtin_minmaxargs(vm *v, int nargs, value *args, value *min, value *max, char *fname) {
+    for (unsigned int i=0; i<nargs; i++) {
+        value arg = MORPHO_GETARG(args, i);
+        if (MORPHO_ISLIST(arg) ||
+            MORPHO_ISMATRIX(arg)) {
+            builtin_minmax(v, arg, (min ? &min[i] : NULL), (max ? &max[i]: NULL));
+        } else if (morpho_isnumber(arg)) {
+            if (min) min[i]=arg;
+            if (max) max[i]=arg;
+        } else {
+            morpho_runtimeerror(v, MAX_ARGS, fname);
+            return false;
+        }
+    }
+    return true;
+}
 
 /** Find the minimum and maximum values in an enumerable object */
 static value builtin_bounds(vm *v, int nargs, value *args) {
+    value minlist[nargs+1],maxlist[nargs+1];
     value out = MORPHO_NIL;
     
-    if (nargs==1) {
-        value bounds[2];
-        
-        if (builtin_minmax(v, MORPHO_GETARG(args, 0), &bounds[0], &bounds[1])) {
+    if (builtin_minmaxargs(v, nargs, args, minlist, maxlist, FUNCTION_BOUNDS)) {
+        if (nargs>0) {
+            value bounds[2];
+            value_minmax(nargs, minlist, &bounds[0], NULL);
+            value_minmax(nargs, maxlist, NULL, &bounds[1]);
+            
             objectlist *list = object_newlist(2, bounds);
             if (list) {
                 out = MORPHO_OBJECT(list);
                 morpho_bindobjects(v, 1, &out);
             } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
-        }
-    } else morpho_runtimeerror(v, VM_INVALIDARGS, 1, nargs);
+            
+        } else morpho_runtimeerror(v, MAX_ARGS, FUNCTION_BOUNDS);
+    }
     
     return out;
 }
 
 /** Find the minimum value in an enumerable object */
 static value builtin_min(vm *v, int nargs, value *args) {
+    value m[nargs+1];
     value out = MORPHO_NIL;
-    // ensure we have 1 argument and that it is a list or a matrix
-    if (nargs==1 && (MORPHO_ISLIST(MORPHO_GETARG(args, 0)) || \
-                    MORPHO_ISMATRIX(MORPHO_GETARG(args, 0)))) {
-            builtin_minmax(v, MORPHO_GETARG(args, 0), &out, NULL);
-    } else morpho_runtimeerror(v, VM_INVALIDARGSDETAIL,FUNCTION_MIN, 1, "list or matrix");
+    
+    if (builtin_minmaxargs(v, nargs, args, m, NULL, FUNCTION_MIN)) {
+        if (nargs>0) value_minmax(nargs, m, &out, NULL);
+        else morpho_runtimeerror(v, MAX_ARGS, FUNCTION_MIN);
+    }
     
     return out;
 }
 
 /** Find the maximum value in an enumerable object */
 static value builtin_max(vm *v, int nargs, value *args) {
+    value m[nargs+1];
     value out = MORPHO_NIL;
-    // ensure we have 1 argument and that it is a list or a matrix
-    if (nargs==1 && (MORPHO_ISLIST(MORPHO_GETARG(args, 0)) || \
-                    MORPHO_ISMATRIX(MORPHO_GETARG(args, 0)))) {
-        builtin_minmax(v, MORPHO_GETARG(args, 0), NULL, &out);
-    } else morpho_runtimeerror(v, VM_INVALIDARGSDETAIL,FUNCTION_MAX, 1, "list or matrix");
+    
+    if (builtin_minmaxargs(v, nargs, args, NULL, m, FUNCTION_MAX)) {
+        if (nargs>0) value_minmax(nargs, m, NULL, &out);
+        else morpho_runtimeerror(v, MAX_ARGS, FUNCTION_MAX);
+    }
     
     return out;
 }
@@ -490,7 +512,8 @@ void functions_initialize(void) {
     morpho_defineerror(MATH_ARGS, ERROR_HALT, MATH_ARGS_MSG);
     morpho_defineerror(MATH_NUMARGS, ERROR_HALT, MATH_NUMARGS_MSG);
     morpho_defineerror(MATH_ATANARGS, ERROR_HALT, MATH_ATANARGS_MSG);
-    morpho_defineerror(TYPE_NUMARGS, ERROR_HALT, TYPE_NUMARGS_MSG);   
+    morpho_defineerror(TYPE_NUMARGS, ERROR_HALT, TYPE_NUMARGS_MSG);
+    morpho_defineerror(MAX_ARGS, ERROR_HALT, MAX_ARGS_MSG);
 }
 
 #undef BUILTIN_MATH

--- a/morpho5/builtin/functions.h
+++ b/morpho5/builtin/functions.h
@@ -48,4 +48,7 @@ void functions_initialize(void);
 #define MAX_ARGS                     "MnMxArgs"
 #define MAX_ARGS_MSG                 "Function '%s' expects at least one numerical argument, list or matrix."
 
+#define APPLY_ARGS                   "ApplyArgs"
+#define APPLY_ARGS_MSG               "Function 'apply' expects at least two arguments."
+
 #endif /* functions_h */

--- a/morpho5/builtin/functions.h
+++ b/morpho5/builtin/functions.h
@@ -45,4 +45,7 @@ void functions_initialize(void);
 #define TYPE_NUMARGS                 "TypArgNm"
 #define TYPE_NUMARGS_MSG             "Function '%s' expects one argument."
 
+#define MAX_ARGS                     "MnMxArgs"
+#define MAX_ARGS_MSG                 "Function '%s' expects at least one numerical argument, list or matrix."
+
 #endif /* functions_h */

--- a/morpho5/datastructures/value.c
+++ b/morpho5/datastructures/value.c
@@ -57,3 +57,27 @@ bool value_promotenumberlist(unsigned int nv, value *v) {
     }
     return true;
 }
+
+/* Finds the maximum and minimum of a list of values */
+bool value_minmax(unsigned int nval, value *list, value *min, value *max) {
+    if (nval==0) return false;
+    
+    if (min) *min=list[0];
+    if (max) *max=list[0];
+    
+    for (unsigned int i=1; i<nval; i++) {
+        if (min) {
+            value l=*min, r=list[i];
+            MORPHO_CMPPROMOTETYPE(l, r);
+            if (morpho_comparevalue(l, r)<0) *min = list[i];
+        }
+        
+        if (max) {
+            value l=*max, r=list[i];
+            MORPHO_CMPPROMOTETYPE(l, r);
+            if (morpho_comparevalue(l, r)>0) *max = list[i];
+        }
+    }
+    
+    return true;
+}

--- a/morpho5/datastructures/value.h
+++ b/morpho5/datastructures/value.h
@@ -206,5 +206,6 @@ bool varray_valuefind(varray_value *varray, value v, unsigned int *out);
 bool varray_valuefindsame(varray_value *varray, value v, unsigned int *out);
 
 bool value_promotenumberlist(unsigned int nv, value *v);
+bool value_minmax(unsigned int nval, value *list, value *min, value *max);
 
 #endif /* value_h */

--- a/morpho5/docs/builtin.md
+++ b/morpho5/docs/builtin.md
@@ -91,7 +91,29 @@ Returns `true` if a value is a sparse matrix or `false` otherwise.
 
 Returns `true` if a value is infinite or `false` otherwise.
 
-## issparse
+## isnan
 [tagisnan]: # (isnan)
 
 Returns `true` if a value is a Not a Number or `false` otherwise.
+
+## iscallable
+[tagiscallable]: # (iscallable)
+
+Returns `true` if a value is callable or `false` otherwise.
+
+## Apply
+[tagapply]: # (apply)
+
+Apply calls a function with the arguments provided as a list:
+
+    apply(f, [0.5, 0.5]) // calls f(0.5, 0.5) 
+    
+It's often useful where a function or method and/or the number of parameters isn't known ahead of time. The first parameter to apply can be any callable object, including a method invocation or a closure. 
+
+You may also instead omit the list and use apply with multiple arguments: 
+
+    apply(f, 0.5, 0.5) // calls f(0.5, 0.5)
+    
+There is one edge case that occurs when you want to call a function that accepts a single list as a parameter. In this case, enclose the list in another list: 
+
+    apply(f, [[1,2]]) // equivalent to f([1,2])

--- a/morpho5/docs/functions.md
+++ b/morpho5/docs/functions.md
@@ -29,3 +29,26 @@ The `return` keyword is used to exit from a function, optionally passing a given
     }
 
 by returning early if `n<2`, otherwise returning the result by recursively calling itself.
+
+# Closures
+[tagclosures]: # (closures)
+[tagclosure]: # (closure)
+
+Functions in morpho can form *closures*, i.e. they can enclose information from their local context. In this example, 
+
+    fn foo(a) {
+        fn g() { return a } 
+        return g
+    }
+
+the function `foo` returns a function that captures the value of `a`. If we now try calling `foo` and then calling the returned functions,
+
+    var p=foo(1), q=foo(2) 
+    print p() // expect: 1 
+    print q() // expect: 2
+    
+we can see that `p` and `q` seem to contain different copies of `g` that encapsulate the value that `foo` was called with. 
+
+Morpho hints that a returned function is actually a closure by displaying it with double brackets: 
+
+    print foo(1) // expect: <<fn g>> 

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -1138,7 +1138,17 @@ value ScalarPotential_gradient(vm *v, int nargs, value *args) {
             } else morpho_runtimeerror(v, SCALARPOTENTIAL_FNCLLBL);
         } else if (objectinstance_getproperty(MORPHO_GETINSTANCE(MORPHO_SELF(args)), scalarpotential_functionproperty, &fn)) {
             // Otherwise try to use the regular scalar function
-            UNREACHABLE("Numerical derivative not implemented");
+            
+            value fn;
+            if (objectinstance_getproperty(MORPHO_GETINSTANCE(MORPHO_SELF(args)), scalarpotential_functionproperty, &fn)) {
+                info.g = MESH_GRADE_VERTEX;
+                info.integrand = scalarpotential_integrand;
+                info.ref = &fn;
+                if (MORPHO_ISCALLABLE(fn)) {
+                    functional_mapnumericalgradient(v, &info, &out);
+                } else morpho_runtimeerror(v, SCALARPOTENTIAL_FNCLLBL);
+            } else morpho_runtimeerror(v, VM_OBJECTLACKSPROPERTY, SCALARPOTENTIAL_FUNCTION_PROPERTY);
+            
         } else morpho_runtimeerror(v, VM_OBJECTLACKSPROPERTY, SCALARPOTENTIAL_FUNCTION_PROPERTY);
     }
     if (!MORPHO_ISNIL(out)) morpho_bindobjects(v, 1, &out);

--- a/morpho5/utils/common.c
+++ b/morpho5/utils/common.c
@@ -195,10 +195,10 @@ bool morpho_countparameters(value f, int *nparams) {
     }
     
     if (MORPHO_ISFUNCTION(g)) {
-        objectfunction *fun = MORPHO_GETFUNCTION(f);
+        objectfunction *fun = MORPHO_GETFUNCTION(g);
         *nparams=fun->nargs;
         success=true;
-    } else if (MORPHO_ISBUILTINFUNCTION(f)) {
+    } else if (MORPHO_ISBUILTINFUNCTION(g)) {
         *nparams = -1;
         success=true;
     }

--- a/morpho5/utils/debug.c
+++ b/morpho5/utils/debug.c
@@ -406,7 +406,7 @@ bool debug_symbolsforfunction(program *code, objectfunction *func, instructionin
 
 /** Prints a stacktrace */
 void morpho_stacktrace(vm *v) {
-    for (callframe *f = v->fp; f!=NULL && f>=v->frame; f--) {
+    for (callframe *f = (v->errfp ? v->errfp : v->fp); f!=NULL && f>=v->frame; f--) {
         instructionindx indx = f->pc-v->current->code.data;
         if (indx>0) indx--; /* Becuase the pc always points to the NEXT instr. */
         

--- a/morpho5/utils/parse.c
+++ b/morpho5/utils/parse.c
@@ -251,7 +251,8 @@ static bool lex_number(lexer *l, token *tok, error *err) {
     while (lex_isdigit(lex_peek(l))) lex_advance(l);
     
     /* Fractional part */
-    char next = lex_peekahead(l, 1);
+    char next = '\0';
+    if (lex_peek(l)!='\0') next=lex_peekahead(l, 1); // Prevent looking beyond buffer
     if (lex_peek(l) == '.' && (lex_isnumber(next)
 #ifndef MORPHO_LOXCOMPATIBILITY
                                || lex_isspace(next) || next=='\0'

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -2347,9 +2347,11 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
         {
             compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, false, 0, false, REGISTER_UNALLOCATED), node); /* Add a return */
         } else if (isanonymous) {
-            if (CODEINFO_ISCONSTANT(bodyinfo) && !CODEINFO_ISCONSTANT(bodyinfo)) {
-                UNREACHABLE("Compiler internal error in compiler_function.");
+            if (!CODEINFO_ISREGISTER(bodyinfo) && !CODEINFO_ISCONSTANT(bodyinfo)) {
+                bodyinfo=compiler_movetoregister(c, node, bodyinfo, REGISTER_UNALLOCATED);
+                ninstructions+=bodyinfo.ninstructions;
             }
+            
             compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, CODEINFO_ISCONSTANT(bodyinfo), bodyinfo.dest, false, REGISTER_UNALLOCATED), node);
         } else {
             compiler_addinstruction(c, ENCODE_BYTE(OP_RETURN), node); /* Add a return */

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -223,6 +223,7 @@ struct svm {
     errorhandler *ehp; /* Error handler pointer */
     
     error err; /** An error struct that will be filled out when an error occurs */
+    callframe *errfp; /** Record frame pointer when an error occured */
     
     object *objects; /** Linked list of objects */
     graylist gray; /** Graylist for garbage collection */

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -181,6 +181,7 @@ static void vm_init(vm *v) {
     varray_valueinit(&v->globals);
     varray_valueresize(&v->stack, MORPHO_STACKINITIALSIZE);
     error_init(&v->err);
+    v->errfp=NULL;
 }
 
 /** Clears a virtual machine */
@@ -1627,6 +1628,7 @@ vm_error:
         }
         
         /* The error was not caught; unwind the stack to the point where we have to return  */
+        if (!v->errfp) v->errfp=v->fp; // Record frame pointer for stacktrace
         v->fp=retfp-1;
         
     }
@@ -1759,6 +1761,7 @@ bool morpho_run(vm *v, program *p) {
 
     /* Clear current error state */
     error_clear(&v->err);
+    v->errfp=NULL;
 
     /* Set up the callframe stack */
     v->fp=v->frame; /* Set the frame pointer to the bottom of the stack */

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1628,7 +1628,11 @@ vm_error:
         }
         
         /* The error was not caught; unwind the stack to the point where we have to return  */
-        if (!v->errfp) v->errfp=v->fp; // Record frame pointer for stacktrace
+        if (!v->errfp) {
+            v->errfp=v->fp; // Record frame pointer for stacktrace
+            v->errfp->pc=pc;
+        }
+        
         v->fp=retfp-1;
         
     }

--- a/test/apply/apply_list.morpho
+++ b/test/apply/apply_list.morpho
@@ -1,0 +1,20 @@
+// Apply a function to a list of arguments
+
+fn f(x,y) {
+  return x^2+y^2
+}
+
+print apply(f, [0.5,0.5])
+// expect: 0.5
+
+var a = [0.1, 0.1]
+
+print apply(f, a)
+// expect: 0.02
+
+fn g(x) {
+  print x
+}
+
+apply(g, [[1,2,3]])
+// expect: [ 1, 2, 3 ]

--- a/test/builtin/bounds.morpho
+++ b/test/builtin/bounds.morpho
@@ -17,4 +17,4 @@ print min(b)
 // expect: -1
 
 print bounds()
-// expect Error 'InvldArgs'
+// expect Error 'MnMxArgs'

--- a/test/builtin/boundsvargs.morpho
+++ b/test/builtin/boundsvargs.morpho
@@ -1,0 +1,10 @@
+// Calculate bounds of enumerable objects
+
+var a = [ 4, 5, 3, 1, 2 ]
+var b = [ 2, -1, 0.3 ]
+
+print bounds(a, 7, b)
+// expect: [ -1, 7 ]
+
+print bounds()
+// expect error 'MnMxArgs'

--- a/test/builtin/maxargs.morpho
+++ b/test/builtin/maxargs.morpho
@@ -1,4 +1,4 @@
-print max([]) 
+print max([])
 // expect: nil
-print max(-120) 
-// expect error 'InvldArgsBltn'
+print max(-120)
+// expect: -120

--- a/test/builtin/minargs.morpho
+++ b/test/builtin/minargs.morpho
@@ -1,4 +1,4 @@
-print min([]) 
+print min([])
 // expect: nil
-print min(-120) 
-// expect error 'InvldArgsBltn'
+print min(-120)
+// expect: -120

--- a/test/builtin/minvargs.morpho
+++ b/test/builtin/minvargs.morpho
@@ -1,0 +1,13 @@
+// Use min/max on varargs
+
+print min(0.1, 0.5, 1, 0.001, 2)
+// expect: 0.001
+
+print min(0.1, [0.5, 1], [2, 0.003])
+// expect: 0.003
+
+print max(0.1, 0.5, 1, 0.001, 2)
+// expect: 2
+
+print max(0.1, [0.5, 3], [2, 0.003])
+// expect: 3

--- a/test/builtin/typecheck.morpho
+++ b/test/builtin/typecheck.morpho
@@ -17,7 +17,7 @@ var tst=Matrix(check.count(),vals.count())
 
 for (i in 0..vals.count()-1) {
   for (j in 0..vals.count()-1) {
-    if (apply(check[i], vals[j])) tst[i,j]=1
+    if (apply(check[i], [].append(vals[j]))) tst[i,j]=1
   }
 }
 

--- a/test/closure/closures_in_loop.morpho
+++ b/test/closure/closures_in_loop.morpho
@@ -1,0 +1,12 @@
+var mesh = Mesh()
+
+while (true) {
+	var L = 1
+
+	var a=Selection(mesh, fn (x,y,z) x+L<0.01)
+
+	var b=LineIntegral(fn (x) x)
+	break
+}
+
+print "ok" // expect: ok

--- a/test/function/anonymous_closure_noparams.morpho
+++ b/test/function/anonymous_closure_noparams.morpho
@@ -1,0 +1,24 @@
+// Anonymous closure
+
+var a = 0.5
+print apply(fn () a, [])
+// expect: 0.5
+
+fn f(x) {
+  return fn () x
+}
+
+print f(0.4)
+// expect: <<fn >>
+
+print f(0.4)()
+// expect: 0.4
+
+for (i in 1..5) {
+  print apply(fn () i, [])
+}
+// expect: 1
+// expect: 2
+// expect: 3
+// expect: 4
+// expect: 5

--- a/test/functionals/scalarpotential/scalarpotential_ndiff.morpho
+++ b/test/functionals/scalarpotential/scalarpotential_ndiff.morpho
@@ -1,0 +1,28 @@
+
+var m = Mesh("tetrahedron.mesh")
+
+fn phi(x,y,z) {
+  return x^2+y^2+z^2
+}
+
+fn gradphi(x,y,z) {
+  return Matrix([2*x,2*y,2*z])
+}
+
+var a = ScalarPotential(phi)
+
+var int = Matrix(4)
+for (x, k in m.vertexmatrix()) {
+  int[k]=phi(x[0], x[1], x[2])
+}
+
+print a.integrand(m)
+// expect: [ 0.374999 0.375 0.375 0.375 ]
+
+print a.total(m)
+// expect: 1.5
+
+print a.gradient(m)
+// expect: [ 0 -0.57735 -0.57735 1.1547 ]
+// expect: [ 0 -1 1 0 ]
+// expect: [ 1.22474 -0.408248 -0.408248 -0.408248 ]

--- a/test/functionals/scalarpotential/scalarpotential_ndiff.morpho
+++ b/test/functionals/scalarpotential/scalarpotential_ndiff.morpho
@@ -11,18 +11,23 @@ fn gradphi(x,y,z) {
 
 var a = ScalarPotential(phi)
 
-var int = Matrix(4)
-for (x, k in m.vertexmatrix()) {
-  int[k]=phi(x[0], x[1], x[2])
+var mc = Matrix([ 0.374999, 0.375, 0.375, 0.375 ])
+var mi = Matrix(4)
+
+for (k in 0...m.count()) {
+  var x = m.vertexposition(k)
+  mi[k]=phi(x[0], x[1], x[2])
 }
 
-print a.integrand(m)
-// expect: [ 0.374999 0.375 0.375 0.375 ]
+print (mi-mc).norm()<1e-5
+// expect: true
 
 print a.total(m)
 // expect: 1.5
 
-print a.gradient(m)
-// expect: [ 0 -0.57735 -0.57735 1.1547 ]
-// expect: [ 0 -1 1 0 ]
-// expect: [ 1.22474 -0.408248 -0.408248 -0.408248 ]
+var ngrad = [[ 0, -0.57735, -0.57735, 1.1547 ],
+             [ 0, -1, 1, 0 ],
+             [ 1.22474, -0.408248, -0.408248, -0.408248 ]]
+
+print (a.gradient(m)-Matrix(Array(ngrad))).norm() < 1e-5
+// expect: true

--- a/test/try/try_reentrancy_uncaught.morpho
+++ b/test/try/try_reentrancy_uncaught.morpho
@@ -1,0 +1,22 @@
+/* **********************************
+ * morpho test suite
+ * try_reentrancy.morpho
+ * try/catch from within renentered vm
+ * ********************************** */
+
+var err = Error("Foo", "A Foo occurred")
+var err2 = Error("Boo", "A Foo occurred")
+
+fn bar (x) {
+  err2.throw()
+}
+
+for (i in 1..4) {
+  try {
+    apply(bar, nil)
+  } catch {
+    "Foo": print "Caught"
+  }
+}
+
+// expect error 'Boo'

--- a/test/type/typecheck.morpho
+++ b/test/type/typecheck.morpho
@@ -15,9 +15,9 @@ var check = [ isnil, isint, isfloat, isbool, isbool, isobject, isstring,
 
 var tst=Matrix(check.count(),vals.count())
 
-for (i in 0..vals.count()-1) {
-  for (j in 0..vals.count()-1) {
-    if (apply(check[i], vals[j])) tst[i,j]=1
+for (i in 0...vals.count()) {
+  for (j in 0...vals.count()) {
+    if (apply(check[i], [].append(vals[j]))) tst[i,j]=1
   }
 }
 


### PR DESCRIPTION
A number of small improvements and fixes that aid the meshgen module. 

- min, max and bounds can accept multiple arguments; none of which have to be lists. So things like:
           min(1,2,-1)
  are supported.
- ScalarPotential will calculate numerical gradients if a gradient function isn't provided. 
- Apply now will apply the function specified to a List IF that is the only other argument, e.g. 
           apply(f, [1,2,3]) // f(1,2,3) 
- Additions to help to support the above. 

- Stacktraces now display correctly again.
- Anonymous functions now return upvalues and globals correctly. Fixed #83.