### PR TITLE
Examples/catenoid

### DIFF
--- a/examples/catenoid/catenoid.morpho
+++ b/examples/catenoid/catenoid.morpho
@@ -1,0 +1,47 @@
+// This script computes the shape of a soap film attached to two circular rings separated vertically.
+// The surface tension minimizes the area of this film, resulting in a shape called a "catenoid". This belongs to the family of "minimal surfaces", which are surfaces that locally minimize their area.
+
+// Showcases: AreaMesh, Area, conjugategradient
+import meshtools
+import plot
+import optimize
+
+// Set up geometrical parameters
+
+var r = 1.0 // radius
+var ratio = 0.4 // Separation to diameter ratio
+var L = 2*r*ratio // Separation
+
+// Generate a tube / cylindrical mesh
+var mesh = AreaMesh(fn (u, v) [r*cos(u), v, r*sin(u)], 
+                    -Pi...Pi:Pi/10,
+                    -L/2..L/2:L/5, 
+                    closed=[true,false]
+)
+
+mesh.addgrade(1)
+
+// Select the boundary
+var bnd = Selection(mesh, boundary=true)
+
+var g = plotselection(mesh, bnd, grade=1)
+g.title = "Before"
+Show(g)
+
+// Define the optimizataion problem
+var problem = OptimizationProblem(mesh)
+// Add the area energy using the built-in Area functional
+var area = Area()
+problem.addenergy(area)
+
+// Define the optimizer
+var opt = ShapeOptimizer(problem, mesh)
+// Ask the optimizer to fix the boundary rings
+opt.fix(bnd)
+
+// Minimize!
+opt.conjugategradient(1000)
+
+g = plotselection(mesh, bnd, grade=1)
+g.title = "After"
+Show(g)

--- a/examples/catenoid/catenoid.morpho
+++ b/examples/catenoid/catenoid.morpho
@@ -1,7 +1,8 @@
 // This script computes the shape of a soap film attached to two circular rings separated vertically.
-// The surface tension minimizes the area of this film, resulting in a shape called a "catenoid". This belongs to the family of "minimal surfaces", which are surfaces that locally minimize their area.
+// The surface tension minimizes the area of this film, resulting in a shape called a "catenoid". 
+// This belongs to the family of "minimal surfaces", which are surfaces that locally minimize their area.
 
-// Showcases: AreaMesh, Area, conjugategradient
+// Showcases: AreaMesh, Area, conjugategradient, fixing boundary in the optimizer.
 import meshtools
 import plot
 import optimize


### PR DESCRIPTION
This PR adds an example of a catenoid soap film. Here, start with an open cylindrical film with fixed boundaries and minimize the surface area. The resulting shape, for small enough separation-to-diameter ratios, is a catenoid. 
It's a neat and simple application involving just one functional, straightforward meshing and no refinement. Additionally, it features the use of fixing the boundary vertices in the optimizer.

Complications of stable vs unstable catenoids (see [here](http://facstaff.susqu.edu/brakke/evolver/examples/cat/catenoids.html#:~:text=The%20soap%20film%20that%20forms,a%20thin%2Dnecked%20unstable%20catenoid.)) can be addressed in a future example. 