### PR TITLE
Altinstruction

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -22,6 +22,7 @@ languages = { "morpho": "morpho5",
 """
 
 languages = { "morpho": "morpho5" }
+samples = 1
 
 # Gets the output generated
 def getoutput(filepath):
@@ -64,8 +65,10 @@ def benchmark(folder):
     for lang in languages.keys():
         test = glob.glob(folder + '**.' + lang, recursive=False)
         if (len(test)>0):
-            time=run(languages[lang], test[0])
-            dict[lang]=time
+            time = []
+            for i in range(1,samples):
+                time.append(run(languages[lang], test[0]))
+            dict[lang]=min(time)
     return dict
 
 print('--Begin testing---------------------')

--- a/morpho5/utils/debug.c
+++ b/morpho5/utils/debug.c
@@ -129,7 +129,7 @@ assemblyrule assemblyrules[] ={
     { OP_BIFF, "biff", "rA +" },
     
     { OP_CALL, "call", "rA, B" }, // b literal
-    { OP_INVOKE, "invoke", "rA, cB, C" }, // c literal
+    { OP_INVOKE, "invoke", "rA, rB, C" }, // c literal
     
     { OP_RETURN, "return", "rB" }, // c literal
 
@@ -140,7 +140,8 @@ assemblyrule assemblyrules[] ={
     
     { OP_CLOSEUP, "closeup", "rA" },
     { OP_LPR, "lpr", "rA, rB, rC" },
-    { OP_SPR, "spr", "rA, cB, rC" },
+    { OP_SPR, "spr", "rA, rB, rC" },
+    
     { OP_LIX, "lix", "rA, rB, rC" },
     { OP_SIX, "six", "rA, rB, rC" },
     

--- a/morpho5/utils/debug.c
+++ b/morpho5/utils/debug.c
@@ -110,38 +110,38 @@ assemblyrule assemblyrules[] ={
     { OP_NOP, "nop", "" },
     { OP_MOV, "mov", "rA, rB" },
     { OP_LCT, "lct", "rA, cX" }, // Custom
-    { OP_ADD, "add", "rA, ?B, ?C" },
-    { OP_SUB, "sub", "rA, ?B, ?C" },
-    { OP_MUL, "mul", "rA, ?B, ?C" },
-    { OP_DIV, "div", "rA, ?B, ?C" },
-    { OP_POW, "pow", "rA, ?B, ?C" },
-    { OP_NOT, "not", "rA, ?B" },
+    { OP_ADD, "add", "rA, rB, rC" },
+    { OP_SUB, "sub", "rA, rB, rC" },
+    { OP_MUL, "mul", "rA, rB, rC" },
+    { OP_DIV, "div", "rA, rB, rC" },
+    { OP_POW, "pow", "rA, rB, rC" },
+    { OP_NOT, "not", "rA, rB" },
     
-    { OP_EQ, "eq ", "rA, ?B, ?C" },
-    { OP_NEQ, "neq", "rA, ?B, ?C" },
-    { OP_LT, "lt ", "rA, ?B, ?C" },
-    { OP_LE, "le ", "rA, ?B, ?C" },
+    { OP_EQ, "eq ", "rA, rB, rC" },
+    { OP_NEQ, "neq", "rA, rB, rC" },
+    { OP_LT, "lt ", "rA, rB, rC" },
+    { OP_LE, "le ", "rA, rB, rC" },
     
-    { OP_PRINT, "print", "?B" },
+    { OP_PRINT, "print", "rA" },
     
     { OP_B, "b", "+" },
-    { OP_BIF, "bif", "F rA +" },
+    { OP_BIF, "bif", "rA +" },
     
     { OP_CALL, "call", "rA, B" }, // b literal
-    { OP_INVOKE, "invoke", "rA, ?B, C" }, // c literal
+    { OP_INVOKE, "invoke", "rA, cB, C" }, // c literal
     
     { OP_RETURN, "return", "rB" }, // c literal
 
     { OP_CLOSURE, "closure", "rA, pB" }, // b prototype
     
     { OP_LUP, "lup", "rA, uB" }, // b 'u'
-    { OP_SUP, "sup", "uA, ?B" }, // a 'u', b c|r
+    { OP_SUP, "sup", "uA, rB" }, // a 'u', b c|r
     
     { OP_CLOSEUP, "closeup", "rA" },
-    { OP_LPR, "lpr", "rA, ?B, ?C" },
-    { OP_SPR, "spr", "rA, ?B, ?C" },
-    { OP_LIX, "lix", "rA, ?B, ?C" },
-    { OP_SIX, "six", "rA, ?B, ?C" },
+    { OP_LPR, "lpr", "rA, rB, rC" },
+    { OP_SPR, "spr", "rA, cB, rC" },
+    { OP_LIX, "lix", "rA, rB, rC" },
+    { OP_SIX, "six", "rA, rB, rC" },
     
     { OP_LGL, "lgl", "rA, gX" }, //
     { OP_SGL, "sgl", "rA, gX" }, // label b with 'g'
@@ -149,9 +149,7 @@ assemblyrule assemblyrules[] ={
     { OP_PUSHERR, "pusherr", "cX" },
     { OP_POPERR, "poperr", "+" },
     
-   // { OP_ARRAY, "array", "rA, ?B, ?C" },
-    { OP_CAT, "cat", "rA, ?B, ?C" },
-   // { OP_RAISE, "raise", "rA" },
+    { OP_CAT, "cat", "rA, rB, rC" },
     { OP_BREAK, "break", "" },
     { OP_END, "end", "" },
     { 0, NULL, "" } // Null terminate the list
@@ -211,13 +209,6 @@ void debug_disassembleinstruction(instruction instruction, instructionindx indx,
                 case 'C': {
                     cm=mode; nc=DECODE_C(instruction);
                     n+=printf("%u", DECODE_C(instruction));
-                }
-                    break;
-                case 'F': n+=printf("%s", (DECODE_F(instruction) ? "t" : "f")); break;
-                case '?': {
-                    bool isconst=(c[1]=='B' ? DECODE_ISBCONSTANT(instruction) : DECODE_ISCCONSTANT(instruction)); // Is the next letter B or C?
-                    mode=( isconst ? CONST : REG );
-                    n+=printf("%s", (isconst ? "c" : "r"));
                 }
                     break;
                 case 'c': mode=CONST; n+=printf("%c", *c); break;

--- a/morpho5/utils/debug.c
+++ b/morpho5/utils/debug.c
@@ -126,6 +126,7 @@ assemblyrule assemblyrules[] ={
     
     { OP_B, "b", "+" },
     { OP_BIF, "bif", "rA +" },
+    { OP_BIFF, "biff", "rA +" },
     
     { OP_CALL, "call", "rA, B" }, // b literal
     { OP_INVOKE, "invoke", "rA, cB, C" }, // c literal

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -1739,7 +1739,7 @@ static codeinfo compiler_if(compiler *c, syntaxtreenode *node, registerindx reqo
     }
     
     /* Now generate the conditional branch over the then clause */
-    compiler_setinstruction(c, ifindx, ENCODE_LONG(OP_BIF, cond.dest, then.ninstructions+nextra));
+    compiler_setinstruction(c, ifindx, ENCODE_LONG(OP_BIFF, cond.dest, then.ninstructions+nextra));
     
     /* If necessary generate the unconditional branch over the else clause */
     if (right->type==NODE_THEN) {
@@ -1837,7 +1837,7 @@ static codeinfo compiler_while(compiler *c, syntaxtreenode *node, registerindx r
     if (node->left!=SYNTAXTREE_UNCONNECTED) {
         /* And generate the conditional branch at the start of the loop.
            The extra 1 is to skip the loop instruction */
-        compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIF, cond.dest, body.ninstructions+1));
+        compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIFF, cond.dest, body.ninstructions+1));
     }
     
     return CODEINFO(REGISTER, REGISTER_UNALLOCATED, ninstructions);
@@ -1947,7 +1947,7 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     ninstructions++;
     
     /* Go back and generate the condition instruction */
-    compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIF, rcond, (add-tst) ));
+    compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIFF, rcond, (add-tst) ));
     
     compiler_fixloop(c, tst, add, end+1);
     
@@ -2127,7 +2127,7 @@ static codeinfo compiler_try(compiler *c, syntaxtreenode *node, registerindx req
 static codeinfo compiler_logical(compiler *c, syntaxtreenode *node, registerindx reqout) {
     /* An AND operator must branch if the first operand is false,
        an OR  operator must branch if the first operator is true */
-    bool bifflag = (node->type==NODE_AND ? false : true);
+    bool biffflag = (node->type==NODE_AND ? true : false); // Generate a BIFF instruction
     
     registerindx out = compiler_regtemp(c, reqout);
     instructionindx condindx=0; /* Where is the condition located */
@@ -2157,12 +2157,8 @@ static codeinfo compiler_logical(compiler *c, syntaxtreenode *node, registerindx
         rinstructions+=right.ninstructions;
     }
     
-    if (bifflag) {
-        UNREACHABLE("BIFF NOT IMPLEMENTED");
-    }
-    
     /* Generate the branch instruction */
-    compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIF, out, rinstructions));
+    compiler_setinstruction(c, condindx, ENCODE_LONG((biffflag ? OP_BIFF : OP_BIF), out, rinstructions));
     
     return CODEINFO(REGISTER, out, linstructions+rinstructions);
 }

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -1940,6 +1940,8 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     compiler_endloop(c);
     
     /* Increment the counter */
+    instructionindx inc=compiler_currentinstructionindex(c);
+    
     registerindx cone = compiler_addconstant(c, node, MORPHO_INTEGER(1), false, false);
     codeinfo oneinfo = CODEINFO(CONSTANT, cone, 0);
     oneinfo = compiler_movetoregister(c, node, oneinfo, REGISTER_UNALLOCATED);
@@ -1955,7 +1957,7 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     /* Go back and generate the condition instruction */
     compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIFF, rcond, (add-tst) ));
     
-    compiler_fixloop(c, tst, add, end+1);
+    compiler_fixloop(c, tst, inc, end+1);
     
     if (CODEINFO_ISREGISTER(method)) compiler_regfreetemp(c, method.dest);
     

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -780,7 +780,7 @@ static codeinfo compiler_movetoregister(compiler *c, syntaxtreenode *node, codei
         /* Move upvalues */
         out.dest=compiler_regtemp(c, reg);
         out.returntype=REGISTER;
-        compiler_addinstruction(c, ENCODE_DOUBLE(OP_LUP, out.dest, false, info.dest), node);
+        compiler_addinstruction(c, ENCODE_DOUBLE(OP_LUP, out.dest, info.dest), node);
         out.ninstructions++;
     } else if (CODEINFO_ISGLOBAL(info)) {
         /* Move upvalues */
@@ -797,7 +797,7 @@ static codeinfo compiler_movetoregister(compiler *c, syntaxtreenode *node, codei
         }
         
         if (out.dest!=info.dest) {
-            compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, out.dest, false, info.dest), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, out.dest, info.dest), node);
             out.ninstructions++;
         }
     }
@@ -812,9 +812,9 @@ static codeinfo compiler_movetoregister(compiler *c, syntaxtreenode *node, codei
 codeinfo compiler_addsymbolwithsizecheck(compiler *c, syntaxtreenode *node, value symbol) {
     codeinfo out = CODEINFO(CONSTANT, 0, 0);
     out.dest = compiler_addsymbol(c, node, symbol);
-    if (out.dest>MORPHO_MAXREGISTERS) {
+    //if (out.dest>MORPHO_MAXREGISTERS) {
         out = compiler_movetoregister(c, node, out, REGISTER_UNALLOCATED);
-    }
+    //}
     return out;
 }
 
@@ -972,13 +972,13 @@ static codeinfo compiler_movetoupvalue(compiler *c, syntaxtreenode *node, codein
     codeinfo out = CODEINFO_EMPTY;
     bool tmp=false;
     
-    if (!(CODEINFO_ISREGISTER(in) || CODEINFO_ISSHORTCONSTANT(in))) {
+    if (!CODEINFO_ISREGISTER(in)) {
         use=compiler_movetoregister(c, node, in, REGISTER_UNALLOCATED);
         out.ninstructions+=use.ninstructions;
         tmp=true;
     }
     
-    compiler_addinstruction(c, ENCODE_DOUBLE(OP_SUP, slot, (use.returntype==CONSTANT), use.dest), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_SUP, slot, use.dest), node);
     out.ninstructions++;
     
     if (tmp) {
@@ -1279,7 +1279,7 @@ static codeinfo compiler_list(compiler *c, syntaxtreenode *node, registerindx re
     varray_syntaxtreeindxclear(&entries);
     
     /* Make the function call */
-    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, out.dest, false, nargs), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, out.dest, nargs), node);
     out.ninstructions++;
     compiler_regfreetoend(c, out.dest+1);
     
@@ -1320,7 +1320,7 @@ static codeinfo compiler_dictionary(compiler *c, syntaxtreenode *node, registeri
     varray_syntaxtreeindxclear(&entries);
     
     /* Make the function call */
-    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, out.dest, false, nargs), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, out.dest, nargs), node);
     out.ninstructions++;
     compiler_regfreetoend(c, out.dest+1);
     
@@ -1360,7 +1360,7 @@ static codeinfo compiler_range(compiler *c, syntaxtreenode *node, registerindx r
     }
     
     /* Make the function call */
-    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, rng.dest, false, n), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, rng.dest, n), node);
     rng.ninstructions++;
     compiler_regfreetoend(c, rng.dest+1);
     
@@ -1407,7 +1407,7 @@ static codeinfo compiler_index(compiler *c, syntaxtreenode *node, registerindx r
     ninstructions+=out.ninstructions;
     
     /* Compile instruction */
-    compiler_addinstruction(c, ENCODEC(OP_LIX, left.dest, false, start, false, end), node);
+    compiler_addinstruction(c, ENCODE(OP_LIX, left.dest, start, end), node);
     ninstructions++;
     
     /* Free anything we're done with */
@@ -1429,15 +1429,20 @@ static codeinfo compiler_negate(compiler *c, syntaxtreenode *node, registerindx 
         out = compiler_nodetobytecode(c, node->left, REGISTER_UNALLOCATED);
         unsigned int ninstructions=out.ninstructions;
         
-        if (!(CODEINFO_ISREGISTER(out) || CODEINFO_ISSHORTCONSTANT(out))) {
-            /* Ensure we're working with a register or a constant */
+        if (!CODEINFO_ISREGISTER(out)) {
+            /* Ensure we're working with a register */
             out=compiler_movetoregister(c, node, out, REGISTER_UNALLOCATED);
             ninstructions+=out.ninstructions;
         }
         
         registerindx zero = compiler_addconstant(c, node, MORPHO_INTEGER(0.0), false, false);
+        codeinfo zeroinfo = CODEINFO(CONSTANT, zero, 0);
+        zeroinfo=compiler_movetoregister(c, node, zeroinfo, REGISTER_UNALLOCATED);
+        ninstructions+=zeroinfo.ninstructions;
+        
         registerindx rout = compiler_regtemp(c, reqout);
-        compiler_addinstruction(c, ENCODEC(OP_SUB, rout, true, zero, CODEINFO_ISCONSTANT(out), out.dest), node);
+        
+        compiler_addinstruction(c, ENCODE(OP_SUB, rout, zero, out.dest), node);
         ninstructions++;
         compiler_releaseoperand(c, out);
         out = CODEINFO(REGISTER, rout, ninstructions);
@@ -1452,13 +1457,13 @@ static codeinfo compiler_not(compiler *c, syntaxtreenode *node, registerindx req
     unsigned int ninstructions=left.ninstructions;
     registerindx out = compiler_regtemp(c, reqout);
     
-    if (!(CODEINFO_ISREGISTER(left) || CODEINFO_ISSHORTCONSTANT(left))) {
+    if (!CODEINFO_ISREGISTER(left)) {
         /* Ensure we're working with a register or a constant */
         left=compiler_movetoregister(c, node, left, REGISTER_UNALLOCATED);
         ninstructions+=left.ninstructions;
     }
     
-    compiler_addinstruction(c, ENCODEC(OP_NOT, out, CODEINFO_ISCONSTANT(left), left.dest, false, REGISTER_UNALLOCATED), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_NOT, out, left.dest), node);
     ninstructions++;
     compiler_releaseoperand(c, left);
     
@@ -1469,16 +1474,16 @@ static codeinfo compiler_not(compiler *c, syntaxtreenode *node, registerindx req
 static codeinfo compiler_binary(compiler *c, syntaxtreenode *node, registerindx reqout) {
     codeinfo left = compiler_nodetobytecode(c, node->left, REGISTER_UNALLOCATED);
     unsigned int ninstructions=left.ninstructions;
-    if (!(CODEINFO_ISREGISTER(left) || CODEINFO_ISSHORTCONSTANT(left))) {
-        /* Ensure we're working with a register or a constant */
+    if (!(CODEINFO_ISREGISTER(left))) {
+        /* Ensure we're working with a register */
         left=compiler_movetoregister(c, node, left, REGISTER_UNALLOCATED);
         ninstructions+=left.ninstructions;
     }
     
     codeinfo right = compiler_nodetobytecode(c, node->right, REGISTER_UNALLOCATED);
     ninstructions+=right.ninstructions;
-    if (!(CODEINFO_ISREGISTER(right) || CODEINFO_ISSHORTCONSTANT(right))) {
-        /* Ensure we're working with a register or a constant */
+    if (!(CODEINFO_ISREGISTER(right))) {
+        /* Ensure we're working with a register  */
         right=compiler_movetoregister(c, node, right, REGISTER_UNALLOCATED);
         ninstructions+=right.ninstructions;
     }
@@ -1513,7 +1518,7 @@ static codeinfo compiler_binary(compiler *c, syntaxtreenode *node, registerindx 
             UNREACHABLE("in compiling binary instruction [check bytecode compiler table]");
     }
     
-    compiler_addinstruction(c, ENCODEC(op, out, CODEINFO_ISCONSTANT(left), left.dest, CODEINFO_ISCONSTANT(right), right.dest), node);
+    compiler_addinstruction(c, ENCODE(op, out, left.dest, right.dest), node);
     ninstructions++;
     compiler_releaseoperand(c, left);
     compiler_releaseoperand(c, right);
@@ -1637,14 +1642,14 @@ static codeinfo compiler_print(compiler *c, syntaxtreenode *node, registerindx r
     codeinfo left=compiler_nodetobytecode(c, node->left, REGISTER_UNALLOCATED);
     unsigned int ninstructions=left.ninstructions;
     
-    if (!(CODEINFO_ISREGISTER(left) || CODEINFO_ISSHORTCONSTANT(left))) {
+    if (!CODEINFO_ISREGISTER(left)) {
         left=compiler_movetoregister(c, node, left, REGISTER_UNALLOCATED);
         ninstructions+=left.ninstructions;
     } else if (c->err.cat==ERROR_NONE &&  left.dest==REGISTER_UNALLOCATED) {
         UNREACHABLE("print was passed an invalid operand");
     }
 
-    compiler_addinstruction(c, ENCODEC(OP_PRINT, REGISTER_UNALLOCATED, CODEINFO_ISCONSTANT(left), left.dest, false, REGISTER_UNALLOCATED), node);
+    compiler_addinstruction(c, ENCODE_SINGLE(OP_PRINT, left.dest), node);
     ninstructions++;
     compiler_releaseoperand(c, left);
     
@@ -1899,7 +1904,7 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     codeinfo mv=compiler_movetoregister(c, collnode, coll, rmax);
     ninstructions+=mv.ninstructions;
     compiler_addinstruction(c, ENCODE_LONG(OP_LCT, rmone, cmone), node);
-    compiler_addinstruction(c, ENCODEC(OP_INVOKE, rmax, CODEINFO_ISCONSTANT(method), method.dest, false, 1), collnode);
+    compiler_addinstruction(c, ENCODE(OP_INVOKE, rmax, method.dest, 1), collnode);
     ninstructions+=2;
     compiler_regfreetemp(c, rmone);
     
@@ -1915,8 +1920,8 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     mv=compiler_movetoregister(c, collnode, coll, rval);
     ninstructions+=mv.ninstructions;
     registerindx rarg=compiler_regalloctop(c);
-    compiler_addinstruction(c, ENCODEC(OP_MOV, rarg, false, rcount, false, 0), node);
-    compiler_addinstruction(c, ENCODEC(OP_INVOKE, rval, CODEINFO_ISCONSTANT(method), method.dest, false, 1), collnode);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, rarg, rcount), node);
+    compiler_addinstruction(c, ENCODE(OP_INVOKE, rval, method.dest, 1), collnode);
     ninstructions+=2;
     compiler_regsetsymbol(c, rval, initnode->content);
     if (indxnode) compiler_regsetsymbol(c, rcount, indxnode->content);
@@ -1932,7 +1937,9 @@ static codeinfo compiler_for(compiler *c, syntaxtreenode *node, registerindx req
     
     /* Increment the counter */
     registerindx cone = compiler_addconstant(c, node, MORPHO_INTEGER(1), false, false);
-    instructionindx add=compiler_addinstruction(c, ENCODEC(OP_ADD, rcount, false, rcount, true, cone), node);
+    codeinfo oneinfo = CODEINFO(CONSTANT, cone, 0);
+    oneinfo = compiler_movetoregister(c, node, oneinfo, REGISTER_UNALLOCATED);
+    instructionindx add=compiler_addinstruction(c, ENCODE(OP_ADD, rcount, rcount, oneinfo.dest), node);
     ninstructions++;
     
     /* Compile the unconditional branch back to the test instruction */
@@ -2003,7 +2010,7 @@ static codeinfo compiler_do(compiler *c, syntaxtreenode *node, registerindx reqo
         }
     
         /* Generate empty instruction to contain the conditional branch */
-        condindx=compiler_addinstruction(c, ENCODE_LONGFLAGS(OP_BIF, cond.dest, true, false, -ninstructions-1), node);
+        condindx=compiler_addinstruction(c, ENCODE_LONG(OP_BIF, cond.dest, -ninstructions-1), node);
         ninstructions++;
         
         compiler_releaseoperand(c, cond);
@@ -2150,8 +2157,12 @@ static codeinfo compiler_logical(compiler *c, syntaxtreenode *node, registerindx
         rinstructions+=right.ninstructions;
     }
     
+    if (bifflag) {
+        UNREACHABLE("BIFF NOT IMPLEMENTED");
+    }
+    
     /* Generate the branch instruction */
-    compiler_setinstruction(c, condindx, ENCODE_LONGFLAGS(OP_BIF, out, bifflag, false, rinstructions));
+    compiler_setinstruction(c, condindx, ENCODE_LONG(OP_BIF, out, rinstructions));
     
     return CODEINFO(REGISTER, out, linstructions+rinstructions);
 }
@@ -2216,7 +2227,7 @@ static codeinfo compiler_declaration(compiler *c, syntaxtreenode *node, register
             }
             
             // Call Array()
-            compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, array.dest, false, iend-istart+1), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, array.dest, iend-istart+1), node);
             ninstructions++;
             
             compiler_regfreetoend(c, istart);
@@ -2359,14 +2370,14 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
         if (ismethod && isinitializer)
 #endif
         {
-            compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, false, 0, false, REGISTER_UNALLOCATED), node); /* Add a return */
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1, 0), node); /* Add a return */
         } else if (isanonymous) {
-            if (!CODEINFO_ISREGISTER(bodyinfo) && !CODEINFO_ISCONSTANT(bodyinfo)) {
+            if (!CODEINFO_ISREGISTER(bodyinfo)) {
                 bodyinfo=compiler_movetoregister(c, node, bodyinfo, REGISTER_UNALLOCATED);
                 ninstructions+=bodyinfo.ninstructions;
             }
             
-            compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, CODEINFO_ISCONSTANT(bodyinfo), bodyinfo.dest, false, REGISTER_UNALLOCATED), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1, bodyinfo.dest), node);
         } else {
             compiler_addinstruction(c, ENCODE_BYTE(OP_RETURN), node); /* Add a return */
         }
@@ -2410,7 +2421,7 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
         
         /* Wrap in a closure if necessary */
         if (closure!=REGISTER_UNALLOCATED) {
-            compiler_addinstruction(c, ENCODE_DOUBLE(OP_CLOSURE, reg, false, (registerindx) closure), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_CLOSURE, reg, (registerindx) closure), node);
             ninstructions++;
         }
         
@@ -2560,7 +2571,7 @@ static codeinfo compiler_call(compiler *c, syntaxtreenode *node, registerindx re
     compiler_endargs(c);
     
     /* Generate the call instruction */
-    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, func.dest, false, lastarg-func.dest), node);
+    compiler_addinstruction(c, ENCODE_DOUBLE(OP_CALL, func.dest, lastarg-func.dest), node);
     ninstructions++;
     
     /* Free all the registers used for the call */
@@ -2568,7 +2579,7 @@ static codeinfo compiler_call(compiler *c, syntaxtreenode *node, registerindx re
     
     /* Move the result to the requested register */
     if (reqout!=REGISTER_UNALLOCATED && func.dest!=reqout) {
-        compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, reqout, false, func.dest), node);
+        compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, reqout, func.dest), node);
         ninstructions++;
         compiler_regfreetemp(c, func.dest);
         func.dest=reqout;
@@ -2621,7 +2632,7 @@ static codeinfo compiler_invoke(compiler *c, syntaxtreenode *node, registerindx 
     compiler_endargs(c);
     
     /* Generate the call instruction */
-    compiler_addinstruction(c, ENCODEC(OP_INVOKE, object.dest, CODEINFO_ISCONSTANT(method), method.dest, false, lastarg-object.dest), node);
+    compiler_addinstruction(c, ENCODE(OP_INVOKE, object.dest, method.dest, lastarg-object.dest), node);
     ninstructions++;
     
     /* Free all the registers used for the call */
@@ -2629,7 +2640,7 @@ static codeinfo compiler_invoke(compiler *c, syntaxtreenode *node, registerindx 
     
     /* Move the result to the requested register */
     if (reqout!=REGISTER_UNALLOCATED && object.dest!=reqout) {
-        compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, reqout, false, object.dest), node);
+        compiler_addinstruction(c, ENCODE_DOUBLE(OP_MOV, reqout, object.dest), node);
         ninstructions++;
         compiler_regfreetemp(c, object.dest);
         object.dest=reqout;
@@ -2659,16 +2670,16 @@ static codeinfo compiler_return(compiler *c, syntaxtreenode *node, registerindx 
                 ninstructions+=left.ninstructions;
             }
             
-            compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, CODEINFO_ISCONSTANT(left), left.dest, false, REGISTER_UNALLOCATED), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1,  left.dest), node);
             ninstructions++;
         }
         compiler_releaseoperand(c, left);
     } else {
         /* Methods return self unless a return value is specified */
         if (compiler_getcurrentclass(c)) {
-            compiler_addinstruction(c, ENCODEC(OP_RETURN, 1, false, 0, false, REGISTER_UNALLOCATED), node); /* Add a return */
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1, 0), node); /* Add a return */
         } else {
-            compiler_addinstruction(c, ENCODEC(OP_RETURN, 0, REGISTER_UNALLOCATED, REGISTER_UNALLOCATED, false, REGISTER_UNALLOCATED), node);
+            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 0, 0), node);
         }
         ninstructions++;
     }
@@ -3009,7 +3020,7 @@ static codeinfo compiler_assign(compiler *c, syntaxtreenode *node, registerindx 
                 if (right.dest!=iend+1) {
                     UNREACHABLE("Failed register allocation in compiling SIX instruction.");
                 }
-                compiler_addinstruction(c, ENCODEC(OP_SIX, reg, false, istart, false, right.dest), node);
+                compiler_addinstruction(c, ENCODE(OP_SIX, reg, istart, right.dest), node);
                 ninstructions++;
             }
                 break;
@@ -3040,8 +3051,8 @@ static codeinfo compiler_property(compiler *c, syntaxtreenode *node, registerind
     left = compiler_nodetobytecode(c, node->left, REGISTER_UNALLOCATED);
     unsigned int ninstructions=left.ninstructions;
     
-    if (!(CODEINFO_ISREGISTER(left) || CODEINFO_ISSHORTCONSTANT(left))) {
-        /* Ensure we're working with a register or a constant */
+    if (!(CODEINFO_ISREGISTER(left))) {
+        /* Ensure we're working with a register */
         left=compiler_movetoregister(c, node, left, REGISTER_UNALLOCATED);
         ninstructions+=left.ninstructions;
     }
@@ -3053,11 +3064,10 @@ static codeinfo compiler_property(compiler *c, syntaxtreenode *node, registerind
         ninstructions+=prop.ninstructions;
     } else {
         compiler_error(c, selector, COMPILE_PROPERTYNAMERQD);
-        //return CODEINFO_EMPTY;
     }
     
     if (out !=REGISTER_UNALLOCATED) {
-        compiler_addinstruction(c, ENCODEC(OP_LPR, out, CODEINFO_ISCONSTANT(left), left.dest, CODEINFO_ISCONSTANT(prop), prop.dest), node);
+        compiler_addinstruction(c, ENCODE(OP_LPR, out, left.dest, prop.dest), node);
         ninstructions++;
         compiler_releaseoperand(c, left);
         if (CODEINFO_ISREGISTER(prop)) compiler_releaseoperand(c, prop);
@@ -3091,14 +3101,14 @@ static codeinfo compiler_movetoproperty(compiler *c, syntaxtreenode *node, codei
     }
     
     codeinfo store = in;
-    if (!(CODEINFO_ISREGISTER(in) || CODEINFO_ISSHORTCONSTANT(in))) {
-        /* Ensure we're working with a register or a constant */
+    if (!CODEINFO_ISREGISTER(in)) {
+        /* Ensure we're working with a register */
         store=compiler_movetoregister(c, node, store, REGISTER_UNALLOCATED);
         ninstructions+=store.ninstructions;
         compiler_releaseoperand(c, store);
     }
     
-    compiler_addinstruction(c, ENCODEC(OP_SPR, left.dest, CODEINFO_ISCONSTANT(prop), prop.dest, CODEINFO_ISCONSTANT(store), store.dest), node);
+    compiler_addinstruction(c, ENCODE(OP_SPR, left.dest, prop.dest, store.dest), node);
     ninstructions++;
     
     if (CODEINFO_ISREGISTER(prop)) compiler_releaseoperand(c, prop);

--- a/morpho5/vm/opcodes.h
+++ b/morpho5/vm/opcodes.h
@@ -48,8 +48,11 @@ OPCODE(LE)
 /** Branching */
 OPCODE(B)
 
-/** Conditional branch */
+/** Branch if true */
 OPCODE(BIF)
+
+/** Branch if false */
+OPCODE(BIFF)
 
 /** Call */
 OPCODE(CALL)

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -833,8 +833,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(ADD):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if (MORPHO_ISFLOAT(left)) {
                 if (MORPHO_ISFLOAT(right)) {
@@ -880,8 +880,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(SUB):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if (MORPHO_ISFLOAT(left)) {
                 if (MORPHO_ISFLOAT(right)) {
@@ -920,8 +920,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(MUL):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if (MORPHO_ISFLOAT(left)) {
                 if (MORPHO_ISFLOAT(right)) {
@@ -960,8 +960,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(DIV):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if (MORPHO_ISFLOAT(left)) {
                 if (MORPHO_ISFLOAT(right)) {
@@ -1000,8 +1000,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(POW):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if (MORPHO_ISFLOAT(left)) {
                 if (MORPHO_ISFLOAT(right)) {
@@ -1042,7 +1042,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(NOT):
             a=DECODE_A(bc); b=DECODE_B(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+            left = reg[b];
+
             if (MORPHO_ISBOOL(left)) {
                 reg[a] = MORPHO_BOOL(!MORPHO_GETBOOLVALUE(left));
             } else {
@@ -1052,8 +1053,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(EQ):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)==0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
@@ -1061,8 +1062,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(NEQ):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             MORPHO_CMPPROMOTETYPE(left,right);
             reg[a] = (morpho_comparevalue(left, right)!=0 ? MORPHO_BOOL(true) : MORPHO_BOOL(false));
@@ -1070,8 +1071,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(LT):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if ( !( (MORPHO_ISFLOAT(left) || MORPHO_ISINTEGER(left)) &&
                    (MORPHO_ISFLOAT(right) || MORPHO_ISINTEGER(right)) ) ) {
@@ -1084,8 +1085,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(LE):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = reg[c];
 
             if ( !( (MORPHO_ISFLOAT(left) || MORPHO_ISINTEGER(left)) &&
                    (MORPHO_ISFLOAT(right) || MORPHO_ISINTEGER(right)) ) ) {
@@ -1103,10 +1104,9 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
 
         CASE_CODE(BIF):
             a=DECODE_A(bc);
-            b=DECODE_sBx(bc);
             left=reg[a];
 
-            if ((MORPHO_ISTRUE(left) ? true : false) == (DECODE_F(bc) ? true : false)) pc+=b;
+            if (MORPHO_ISTRUE(left)) pc+=DECODE_sBx(bc);
 
             DISPATCH();
 
@@ -1173,7 +1173,7 @@ callfunction: // Jump here if an instruction becomes a call
             b=DECODE_B(bc);
             c=DECODE_C(bc);
             left=reg[a];
-            right=(DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+            right=v->konst[b];
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
@@ -1252,7 +1252,7 @@ callfunction: // Jump here if an instruction becomes a call
 
             if (a>0) {
                 b=DECODE_B(bc);
-                reg[0] = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+                reg[0] = reg[b];
             } else {
                 reg[0] = MORPHO_NIL; /* No return value; returns nil */
             }
@@ -1309,7 +1309,7 @@ callfunction: // Jump here if an instruction becomes a call
         CASE_CODE(SUP):
             a=DECODE_A(bc);
             b=DECODE_B(bc);
-            right = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+            right = reg[b];
             if (v->fp->closure && v->fp->closure->upvalues[a]) {
                 *v->fp->closure->upvalues[a]->location=right;
             } else {
@@ -1337,8 +1337,8 @@ callfunction: // Jump here if an instruction becomes a call
 
         CASE_CODE(LPR): /* Load property */
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            left = reg[b];
+            right = v->konst[c];
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
@@ -1400,11 +1400,11 @@ callfunction: // Jump here if an instruction becomes a call
         CASE_CODE(SPR):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
             left = reg[a];
-            right = (DECODE_ISCCONSTANT(bc) ? v->konst[c] : reg[c]);
+            right = reg[c];
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
-                left = (DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+                left = v->konst[b]; // B is always a constant
                 dictionary_insertintern(&instance->fields, left, right);
             } else {
                 ERROR(VM_NOTANOBJECT);
@@ -1474,22 +1474,6 @@ callfunction: // Jump here if an instruction becomes a call
             v->ehp--;         // Pull error handler off error stack
             if (v->ehp<v->errorhandlers) v->ehp=NULL; // If the stack is empty rest to NULL
             DISPATCH();
-        
-        /*CASE_CODE(ARRAY):
-            a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
-            if (DECODE_ISBCONSTANT(bc)) {
-
-            } else {
-                objectarray *new = object_arrayfromvalueindices((unsigned int) c-b+1, &reg[b]);
-                if (new) {
-                    reg[a]=MORPHO_OBJECT(new);
-                    vm_bindobject(v, reg[a]);
-                } else {
-                    ERROR(ERROR_ALLOCATIONFAILED);
-                }
-            }
-
-            DISPATCH();*/
 
         CASE_CODE(CAT):
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
@@ -1498,8 +1482,8 @@ callfunction: // Jump here if an instruction becomes a call
             DISPATCH();
 
         CASE_CODE(PRINT):
-            b=DECODE_B(bc);
-            left=(DECODE_ISBCONSTANT(bc) ? v->konst[b] : reg[b]);
+            a=DECODE_A(bc);
+            left=reg[a];
 #ifdef MORPHO_COLORTERMINAL
             printf("\033[1m");
 #endif
@@ -1511,13 +1495,6 @@ callfunction: // Jump here if an instruction becomes a call
 #endif
             printf("\n");
             DISPATCH();
-
-/*        CASE_CODE(RAISE):
-            a=DECODE_A(bc);
-            if (MORPHO_ISSTRING(reg[a])) {
-                ERROR(MORPHO_GETCSTRING(reg[a]));
-            }
-            DISPATCH();*/
 
         CASE_CODE(BREAK):
             if (v->debug) {

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1107,7 +1107,13 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
             left=reg[a];
 
             if (MORPHO_ISTRUE(left)) pc+=DECODE_sBx(bc);
+            DISPATCH();
+        
+        CASE_CODE(BIFF):
+            a=DECODE_A(bc);
+            left=reg[a];
 
+            if (MORPHO_ISFALSE(left)) pc+=DECODE_sBx(bc);
             DISPATCH();
 
         CASE_CODE(CALL):

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1179,7 +1179,7 @@ callfunction: // Jump here if an instruction becomes a call
             b=DECODE_B(bc);
             c=DECODE_C(bc);
             left=reg[a];
-            right=v->konst[b];
+            right=reg[b];
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
@@ -1344,7 +1344,7 @@ callfunction: // Jump here if an instruction becomes a call
         CASE_CODE(LPR): /* Load property */
             a=DECODE_A(bc); b=DECODE_B(bc); c=DECODE_C(bc);
             left = reg[b];
-            right = v->konst[c];
+            right = reg[c];
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
@@ -1410,7 +1410,7 @@ callfunction: // Jump here if an instruction becomes a call
 
             if (MORPHO_ISINSTANCE(left)) {
                 objectinstance *instance = MORPHO_GETINSTANCE(left);
-                left = v->konst[b]; // B is always a constant
+                left = reg[b];
                 dictionary_insertintern(&instance->fields, left, right);
             } else {
                 ERROR(VM_NOTANOBJECT);


### PR DESCRIPTION
Retooling of the virtual machine with a modified instruction set. All operands are now registers except load instructions, reducing the number of branches within opcodes and permitting up to 256 opcodes (vs 64). 