### PR TITLE
Fixed export of 2D fields

### DIFF
--- a/morpho5/modules/vtk.morpho
+++ b/morpho5/modules/vtk.morpho
@@ -111,8 +111,12 @@ class VTKExporter is VTK {
     
     // Writes a vector to the file 
     _writevector(file, v) {
-        
-        file.write("${v[0]} ${v[1]} ${v[2]} ")
+        if (v.count()==2) {
+            file.write("${v[0]} ${v[1]} 0 ")
+        }
+        else {
+            file.write("${v[0]} ${v[1]} ${v[2]} ")
+        }
     }
 
     // Writes all the vertices to the file

--- a/test/vtk/export_and_import_vector_2d.morpho
+++ b/test/vtk/export_and_import_vector_2d.morpho
@@ -1,0 +1,30 @@
+// Testing whether exporting and importing a vector field works 
+
+import vtk
+import meshtools
+
+var m1 = LineMesh(fn (t) [t,0,0], -1..1:2)
+
+var g1 = Field(m1, fn(x,y,z) Matrix([x,2*x]))
+
+var vtkE = VTKExporter(g1, fieldname="g")
+
+var filename = "data.vtk"
+
+vtkE.export(filename)
+
+var vtkI = VTKImporter(filename)
+
+var m2 = vtkI.mesh()
+
+var g2 = vtkI.field("g")
+
+print m2 // expect: <Mesh: 2 vertices>
+
+print g2 // expect: <Field>
+// expect: [ -1 ]
+// expect: [ -2 ]
+// expect: [ 0 ]
+// expect: [ 1 ]
+// expect: [ 2 ]
+// expect: [ 0 ]

--- a/test/vtk/export_and_import_vector_2d.morpho
+++ b/test/vtk/export_and_import_vector_2d.morpho
@@ -1,4 +1,5 @@
-// Testing whether exporting and importing a vector field works 
+// Testing whether exporting and importing a 2D vector field works. This
+// should add a 0 in the z component of the vector in the saved file. 
 
 import vtk
 import meshtools


### PR DESCRIPTION
This PR fixes a small bug in the VTK module. VTK Vectors are always 3D, so we need to append a 0 for the z component when the field is 2D.
 
Added a test to lock down the behavior.