### PR TITLE
Fixed Latent Error for render() method

### DIFF
--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -161,8 +161,21 @@ class POVRaytracer {
     if (quiet) silent = "&> /dev/null"
     var disp = ""
     if (!display) disp = "-D"
-    system("povray ${path} ${disp} +A +W${self.width} +H${self.height} ${silent}")
-    var out = path.split(".")[0]
-    if (!quiet && display) system("open ${out}.png")
+    system("povray ./\"${path}\" ${disp} +A +W${self.width} +H${self.height} ${silent}")
+    var out = self._slice(path, 0, path.count()-4)
+    if (!quiet && display) system("open ./${out}.png")
+  }
+  /*
+  private method: slice a string given a start and an end
+  @param string: string to be slice
+  @param start: starting index
+  @param end: ending index(exclusive)
+  */
+  _slice(string, start, end) {
+    var s = ""
+    for (i in start...end) {
+      s += string[i]
+    }
+    return s
   }
 }


### PR DESCRIPTION
Fix the following type of error
To reproduce the error:

        // ** deltaSigma = -0.25
        // ** angle[0] = [82.6, 88.8, 85.94, 105.72]
        // ** angle[1] = 71
       var surface = PolyhedronMesh([[-2.5,2.5,-0.5],[2.5,2.5,-0.5],[-2.5,-2.5,-0.5],[2.5,-2.5,-0.5],
                        [-2.5,2.5,-1],[2.5,2.5,-1],[-2.5,-2.5,-1],[2.5,-2.5,-1]],
                        [[0,1,3,2], [0,1,5,4], [0,2,6,4], [7,3,2,6],
                        [1,3,7,5], [4,6,7,5]])
        var graphic2 = plotmesh(surface, grade=[0,1,2])
        var pov = POVRaytracer(graphic2)
        pov.viewpoint=Matrix([0, -4, -5])
        pov.viewangle=0
        pov.light=[Matrix([10,10,10]), Matrix([-10,-10,10])]
       
        pov.render("${deltaSigma}_${angle[1]}.pov", display=true, quiet=false)
        
        /*  1.throwing error in the render() method in the POVRaytracer class at morpho/morpho5/modules/povray.morpho
                line 164 executed command in shell "povray -0.25_90.pov +A +W2048 +H1536"
                Error message: Failed to parse command-line option
                Error reason: "-0.25_90.pov" is not a valid command-line option, it should be a filename
                Fix Applied: add the prefix "./" to before the filename parameter

            2. throwing error in the render() method in the POVRaytracer class at morpho/morpho5/modules/povray.morpho
                line 166 executed command in shell "open ${out}.png"
                Error message: xdg-open: file '-0.png' does not exist
                Error reason: Latent error - line 165 
                Fix Applied: use loop to generate the filename
        */
        var csv = File("data.csv", "append")
        csv.write("${deltaSigma},${angle[1]},\"${angle[0]}\"")