### PR TITLE
Fix107

### DIFF
--- a/morpho5/geometry/mesh.c
+++ b/morpho5/geometry/mesh.c
@@ -991,7 +991,7 @@ bool mesh_save(objectmesh *m, char *file) {
 
     fprintf(f, "\n");
 
-    for (grade g=1; g<m->dim; g++) {
+    for (grade g=1; g<=m->dim; g++) {
         objectsparse *conn=mesh_getconnectivityelement(m, 0, g);
 
         if (conn) {

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -2287,6 +2287,8 @@ static void compiler_functionparameters(compiler *c, syntaxtreeindx indx) {
     }
 }
 
+value _selfsymbol;
+
 /** Compiles a function declaration */
 static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerindx reqout) {
     syntaxtreeindx body=node->right; /* Function body */
@@ -2323,8 +2325,7 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
     
     /* The function has a reference to itself in r0, which may be 'self' if we're in a method */
     value r0symbol=node->content;
-    objectstring slfsymbol = MORPHO_STATICSTRING("self");
-    if (ismethod) r0symbol=MORPHO_OBJECT(&slfsymbol);
+    if (ismethod) r0symbol=_selfsymbol;
     compiler_regalloc(c, r0symbol);
     
     /* -- Compile the parameters -- */
@@ -3425,6 +3426,8 @@ void morpho_setbaseclass(value klss) {
 /** Initializes the error handling system */
 void compile_initialize(void) {
     baseclass=NULL;
+    
+    _selfsymbol=builtin_internsymbolascstring("self");
     
     /* Lex errors */
     morpho_defineerror(COMPILE_UNTERMINATEDCOMMENT, ERROR_LEX, COMPILE_UNTERMINATEDCOMMENT_MSG);


### PR DESCRIPTION
Test method/too_many_parameters.morpho exposed a pernicious compiler bug; the value 'self' was being stored in the r0 register allocation by compiler_function as a static string, but was under certain circumstances being read from after this function had returned triggering an abort. We now intern a symbol 'self' globally using builtin_internsymbolascstring and this fixes the problem. 

Fixes #107 