### PR TITLE
More careful calculation of inclusive range limits (fixes #105)

### DIFF
--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -1619,7 +1619,7 @@ int range_count(objectrange *range) {
         double diff=MORPHO_GETFLOATVALUE(range->end)-MORPHO_GETFLOATVALUE(range->start);
         double stp=(MORPHO_ISNIL(range->step) ? 1 : MORPHO_GETFLOATVALUE(range->step));
         double cnt = ceil(diff / stp);
-        if (isfinite(cnt)) out = cnt + (cnt * stp - diff <= DBL_EPSILON);
+        if (isfinite(cnt)) out = cnt + (fabs(cnt * stp - diff) <= DBL_EPSILON);
     } else {
         int diff=MORPHO_GETINTEGERVALUE(range->end)-MORPHO_GETINTEGERVALUE(range->start);
         int stp=(MORPHO_ISNIL(range->step) ? 1 : MORPHO_GETINTEGERVALUE(range->step));

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -1618,15 +1618,14 @@ int range_count(objectrange *range) {
     if (MORPHO_ISFLOAT(range->start)) {
         double diff=MORPHO_GETFLOATVALUE(range->end)-MORPHO_GETFLOATVALUE(range->start);
         double stp=(MORPHO_ISNIL(range->step) ? 1 : MORPHO_GETFLOATVALUE(range->step));
-        out=diff/stp;
+        double cnt = ceil(diff / stp);
+        if (isfinite(cnt)) out = cnt + (cnt * stp - diff <= DBL_EPSILON);
     } else {
         int diff=MORPHO_GETINTEGERVALUE(range->end)-MORPHO_GETINTEGERVALUE(range->start);
         int stp=(MORPHO_ISNIL(range->step) ? 1 : MORPHO_GETINTEGERVALUE(range->step));
-        out=diff/stp;
+        if (stp != 0) out = diff / stp + 1;
     }
-    if (out>=0) out+=1;
-    else out=0;
-    
+    if (out < 0) out=0;
     return out;
 }
 

--- a/test/range/exclusive.morpho
+++ b/test/range/exclusive.morpho
@@ -16,6 +16,3 @@ for (i in 0...-2:-0.5) print i
 // expect: -1
 // expect: -1.5
 
-for (i in 1.0...1.2:0.15) print i
-// expect: 1
-// AssumeFail(#114): 1.15

--- a/test/range/exclusive.morpho
+++ b/test/range/exclusive.morpho
@@ -15,3 +15,7 @@ for (i in 0...-2:-0.5) print i
 // expect: -0.5
 // expect: -1
 // expect: -1.5
+
+for (i in 1.0...1.2:0.15) print i
+// expect: 1
+// AssumeFail(#114): 1.15

--- a/test/range/inclusive.morpho
+++ b/test/range/inclusive.morpho
@@ -1,0 +1,19 @@
+for (i in 1..5) print i
+// expect: 1
+// expect: 2
+// expect: 3
+// expect: 4
+// expect: 5
+
+for (i in 0.1..1.2:0.1) print i
+// expect: 0.1
+// expect: 0.2
+// expect: 0.3
+// expect: 0.4
+// expect: 0.5
+// expect: 0.6
+// expect: 0.7
+// expect: 0.8
+// expect: 0.9
+// expect: 1
+// expect: 1.1

--- a/test/range/inclusive.morpho
+++ b/test/range/inclusive.morpho
@@ -17,3 +17,4 @@ for (i in 0.1..1.2:0.1) print i
 // expect: 0.9
 // expect: 1
 // expect: 1.1
+// expect: 1.2

--- a/test/range/syntax.morpho
+++ b/test/range/syntax.morpho
@@ -12,6 +12,10 @@ var b = 1..2:2
 print b
 // expect: 1..2:2
 
+var c = 1.0...1.2:0.15
+print c
+// AssumeFail(#114): 1.0..1.15:0.15
+
 var n=2
 a = n..2*n:2
 print a

--- a/test/range/syntax.morpho
+++ b/test/range/syntax.morpho
@@ -12,10 +12,6 @@ var b = 1..2:2
 print b
 // expect: 1..2:2
 
-var c = 1.0...1.2:0.15
-print c
-// AssumeFail(#114): 1.0..1.15:0.15
-
 var n=2
 a = n..2*n:2
 print a


### PR DESCRIPTION
In the `range_count` function, floating point error would lead to inaccurate calculation of the size of an inclusive range. 

In the case of the example shown in #105, with `start = 0.1`, `end = 2.0`, and `step = 0.1`, we compute the number of elements in the range to be `1 + (int) ((2.0 - 0.1) / 0.1) = 1 + (int) (18.99...96) = 19` which is off by one. Instead, we need to make sure to take the ceiling of the result before casting to an integer.

I additionally removed a possible integer division by 0, as well as added checks for infinities and nans before casting to an integer. In these cases, I take the number of elements to be 0 since there's no well-defined set of elements to return.

This should resolve #105