### PR TITLE
Unit test

### DIFF
--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -65,7 +65,7 @@ value Object_respondsto(vm *v, int nargs, value *args) {
     if (nargs == 0) {
         value out = MORPHO_NIL;
         objectlist *new = object_newlist(0, NULL);
-        if (new && klass) {
+        if (new) {
             list_resize(new, klass->methods.count);
             for (unsigned int i=0; i<klass->methods.capacity; i++) {
                 if (MORPHO_ISSTRING(klass->methods.contents[i].key)) {

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -109,7 +109,7 @@ value Object_has(vm *v, int nargs, value *args) {
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         return MORPHO_BOOL(dictionary_get(&MORPHO_GETINSTANCE(self)->fields, MORPHO_GETARG(args, 0), NULL));
         
-    } else MORPHO_RAISE(v, RESPONDSTO_ARG);
+    } else MORPHO_RAISE(v, HAS_ARG);
     
     return MORPHO_FALSE;
 }
@@ -1862,6 +1862,7 @@ void veneer_initialize(void) {
     morpho_defineerror(DICT_DCTSTARG, ERROR_HALT, DICT_DCTSTARG_MSG);
     morpho_defineerror(SETINDEX_ARGS, ERROR_HALT, SETINDEX_ARGS_MSG);
     morpho_defineerror(RESPONDSTO_ARG, ERROR_HALT, RESPONDSTO_ARG_MSG);
+    morpho_defineerror(HAS_ARG, ERROR_HALT, HAS_ARG_MSG);
     morpho_defineerror(ISMEMBER_ARG, ERROR_HALT, ISMEMBER_ARG_MSG);
     morpho_defineerror(CLASS_INVK, ERROR_HALT, CLASS_INVK_MSG);
     morpho_defineerror(LIST_ENTRYNTFND, ERROR_HALT, LIST_ENTRYNTFND_MSG);

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -95,7 +95,7 @@ value Object_has(vm *v, int nargs, value *args) {
         if (new) {
             objectinstance *slf = MORPHO_GETINSTANCE(self);
             list_resize(new, MORPHO_GETINSTANCE(self)->fields.count);
-            for (unsigned int i=0; i<slf->fields.count; i++) {
+            for (unsigned int i=0; i<slf->fields.capacity; i++) {
                 if (MORPHO_ISSTRING(slf->fields.contents[i].key)) {
                     list_append(new, slf->fields.contents[i].key);
                 }

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -62,8 +62,22 @@ value Object_super(vm *v, int nargs, value *args) {
 value Object_respondsto(vm *v, int nargs, value *args) {
     value self = MORPHO_SELF(args);
     objectclass *klass=MORPHO_GETINSTANCE(self)->klass;
+    if (nargs == 0) {
+        value out = MORPHO_NIL;
+        objectlist *new = object_newlist(0, NULL);
+        if (new) {
+            list_resize(new, klass->methods.count);
+            for (unsigned int i=0; i<klass->methods.capacity; i++) {
+                if (MORPHO_ISSTRING(klass->methods.contents[i].key)) {
+                    list_append(new, klass->methods.contents[i].key);
+                }
+            }
+            out = MORPHO_OBJECT(new);
+            morpho_bindobjects(v, 1, &out);
+        } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
+        return out;
 
-    if (nargs==1 &&
+    } else if (nargs==1 &&
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         return MORPHO_BOOL(dictionary_get(&klass->methods, MORPHO_GETARG(args, 0), NULL));
     } else MORPHO_RAISE(v, RESPONDSTO_ARG);
@@ -75,7 +89,23 @@ value Object_respondsto(vm *v, int nargs, value *args) {
 value Object_has(vm *v, int nargs, value *args) {
     value self = MORPHO_SELF(args);
 
-    if (nargs==1 &&
+    if (nargs == 0) {
+        value out = MORPHO_NIL;
+        objectlist *new = object_newlist(0, NULL);
+        if (new) {
+            objectinstance *slf = MORPHO_GETINSTANCE(self);
+            list_resize(new, MORPHO_GETINSTANCE(self)->fields.count);
+            for (unsigned int i=0; i<slf->fields.count; i++) {
+                if (MORPHO_ISSTRING(slf->fields.contents[i].key)) {
+                    list_append(new, slf->fields.contents[i].key);
+                }
+            }
+            out = MORPHO_OBJECT(new);
+            morpho_bindobjects(v, 1, &out);
+        } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
+        return out;
+
+    } else if (nargs==1 &&
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         return MORPHO_BOOL(dictionary_get(&MORPHO_GETINSTANCE(self)->fields, MORPHO_GETARG(args, 0), NULL));
         

--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -65,7 +65,7 @@ value Object_respondsto(vm *v, int nargs, value *args) {
     if (nargs == 0) {
         value out = MORPHO_NIL;
         objectlist *new = object_newlist(0, NULL);
-        if (new) {
+        if (new && klass) {
             list_resize(new, klass->methods.count);
             for (unsigned int i=0; i<klass->methods.capacity; i++) {
                 if (MORPHO_ISSTRING(klass->methods.contents[i].key)) {

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -54,7 +54,10 @@
 #define DICT_DCTKYNTFND_MSG               "Key not found in dictionary."
 
 #define RESPONDSTO_ARG                    "RspndsToArg"
-#define RESPONDSTO_ARG_MSG                "Method respondsto expects a single string argument."
+#define RESPONDSTO_ARG_MSG                "Method respondsto expects a single string argument or no argrument."
+
+#define HAS_ARG                    		  "HasArg"
+#define HAS_ARG_MSG                		  "Method has expects a single string argument or no argument."
 
 #define ISMEMBER_ARG                      "IsMmbrArg"
 #define ISMEMBER_ARG_MSG                  "Method ismember expects a single argument."

--- a/morpho5/docs/index.rst
+++ b/morpho5/docs/index.rst
@@ -60,6 +60,7 @@ Morpho
    optimize
    plot
    povray
+   unittest
    vtk
 
 .. toctree::

--- a/morpho5/docs/unittest.md
+++ b/morpho5/docs/unittest.md
@@ -1,0 +1,113 @@
+[comment]: # (Unittest module help)
+[version]: # (0.5)
+
+# Unit Test
+
+[tagunittest]: # (unittest)
+
+The `unittest` module is used to facilitate creating unit test to lock down behavior in code. Once you have unit tests written for your code they can be run anytime the code is changed to verify the expected behavior.
+
+To create a unit test you first import the module
+
+    import unittest
+
+Then create a new test class that inherits from the base class `unittest` and end the definition by creating an instance of the test class
+
+    exampleTest is unittest { 
+        ...
+    } exampleTest()
+
+Methods of this class are then test methods that run when an instance of this class is created. It is recommended that these methods be named so that they let the reader know exactly what is being tested. These methods are not part of the source code and never called by name so brevity is not a consideration.
+
+## Assert
+
+In a test method `self.assert(value)` will test if the value is true and `self.assertEqual(value1, value2)` will test if the contents of the values are equal. If an assert fails then the test that calls it will fail with an appropriate message.
+
+## Test Fixtures
+
+The special method `fixture()` will run before each of the test methods are executed. This can be used to set up common data for tests.
+
+## Floating point tolerance
+
+Equality for floating point numbers defaults to a tolerance of 1e-10 but can be changed by setting the `self.tol` property in a test or fixture.
+
+## Assume Fail
+
+Sometimes it is beneficial to write a test when you have identified a bug but have yet to fix it. In these cases setting
+
+    self.assumeFail = "Reason"
+
+will force a test to pass regardless of asserts or errors and display a message that the test was assumed to fail because of the `"Reason"`.
+
+## Example
+
+The following is an example test for the exponential operator with a fixture and an test that assumes failure
+
+    import unittest
+    class power_spec is unit_test {
+        fixture(){
+            self.myNumber = 3
+        }
+        integer_raised_to_an_integer(){
+            self.assertEqual(2^2,4)
+        }
+        float_raised_to_an_integer(){
+            self.assertEqual(2.0^3,8)
+        }
+        integer_raised_to_a_float(){
+            self.assertEqual(2^3.0, 8)
+        }
+        float_raised_to_a_float(){
+            self.assertEqual(2.0^3.0, 8 )
+        }
+        exponent_binds_before_uminus(){
+            self.assertEqual(-1^2, -1)
+            var x = -1
+            self.assertEqual(x^2, 1)
+            self.assertEqual((-1)^2, 1)
+        }
+        higher_exponents_happen_first(){
+            self.assertEqual(2^3^2, 512)
+        }
+        variable_to_exponent(){
+            self.assertEqual(self.myNumber^self.myNumber,27)
+        }
+        assume_failure(){
+            self.assumeFail = "Example Reason"
+            self.assertEqual(2^3,7)
+        }
+    } power_spec()
+
+This produces the following report:
+
+    ===================================
+    Running test suite: @power_spec
+    ===================================
+    Running test higher_exponents_happen_first:
+    Passed
+    Running test variable_to_exponent:
+    Passed
+    Running test exponent_binds_before_uminus:
+    Passed
+    Running test integer_raised_to_a_float:
+    Passed
+    Running test float_raised_to_a_float:
+    Passed
+    Running test assume_failure:
+    Assumed Fail: Example Reason
+    Running test integer_raised_to_an_integer:
+    Passed
+    Running test float_raised_to_an_integer:
+    Passed
+    ===================================
+        Ran 8 tests  
+        No Failures Detected        
+    ===================================
+
+A failure would look like
+
+    Running test assume_failure:
+    Assertion Failed 8 != 7, difference is 1 which is above the tolerance of 1e-10
+    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+     assume_failure: FAILED
+    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/morpho5/docs/unittest.md
+++ b/morpho5/docs/unittest.md
@@ -21,7 +21,7 @@ Methods of this class are then test methods that run when an instance of this cl
 
 ## Assert
 
-In a test method `self.assert(value)` will test if the value is true and `self.assertEqual(value1, value2)` will test if the contents of the values are equal. If an assert fails then the test that calls it will fail with an appropriate message.
+In a test method `self.assert(value)` will test if the value is true and `self.assertEqual(value1, value2)` will test if the contents of the values are equal. If an assert fails then the test that calls it will fail with an appropriate message. If you want to check set equality of a list you can use `self.assertSetEqualityOfList(list1,list2)`.
 
 ## Test Fixtures
 

--- a/morpho5/docs/unittest.md
+++ b/morpho5/docs/unittest.md
@@ -13,7 +13,7 @@ To create a unit test you first import the module
 
 Then create a new test class that inherits from the base class `unittest` and end the definition by creating an instance of the test class
 
-    exampleTest is unittest { 
+    exampleTest is UnitTest { 
         ...
     } exampleTest()
 
@@ -44,7 +44,7 @@ will force a test to pass regardless of asserts or errors and display a message 
 The following is an example test for the exponential operator with a fixture and an test that assumes failure
 
     import unittest
-    class power_spec is unit_test {
+    class power_spec is UnitTest {
         fixture(){
             self.myNumber = 3
         }

--- a/morpho5/geometry/selection.c
+++ b/morpho5/geometry/selection.c
@@ -421,6 +421,17 @@ value Selection_setindex(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
+/** Returns the max grade of the selection */
+value Selection_maxgrade(vm *v, int nargs,value *args){
+    objectselection *sel = MORPHO_GETSELECTION(MORPHO_SELF(args));
+    value out = MORPHO_NIL;
+
+    if (nargs == 0){
+        out = MORPHO_INTEGER(selection_maxgrade(sel));
+    } else morpho_runtimeerror(v, SELECTION_ISSLCTDARG);
+    return out;
+}
+
 /** Tests if something is selected */
 value Selection_isselected(vm *v, int nargs, value *args) {
     objectselection *sel = MORPHO_GETSELECTION(MORPHO_SELF(args));
@@ -549,6 +560,7 @@ MORPHO_METHOD(MORPHO_DIFFERENCE_METHOD, Selection_difference, BUILTIN_FLAGSEMPTY
 MORPHO_METHOD(MORPHO_ADD_METHOD, Selection_union, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_SUB_METHOD, Selection_difference, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SELECTION_ADDGRADEMETHOD, Selection_addgrade, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(SELECTION_MAXGRADEMETHOD, Selection_maxgrade, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SELECTION_REMOVEGRADEMETHOD, Selection_removegrade, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_CLONE_METHOD, Selection_clone, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS
@@ -571,6 +583,7 @@ void selection_initialize(void) {
     morpho_defineerror(SELECTION_NOMESH, ERROR_HALT, SELECTION_NOMESH_MSG);
     morpho_defineerror(SELECTION_ISSLCTDARG, ERROR_HALT, SELECTION_ISSLCTDARG_MSG);
     morpho_defineerror(SELECTION_GRADEARG, ERROR_HALT, SELECTION_GRADEARG_MSG);
+    morpho_defineerror(SELECTION_MAXGRADEARG, ERROR_HALT, SELECTION_MAXGRADEARG_MSG);
     morpho_defineerror(SELECTION_STARG, ERROR_HALT, SELECTION_STARG_MSG);
     morpho_defineerror(SELECTION_BND, ERROR_HALT, SELECTION_BND_MSG);
 }

--- a/morpho5/geometry/selection.h
+++ b/morpho5/geometry/selection.h
@@ -46,6 +46,7 @@ objectselection *object_newselection(objectmesh *mesh);
 #define SELECTION_IDLISTFORGRADEMETHOD "idlistforgrade"
 #define SELECTION_ADDGRADEMETHOD "addgrade"
 #define SELECTION_REMOVEGRADEMETHOD "removegrade"
+#define SELECTION_MAXGRADEMETHOD "maxgrade"
 
 #define SELECTION_COMPLEMENTMETHOD "complement"
 
@@ -60,6 +61,9 @@ objectselection *object_newselection(objectmesh *mesh);
 
 #define SELECTION_GRADEARG                   "SlGrdArg"
 #define SELECTION_GRADEARG_MSG               "Method requires a grade as the argument."
+
+#define SELECTION_MAXGRADEARG                   "SlMxGrdArg"
+#define SELECTION_MAXGRADEARG_MSG               "Method expects no arguments."
 
 #define SELECTION_STARG                      "SlStArg"
 #define SELECTION_STARG_MSG                  "Selection set methods require a selection as the argument."

--- a/morpho5/modules/unittest.morpho
+++ b/morpho5/modules/unittest.morpho
@@ -14,7 +14,7 @@
 
 class unit_test {
     init(){
-        self.tol = 1e-10 // tolerance for float comparison
+        self.tolDefault = 1e-10 // tolerance for float comparison
         self.run()
     }
     run(){
@@ -25,7 +25,7 @@ class unit_test {
         var listOfMethods = self.respondsto()
         // remove common methods
         var commonMethods = [ "init","runTest","assert","run","setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
-        var assertMethods = ["assertListEqual", "assertArrayEqual", "assertMatrixEqual", "assertSparseEqual", "assertIntEqual", "assertFloatEqual", "assertMeshEqual", "assertSelectionEqual", "assertFieldEqual", "assertDictionayEqual", "assertRangeEqual", "assertStringEqual", "assertBoolEqual", "assertObjectEqual", "failAssertion","assertProperites","assertDimensions","assertSetEqualityOfList","assertDeepEqual","assertEquals"]
+        var assertMethods = ["assertListEqual", "assertArrayEqual", "assertMatrixEqual", "assertSparseEqual", "assertIntEqual", "assertFloatEqual", "assertMeshEqual", "assertSelectionEqual", "assertFieldEqual", "assertDictionayEqual", "assertRangeEqual", "assertStringEqual", "assertBoolEqual", "assertObjectEqual", "failAssertion","assertProperites","assertDimensions","assertSetEqualityOfList","assertDeepEqual","assertEqual"]
         var fixtureName = "fixture"
         var hasfixture = false
         if (self.respondsto(fixtureName)) {
@@ -41,6 +41,7 @@ class unit_test {
         self.failures = 0
         self.failedTests = []
         for (method in listOfMethods) {
+            self.tol = self.tolDefault
             if (hasfixture) self.invoke(fixtureName)
             self.runTest(method) 
         }
@@ -53,7 +54,7 @@ class unit_test {
         } else {
             print "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
             for (test in self.failedTests){
-                print " ${self.clss()}:test FAILED"
+                print " ${test}: FAILED"
             }
             print "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
         }
@@ -65,7 +66,7 @@ class unit_test {
         try {
             print "Running test ${method}:"
             self.invoke(method) // try running the method
-            if (self.passing) print "Passed"
+            if (self.passing && !self.assumeFail) print "Passed"
             if (self.assumeFail) print "Assumed Fail: ${self.assumeFail}"
             self.passed = true
         }
@@ -84,15 +85,13 @@ class unit_test {
     }
     assert(value){
         if (!value){
-            print "Assertion Failed"
-            self.passing = false
+            self.failAssertion("Assertion Failed")
+            return false
         }
+        return true
     }
-    assertEquals(v1,v2) {
-        if(v1!=v2 && !self.assertDeepEqual(v1,v2)) {
-            print "Assert Equal failed ${v1} != ${v2}"
-            self.passing = false
-        }
+    assertEqual(v1,v2) {
+        if(v1!=v2) self.assertDeepEqual(v1,v2)
     }
 
     assertDeepEqual(v1,v2) {
@@ -134,14 +133,16 @@ class unit_test {
         }
     }
     failAssertion(message) {
-        print message
-        self.passing = false
+        if (!self.assumeFail) {
+            print message
+            self.passing = false
+        }
     }
     assertListEqual(v1,v2,quiet = false) {
         var reason
         if (v1.count()!=v2.count()) {
             if (!quiet) {
-                self.failAssertion("Assertion Failed: Lists have differnt number of elements")
+                self.failAssertion("Assertion Failed: Lists have different number of elements")
             }
             return false
         }
@@ -152,8 +153,7 @@ class unit_test {
     }
     assertDimensions(v1,v2) {
         if (!self.assertListEqual(v1.dimensions(), v2.dimensions(),quiet = true)) {
-            print "Assertion Failed: Objects have differnt dimensions"
-            self.passing = false
+            self.failAssertion("Assertion Failed: Objects have different dimensions")
             return false
         }
         return true
@@ -179,7 +179,7 @@ class unit_test {
         if (!self.assertSetEqualityOfList(v1.indices(),v2.indices())) return false
         for (ind in v1.indices()) {
             if(!self.assertDeepEqual(v1[ind[0],ind[1]],v2[ind[0],ind[1]])) {
-                self.failAssertion("Spares Matrix elementes at ${ind} have differnt values")
+                self.failAssertion("Spares Matrix elementes at ${ind} have different values")
                 return false
             }
         }
@@ -188,14 +188,13 @@ class unit_test {
     }
     assertIntEqual(v1,v2) {
         if (v1!=v2) {
-            self.passing = false
-            print "Assertion Failed ${v1} != ${v2}"
+            self.failAssertion("Assertion Failed ${v1} != ${v2}")
             return false
         }
     }
     assertFloatEqual(v1,v2) {
         if (abs(v1-v2)>self.tol) {
-            self.failAssertion("Assertion Failed ${v1} != ${v2}, differencs is ${abs(v1-v2)} which is above the tolerance of ${self.tol}")
+            self.failAssertion("Assertion Failed ${v1} != ${v2}, difference is ${abs(v1-v2)} which is above the tolerance of ${self.tol}")
             return false
         }
         return true
@@ -206,19 +205,19 @@ class unit_test {
             return false
         }
         // check connectivity equality
-        if (!self.assertEquals(v1.maxgrade(),v2.maxgrade())) return false
+        if (!self.assertEqual(v1.maxgrade(),v2.maxgrade())) return false
         for (i in 1...v1.maxgrade()) {
             // only need to check vertex-higher grade because this contains all the information
-            if (!self.assertEquals(v1.connectivitymatrix(0,i),v2.connectivitymatrix(0,i))) return false;
+            if (!self.assertEqual(v1.connectivitymatrix(0,i),v2.connectivitymatrix(0,i))) return false;
         }
         return true
 
     }
     assertSelectionEqual(v1,v2) { 
-        if (!self.assertEquals(v1.maxgrade(),v2.maxgrade())) return false
+        if (!self.assertEqual(v1.maxgrade(),v2.maxgrade())) return false
 
         for (i in 0...v1.maxgrade()) {
-            if (!self.assertEquals(v1.idlistforgrade(i),v2.idlistforgrade(i))) return false
+            if (!self.assertEqual(v1.idlistforgrade(i),v2.idlistforgrade(i))) return false
         }
         return true
         
@@ -244,7 +243,7 @@ class unit_test {
         // will do set equality on lists of lists 
         if (v1.count()!=v2.count()) {
             if (!quiet) {
-                self.failAssertion("Assertion Failed: Lists have differnt number of elements")
+                self.failAssertion("Assertion Failed: Lists have different number of elements")
             }
             return false
         }
@@ -279,7 +278,7 @@ class unit_test {
     }
     assertDictionayEqual(v1,v2) {
         if (!self.assertSetEqualityOfList(v1.keys(),v2.keys())) {
-            self.failAssertion("Assertion Failed: Dictionaries have differnt keys")
+            self.failAssertion("Assertion Failed: Dictionaries have different keys")
         }
         for (key in v1.keys()) {
             if (!self.assertDeepEqual(v1[key],v2[key])) {
@@ -292,16 +291,16 @@ class unit_test {
     assertRangeEqual(v1,v2) {
         // if ranges have the same count, the same begining and the same incrment they are the same
         if (v1.count()!=v2.count()) {
-            self.failAssertion("Asseration Failed: Ranges have differnt number of elements")
+            self.failAssertion("Asseration Failed: Ranges have different number of elements")
             return false
         }
         if (!self.assertDeepEqual(v1.enumerate(0),v2.enumerate(0))) {
-            self.failAssertion("Assert Failed: Ranges have differnt start elements")
+            self.failAssertion("Assert Failed: Ranges have different start elements")
             return false
         }
         if (v1.count()>1) {
             if (!self.assertDeepEqual(v1.enumerate(1)-v1.enumerate(0),v2.enumerate(1)-v2.enumerate(0))) {
-                self.failAssertion("Assert Failed: Ranges have differnt increments")
+                self.failAssertion("Assert Failed: Ranges have different increments")
                 return false
             }
         }
@@ -311,14 +310,14 @@ class unit_test {
     }
     assertStringEqual(v1,v2) {
         if (v1 != v2) {
-            print "Assertion Failed: strings are ${v1} and ${v2}"
+            self.failAssertion("Assertion Failed: strings are ${v1} and ${v2}")
             return false
         }
         return true
     }
     assertBoolEqual(v1,v2) {
         if (v1 != v2) {
-            print "Assertion Failed: bools are ${v1} and ${v2}"
+            self.failAssertion("Assertion Failed: bools are ${v1} and ${v2}")
             return false
         }
         return true
@@ -326,8 +325,7 @@ class unit_test {
 
     assertProperites(v1,v2) {
         if (!self.assertListEqual(v1.has(), v2.has(),quiet = true)) {
-            print "Assertion Failed: Objects have differnt properites"
-            self.passing = false
+            self.failAssertion("Assertion Failed: Objects have different properites")
             return false
         }
         return true
@@ -339,7 +337,7 @@ class unit_test {
 
         for (prop in v1.has()) {
             if (!self.assertDeepEqual(v1[prop],v2[prop])) {
-                print "Property ${prop} not equal"
+                self.failAssertion("Property ${prop} not equal")
                 return false
             }
         }

--- a/morpho5/modules/unittest.morpho
+++ b/morpho5/modules/unittest.morpho
@@ -12,7 +12,7 @@
  * The fixture method will be run before each test.
  */
 
-class unit_test {
+class unittest {
     init(){
         self.tolDefault = 1e-10 // tolerance for float comparison
         self.run()
@@ -223,7 +223,6 @@ class unit_test {
         
     }
     assertFieldEqual(v1,v2) { 
-        // shape give the number of elements per grade
         if (!self.assertEqual(v1.shape(),v2.shape())) return false
         var shape = v1.shape()
         var mesh = v1.mesh()
@@ -231,7 +230,7 @@ class unit_test {
             var elmax = shape[grade]
             for (elid in 0...mesh.count(grade)) {
                 for (i in 0...elmax) {
-                    if (!self.assertEqual(v1[grade,elid,i])) return false
+                    if (!self.assertEqual(v1[grade,elid,i],v2[grade,elid,i])) return false
                 }
             }
         }

--- a/morpho5/modules/unittest.morpho
+++ b/morpho5/modules/unittest.morpho
@@ -12,7 +12,7 @@
  * The fixture method will be run before each test.
  */
 
-class unittest {
+class UnitTest {
     init(){
         self.tolDefault = 1e-10 // tolerance for float comparison
         self.run()

--- a/morpho5/modules/unittest.morpho
+++ b/morpho5/modules/unittest.morpho
@@ -1,0 +1,347 @@
+/** unit test framework */
+/* Usage: To make a new unit test create a class that inherites from unittest
+ * Each method of that test class will be run as a test
+ * use self.assert to test the truth of statement 
+ *
+ * use self.assertEqual to check the equality of the contence of two varibles
+ *
+ * set self.assumeFail = "reason" to automatically pass the test but leave a note as to why it didn't run
+ * 
+ * you can define a method fixture that will run before any methods do, use this to set common varibels that each test might want
+ *  for example you can read in a mesh and store it in self.mesh, then have each other test method refernce it.
+ * The fixture method will be run before each test.
+ */
+
+class unit_test {
+    init(){
+        self.tol = 1e-10 // tolerance for float comparison
+        self.run()
+    }
+    run(){
+        print "==================================="
+        print "Running test suite: ${self.clss()}"
+        print "==================================="
+        
+        var listOfMethods = self.respondsto()
+        // remove common methods
+        var commonMethods = [ "init","runTest","assert","run","setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+        var assertMethods = ["assertListEqual", "assertArrayEqual", "assertMatrixEqual", "assertSparseEqual", "assertIntEqual", "assertFloatEqual", "assertMeshEqual", "assertSelectionEqual", "assertFieldEqual", "assertDictionayEqual", "assertRangeEqual", "assertStringEqual", "assertBoolEqual", "assertObjectEqual", "failAssertion","assertProperites","assertDimensions","assertSetEqualityOfList","assertDeepEqual","assertEquals"]
+        var fixtureName = "fixture"
+        var hasfixture = false
+        if (self.respondsto(fixtureName)) {
+            listOfMethods.remove(fixtureName)
+            hasfixture = true
+        }
+
+        for (method in commonMethods+assertMethods) {
+            listOfMethods.remove(method)
+        }
+        // now we are left with just the test methods
+        self.numTests = listOfMethods.count()
+        self.failures = 0
+        self.failedTests = []
+        for (method in listOfMethods) {
+            if (hasfixture) self.invoke(fixtureName)
+            self.runTest(method) 
+        }
+
+        if (self.failures == 0) {
+            print "==================================="
+            print "       Ran ${self.numTests} tests  "
+            print "       No Failures Detected        "
+            print "==================================="
+        } else {
+            print "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+            for (test in self.failedTests){
+                print " ${self.clss()}:test FAILED"
+            }
+            print "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        }
+    }
+    runTest(method) {
+        self.passing = true
+        self.passed = false
+        self.assumeFail = false
+        try {
+            print "Running test ${method}:"
+            self.invoke(method) // try running the method
+            if (self.passing) print "Passed"
+            if (self.assumeFail) print "Assumed Fail: ${self.assumeFail}"
+            self.passed = true
+        }
+        catch {
+        }
+        if (!self.passed && !self.assumeFail) {
+            print "Error is test ${method}"
+            self.passing = false
+        }
+
+        if (!self.passing && !self.assumeFail) {
+            self.failures +=1
+            self.failedTests.append(method)
+        }
+
+    }
+    assert(value){
+        if (!value){
+            print "Assertion Failed"
+            self.passing = false
+        }
+    }
+    assertEquals(v1,v2) {
+        if(v1!=v2 && !self.assertDeepEqual(v1,v2)) {
+            print "Assert Equal failed ${v1} != ${v2}"
+            self.passing = false
+        }
+    }
+
+    assertDeepEqual(v1,v2) {
+        // try to find builtin datatypes
+        if (islist(v1) && islist(v2)) { //lists
+            return self.assertListEqual(v1,v2)
+        } else if (isarray(v1) && isarray(v2)) {// arrays
+            return self.assertArrayEqual(v1,v2)
+        } else if (ismatrix(v1) && ismatrix(v2)) { //matrix
+            return self.assertMatrixEqual(v1,v2)
+        } else if (issparse(v1) && issparse(v2)) { // sparse
+            return self.assertSparseEqual(v1,v2)
+        } else if (isint(v1) && isint(v2)) { // int
+            return self.assertIntEqual(v1,v2)
+        } else if (isnumber(v1) && isnumber(v2)) {// floats
+            return self.assertFloatEqual(v1,v2)
+        } else if (ismesh(v1) && ismesh(v2)) {
+            return self.assertMeshEqual(v1,v2)
+        } else if (isselection(v1) && isselection(v2)) {
+            return self.assertSelectionEqual(v1,v2)
+        } else if (isfield(v1) && isfield(v2)) {
+            return self.assertFieldEqual(v1,v2)
+        } else if (isdictionary(v1) && isdictionary(v2)) {
+            return self.assertDictionayEqual(v1,v2)
+        } else if (isrange(v1) && isrange(v2)) {
+            return self.assertRangeEqual(v1,v2)
+        } else if (isstring(v1) && isstring(v2)) {
+            return self.assertStringEqual(v1,v2)
+        } else if (isnil(v1) && isnil(v2)) {
+            return true
+        } else if (isbool(v1) && isbool(v2)) {
+            return self.assertBoolEqual(v1,v2)
+        } else if (isobject(v1) && isobject(v2)) {
+            return self.assertObjectEqual(v1,v2)
+        } else {
+            // couldn't determine comparible type
+            self.failAssertion("Assert Failed, ${v1} is not same type as ${v2}")
+            return false
+        }
+    }
+    failAssertion(message) {
+        print message
+        self.passing = false
+    }
+    assertListEqual(v1,v2,quiet = false) {
+        var reason
+        if (v1.count()!=v2.count()) {
+            if (!quiet) {
+                self.failAssertion("Assertion Failed: Lists have differnt number of elements")
+            }
+            return false
+        }
+        for (i in 0...v1.count()) {
+            if(!self.assertDeepEqual(v1[i],v2[i])) return false
+        }
+        return true
+    }
+    assertDimensions(v1,v2) {
+        if (!self.assertListEqual(v1.dimensions(), v2.dimensions(),quiet = true)) {
+            print "Assertion Failed: Objects have differnt dimensions"
+            self.passing = false
+            return false
+        }
+        return true
+
+    }
+    assertArrayEqual(v1,v2) {
+        if (!self.assertDimensions(v1,v2)) return false
+        for (i in 0...v1.count()){
+            if (!self.assertDeepEqual(v1.enumerate(i),v2.enumerate(i))) return false
+        }
+        return true
+    }
+    assertMatrixEqual(v1,v2) {
+        if (!self.assertDimensions(v1,v2)) return false
+        for (i in 0...v1.count()){
+            if (!self.assertDeepEqual(v1.enumerate(i),v2.enumerate(i))) return false
+        }
+        return true
+
+    }
+    assertSparseEqual(v1,v2) {
+        if (!self.assertDimensions(v1,v2)) return false
+        if (!self.assertSetEqualityOfList(v1.indices(),v2.indices())) return false
+        for (ind in v1.indices()) {
+            if(!self.assertDeepEqual(v1[ind[0],ind[1]],v2[ind[0],ind[1]])) {
+                self.failAssertion("Spares Matrix elementes at ${ind} have differnt values")
+                return false
+            }
+        }
+        return true
+
+    }
+    assertIntEqual(v1,v2) {
+        if (v1!=v2) {
+            self.passing = false
+            print "Assertion Failed ${v1} != ${v2}"
+            return false
+        }
+    }
+    assertFloatEqual(v1,v2) {
+        if (abs(v1-v2)>self.tol) {
+            self.failAssertion("Assertion Failed ${v1} != ${v2}, differencs is ${abs(v1-v2)} which is above the tolerance of ${self.tol}")
+            return false
+        }
+        return true
+    }
+    assertMeshEqual(v1,v2) {
+        // check matrix equality 
+        if (!self.assertMatrixEqual(v1.vertexmatrix(),v2.vertexmatrix())) {
+            return false
+        }
+        // check connectivity equality
+        if (!self.assertEquals(v1.maxgrade(),v2.maxgrade())) return false
+        for (i in 1...v1.maxgrade()) {
+            // only need to check vertex-higher grade because this contains all the information
+            if (!self.assertEquals(v1.connectivitymatrix(0,i),v2.connectivitymatrix(0,i))) return false;
+        }
+        return true
+
+    }
+    assertSelectionEqual(v1,v2) { 
+        if (!self.assertEquals(v1.maxgrade(),v2.maxgrade())) return false
+
+        for (i in 0...v1.maxgrade()) {
+            if (!self.assertEquals(v1.idlistforgrade(i),v2.idlistforgrade(i))) return false
+        }
+        return true
+        
+    }
+    assertFieldEqual(v1,v2) { 
+        // shape give the number of elements per grade
+        if (!self.assertEqual(v1.shape(),v2.shape())) return false
+        var shape = v1.shape()
+        var mesh = v1.mesh()
+        for (grade in 0...v1.shape().count()) {
+            var elmax = shape[grade]
+            for (elid in 0...mesh.count(grade)) {
+                for (i in 0...elmax) {
+                    if (!self.assertEqual(v1[grade,elid,i])) return false
+                }
+            }
+        }
+        return true
+    }
+
+    assertSetEqualityOfList(v1,v2,quiet = false) {
+        // does a shallow comparison for elements in the list but doens't care about order
+        // will do set equality on lists of lists 
+        if (v1.count()!=v2.count()) {
+            if (!quiet) {
+                self.failAssertion("Assertion Failed: Lists have differnt number of elements")
+            }
+            return false
+        }
+        for (i in 0...v1.count()) {
+            if (islist(v2[i])) {
+                var match = false
+                for (el in v1) {
+                    if (islist(el)) {
+                        if (self.assertListEqual(el,v2[i],quiet = true)) {
+                            match = true 
+                            continue
+                        }
+                    }
+                }
+                if (match == false) {
+                    if (!quiet) {
+                        self.failAssertion("Assertion Failed: Lists contain different elements ${v2[i]}")
+                    }
+                    return false
+                }
+            } else if (!v1.ismember(v2[i])) {
+                if (!quiet) {
+                    self.failAssertion("Assertion Failed: Lists contain different elements ${v2[i]}")
+                    print v1
+                    print v2
+                }
+                return false
+            } else v1.remove(v2[i]) // guard against mulitple same entries
+        }
+        return true
+        
+    }
+    assertDictionayEqual(v1,v2) {
+        if (!self.assertSetEqualityOfList(v1.keys(),v2.keys())) {
+            self.failAssertion("Assertion Failed: Dictionaries have differnt keys")
+        }
+        for (key in v1.keys()) {
+            if (!self.assertDeepEqual(v1[key],v2[key])) {
+                self.failAssertion("Assertion Failed: Dictionaries have different values at ${key}")
+                return false
+            }
+        }
+
+    }
+    assertRangeEqual(v1,v2) {
+        // if ranges have the same count, the same begining and the same incrment they are the same
+        if (v1.count()!=v2.count()) {
+            self.failAssertion("Asseration Failed: Ranges have differnt number of elements")
+            return false
+        }
+        if (!self.assertDeepEqual(v1.enumerate(0),v2.enumerate(0))) {
+            self.failAssertion("Assert Failed: Ranges have differnt start elements")
+            return false
+        }
+        if (v1.count()>1) {
+            if (!self.assertDeepEqual(v1.enumerate(1)-v1.enumerate(0),v2.enumerate(1)-v2.enumerate(0))) {
+                self.failAssertion("Assert Failed: Ranges have differnt increments")
+                return false
+            }
+        }
+
+        return true
+
+    }
+    assertStringEqual(v1,v2) {
+        if (v1 != v2) {
+            print "Assertion Failed: strings are ${v1} and ${v2}"
+            return false
+        }
+        return true
+    }
+    assertBoolEqual(v1,v2) {
+        if (v1 != v2) {
+            print "Assertion Failed: bools are ${v1} and ${v2}"
+            return false
+        }
+        return true
+    }
+
+    assertProperites(v1,v2) {
+        if (!self.assertListEqual(v1.has(), v2.has(),quiet = true)) {
+            print "Assertion Failed: Objects have differnt properites"
+            self.passing = false
+            return false
+        }
+        return true
+
+    }
+    assertObjectEqual(v1,v2){
+        //check property lists
+        if (!self.assertProperites(v1,v2)) return false
+
+        for (prop in v1.has()) {
+            if (!self.assertDeepEqual(v1[prop],v2[prop])) {
+                print "Property ${prop} not equal"
+                return false
+            }
+        }
+    }
+}

--- a/test/arithmetic/power_spec.morpho
+++ b/test/arithmetic/power_spec.morpho
@@ -1,8 +1,5 @@
 import unittest
 class power_spec is unit_test {
-    fixture(){
-        self.myNumber = 3
-    }
     integer_raised_to_an_integer(){
         self.assertEqual(2^2,4)
     }
@@ -13,7 +10,7 @@ class power_spec is unit_test {
         self.assertEqual(2^3.0, 8)
     }
     float_raised_to_a_float(){
-        self.assertEqual(2.0^3.0, 8 )
+        self.assertEqual(2.0^3.0, 8)
     }
     exponent_binds_before_uminus(){
         self.assertEqual(-1^2, -1)
@@ -23,12 +20,5 @@ class power_spec is unit_test {
     }
     higher_exponents_happen_first(){
         self.assertEqual(2^3^2, 512)
-    }
-    variable_to_exponent(){
-        self.assertEqual(self.myNumber^self.myNumber,27)
-    }
-    assume_failure(){
-        // self.assumeFail = "Example Reason"
-        self.assertEqual(2^3,7)
     }
 } power_spec()

--- a/test/arithmetic/power_spec.morpho
+++ b/test/arithmetic/power_spec.morpho
@@ -1,0 +1,24 @@
+import unittest
+class power_spec is unit_test {
+    integer_raised_to_an_integer(){
+        self.assertEquals(2^2,4)
+    }
+    float_raised_to_an_integer(){
+        self.assertEquals(2.0^3,8)
+    }
+    integer_raised_to_a_float(){
+        self.assertEquals(2^3.0, 8)
+    }
+    float_raised_to_a_float(){
+        self.assertEquals(2.0^3.0, 8 )
+    }
+    exponet_binds_before_uminus(){
+        self.assertEquals(-1^2, -1)
+        var x = -1
+        self.assertEquals(x^2, 1)
+        self.assertEquals((-1)^2, 1)
+    }
+    higher_exponents_happen_first(){
+        self.assertEquals(2^3^2, 512)
+    }
+} power_spec()

--- a/test/arithmetic/power_spec.morpho
+++ b/test/arithmetic/power_spec.morpho
@@ -1,24 +1,34 @@
 import unittest
 class power_spec is unit_test {
+    fixture(){
+        self.myNumber = 3
+    }
     integer_raised_to_an_integer(){
-        self.assertEquals(2^2,4)
+        self.assertEqual(2^2,4)
     }
     float_raised_to_an_integer(){
-        self.assertEquals(2.0^3,8)
+        self.assertEqual(2.0^3,8)
     }
     integer_raised_to_a_float(){
-        self.assertEquals(2^3.0, 8)
+        self.assertEqual(2^3.0, 8)
     }
     float_raised_to_a_float(){
-        self.assertEquals(2.0^3.0, 8 )
+        self.assertEqual(2.0^3.0, 8 )
     }
-    exponet_binds_before_uminus(){
-        self.assertEquals(-1^2, -1)
+    exponent_binds_before_uminus(){
+        self.assertEqual(-1^2, -1)
         var x = -1
-        self.assertEquals(x^2, 1)
-        self.assertEquals((-1)^2, 1)
+        self.assertEqual(x^2, 1)
+        self.assertEqual((-1)^2, 1)
     }
     higher_exponents_happen_first(){
-        self.assertEquals(2^3^2, 512)
+        self.assertEqual(2^3^2, 512)
+    }
+    variable_to_exponent(){
+        self.assertEqual(self.myNumber^self.myNumber,27)
+    }
+    assume_failure(){
+        // self.assumeFail = "Example Reason"
+        self.assertEqual(2^3,7)
     }
 } power_spec()

--- a/test/arithmetic/power_spec.morpho
+++ b/test/arithmetic/power_spec.morpho
@@ -1,5 +1,5 @@
 import unittest
-class power_spec is unit_test {
+class power_spec is unittest {
     integer_raised_to_an_integer(){
         self.assertEqual(2^2,4)
     }

--- a/test/arithmetic/power_spec.morpho
+++ b/test/arithmetic/power_spec.morpho
@@ -1,5 +1,5 @@
 import unittest
-class power_spec is unittest {
+class power_spec is UnitTest {
     integer_raised_to_an_integer(){
         self.assertEqual(2^2,4)
     }

--- a/test/object/has.morpho
+++ b/test/object/has.morpho
@@ -1,6 +1,6 @@
 // Check Object.has()
 import unittest
-class has_test is unittest {
+class has_test is UnitTest {
     fixture() { 
         self.a = Object()
         self.a.things = "stuff"

--- a/test/object/has.morpho
+++ b/test/object/has.morpho
@@ -1,11 +1,36 @@
-// Check Object.respondsto()
+// Check Object.has()
+import unittest
+class has_test is unittest {
+    fixture() { 
+        self.a = Object()
+        self.a.things = "stuff"
 
-var a = Object()
-
-a.things = "stuff"
-
-print a.has("things")
-// expect: true
-
-print a.has("stuff")
-// expect: false
+    }
+    has_with_an_arg_checks_a_properity() {
+        self.assertEqual(self.a.has("things"),true)
+        self.assertEqual(self.a.has("stuff"),false)
+    }
+    has_with_no_args_returns_list_of_properites() {
+        self.assertEqual(self.a.has(),["things"])
+        self.a.stuff = 2
+        self.assertSetEqualityOfList(self.a.has(),["things","stuff"])
+    }
+    has_with_muliple_args_throws_error() {
+        var correctError = false
+        try {
+            self.a.has("one","two")
+        } catch {
+            "RspndsToArg": correctError = true
+        }
+        self.assert(correctError)
+    }
+    has_with_nonstring_throws_error() {
+        var correctError = false
+        try {
+            self.a.has(2)
+        } catch {
+            "RspndsToArg": correctError = true
+        }
+        self.assert(correctError)
+    }
+} has_test()

--- a/test/object/has.morpho
+++ b/test/object/has.morpho
@@ -20,7 +20,7 @@ class has_test is unittest {
         try {
             self.a.has("one","two")
         } catch {
-            "RspndsToArg": correctError = true
+            "HasArg": correctError = true
         }
         self.assert(correctError)
     }
@@ -29,7 +29,7 @@ class has_test is unittest {
         try {
             self.a.has(2)
         } catch {
-            "RspndsToArg": correctError = true
+            "HasArg": correctError = true
         }
         self.assert(correctError)
     }

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -1,6 +1,6 @@
 // Check Object.respondsto()
-import UnitTest
-class respondsto_test is unittest {
+import unittest
+class respondsto_test is UnitTest {
     fixture() { 
         self.a = Object()
     }

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -1,43 +1,24 @@
 // Check Object.respondsto()
 import unittest
-class respondsto_test is UnitTest {
-    fixture() { 
-        self.a = Object()
-    }
-    respondsto_with_an_arg_checks_a_properity() {
-        self.assertEqual(self.a.respondsto("invoke"),true)
-        self.assertEqual(self.a.respondsto("squiggle"),false)
-    }
-    respondsto_with_no_args_returns_list_of_properites() {
-        var objectMethods = [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
-        self.assertSetEqualityOfList(self.a.respondsto(),objectMethods)
-        
-        // class aplus {
-        //     newmethod(){
-        //         return true
-        //     }
-        // }
-        self.assumeFail = "Class Defined in another classes method gains subsequent methods #146"
 
-        // var newA = aplus()
-        // self.assertSetEqualityOfList(newA.respondsto(),objectMethods.append("newmethod"))
-    }
-    respondsto_with_muliple_args_throws_error() {
-        var correctError = false
-        try {
-            self.a.respondsto("squiggle","foo")
-        } catch {
-            "RspndsToArg": correctError = true
-        }
-        self.assert(correctError)
-    }
-    respondsto_with_nonstring_throws_error() {
-        var correctError = false
-        try {
-            self.a.respondsto(2)
-        } catch {
-            "RspndsToArg": correctError = true
-        }
-        self.assert(correctError)
-    }
-} respondsto_test()
+// Check Object.respondsto()
+
+var a = Object()
+
+print a.respondsto("invoke")
+// expect: true
+
+print a.respondsto("squiggle")
+// expect: false
+
+print a.respondsto()
+// expect: [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+
+var a = Object
+a.respondsto()
+// expect: [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+
+print a.respondsto("squiggle","foo")
+// expect error 'RspndsToArg'
+
+

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -1,12 +1,43 @@
 // Check Object.respondsto()
+import unittest
+class respondsto_test is unittest {
+    fixture() { 
+        self.a = Object()
+    }
+    respondsto_with_an_arg_checks_a_properity() {
+        self.assertEqual(self.a.respondsto("invoke"),true)
+        self.assertEqual(self.a.respondsto("squiggle"),false)
+    }
+    respondsto_with_no_args_returns_list_of_properites() {
+        var objectMethods = [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+        self.assertSetEqualityOfList(self.a.respondsto(),objectMethods)
+        
+        // class aplus {
+        //     newmethod(){
+        //         return true
+        //     }
+        // }
+        self.assumeFail = "Class Defined in another classes method gains subsequent methods #146"
 
-var a = Object()
-
-print a.respondsto("invoke")
-// expect: true
-
-print a.respondsto("squiggle")
-// expect: false
-
-print a.respondsto("squiggle","foo")
-// expect error 'RspndsToArg'
+        // var newA = aplus()
+        // self.assertSetEqualityOfList(newA.respondsto(),objectMethods.append("newmethod"))
+    }
+    respondsto_with_muliple_args_throws_error() {
+        var correctError = false
+        try {
+            self.a.respondsto("squiggle","foo")
+        } catch {
+            "RspndsToArg": correctError = true
+        }
+        self.assert(correctError)
+    }
+    respondsto_with_nonstring_throws_error() {
+        var correctError = false
+        try {
+            self.a.respondsto(2)
+        } catch {
+            "RspndsToArg": correctError = true
+        }
+        self.assert(correctError)
+    }
+} respondsto_test()

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -1,5 +1,5 @@
 // Check Object.respondsto()
-import unittest
+import UnitTest
 class respondsto_test is unittest {
     fixture() { 
         self.a = Object()

--- a/test/test.py
+++ b/test/test.py
@@ -232,7 +232,7 @@ success=0 # number of successful tests
 total=0   # total number of tests
 
 # look for a command line argument that says
-# this is being run for continuos integration
+# this is being run for continuous integration
 CI = False
 if (len(sys.argv) > 1):
     CI = sys.argv[1] == '-c'


### PR DESCRIPTION
This change introduces a unit test framework to Morpho, making it easy to lock down behavior in code and make it clear what behavior you're locking down. 

    import unittest

    exampleTest is unittest {
        test_that_input_produces_behavior{
                ...
             assertEqual(....)
        }
        ...
    } exampleTest()

Full usage is detailed below in the documentation. 

This change also adds zero argument options for `.has()` and `.respondsto()` which return the full list of properties/methods of an object.

I've also added support for these new unit tests in the Morpho test suite,
Unit tests for has and respondsto have been added in this new framework as well



