### PR TITLE
Hydrogel Errors

### DIFF
--- a/morpho5/geometry/field.c
+++ b/morpho5/geometry/field.c
@@ -379,6 +379,11 @@ bool field_compareshape(objectfield *a, objectfield *b) {
     return false;
 }
 
+/** Returns the number of degrees of freedom in a given grade */
+unsigned int field_dofforgrade(objectfield *f, grade g) {
+    return (g<=f->ngrades ? f->dof[g] : 0);
+}
+
 /** Adds two fields together */
 bool field_add(objectfield *left, objectfield *right, objectfield *out) {
     return (matrix_add(&left->data, &right->data, &out->data)==MATRIX_OK);

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -84,6 +84,7 @@ objectfield *object_newfield(objectmesh *mesh, value prototype, unsigned int *do
 
 void field_zero(objectfield *field);
 
+unsigned int field_dofforgrade(objectfield *f, grade g);
 bool field_getelement(objectfield *field, grade grade, elementid el, int indx, value *out);
 bool field_getelementwithindex(objectfield *field, int indx, value *out);
 bool field_getelementaslist(objectfield *field, grade grade, elementid el, int indx, unsigned int *nentries, double **out);

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -1418,14 +1418,20 @@ bool hydrogel_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid,
     if (!functional_elementsize(v, info->refmesh, info->grade, id, nv, vid, &V0)) return false;
     if (!functional_elementsize(v, mesh, info->grade, id, nv, vid, &V)) return false;
 
-    if (V0<1e-8) printf("Warning: Reference element %u has tiny volume V=%g, V0=%g\n", id, V, V0);
-
+    if (V0<1e-8) {
+        printf("Warning: Reference element %u has tiny volume V=%g, V0=%g\n", id, V, V0);
+        //morpho_runtimeerror(v, HYDROGEL_ZEEROREFELEMENT, id, V, V0);
+    }
+    
     if (fabs(V)<MORPHO_EPS) return false;
 
     // Determine phi0 either as a number or by looking up something in a field
     if (MORPHO_ISFIELD(info->phi0)) {
         objectfield *p = MORPHO_GETFIELD(info->phi0);
-        field_getelement(p, info->grade, id, 0, &vphi0);
+        if (!field_getelement(p, info->grade, id, 0, &vphi0)) {
+            morpho_runtimeerror(v, HYDROGEL_FLDGRD, (unsigned int) info->grade);
+            return false;
+        }
     }
     if (MORPHO_ISNUMBER(vphi0)) {
         if (!morpho_valuetofloat(vphi0, &phi0)) return false;
@@ -3036,16 +3042,24 @@ void functional_initialize(void) {
 
     morpho_defineerror(FUNC_INTEGRAND_MESH, ERROR_HALT, FUNC_INTEGRAND_MESH_MSG);
     morpho_defineerror(FUNC_ELNTFND, ERROR_HALT, FUNC_ELNTFND_MSG);
+    
     morpho_defineerror(SCALARPOTENTIAL_FNCLLBL, ERROR_HALT, SCALARPOTENTIAL_FNCLLBL_MSG);
+    
     morpho_defineerror(LINEARELASTICITY_REF, ERROR_HALT, LINEARELASTICITY_REF_MSG);
     morpho_defineerror(LINEARELASTICITY_PRP, ERROR_HALT, LINEARELASTICITY_PRP_MSG);
+    
     morpho_defineerror(HYDROGEL_ARGS, ERROR_HALT, HYDROGEL_ARGS_MSG);
     morpho_defineerror(HYDROGEL_PRP, ERROR_HALT, HYDROGEL_PRP_MSG);
+    morpho_defineerror(HYDROGEL_FLDGRD, ERROR_HALT, HYDROGEL_FLDGRD_MSG);
+    morpho_defineerror(HYDROGEL_ZEEROREFELEMENT, ERROR_WARNING, HYDROGEL_ZEEROREFELEMENT_MSG);
+    
     morpho_defineerror(EQUIELEMENT_ARGS, ERROR_HALT, EQUIELEMENT_ARGS_MSG);
     morpho_defineerror(GRADSQ_ARGS, ERROR_HALT, GRADSQ_ARGS_MSG);
     morpho_defineerror(NEMATIC_ARGS, ERROR_HALT, NEMATIC_ARGS_MSG);
     morpho_defineerror(NEMATICELECTRIC_ARGS, ERROR_HALT, NEMATICELECTRIC_ARGS_MSG);
+    
     morpho_defineerror(FUNCTIONAL_ARGS, ERROR_HALT, FUNCTIONAL_ARGS_MSG);
+    
     morpho_defineerror(LINEINTEGRAL_ARGS, ERROR_HALT, LINEINTEGRAL_ARGS_MSG);
     morpho_defineerror(LINEINTEGRAL_NFLDS, ERROR_HALT, LINEINTEGRAL_NFLDS_MSG);
 }

--- a/morpho5/geometry/functional.h
+++ b/morpho5/geometry/functional.h
@@ -94,7 +94,13 @@
 #define HYDROGEL_ARGS_MSG              "Hydrogel requires a reference mesh and allows 'grade', 'a', 'b', 'c', 'd', 'phi0' and 'phiref' as optional arguments."
 
 #define HYDROGEL_PRP                   "HydrglPrp"
-#define HYDROGEL_PRP_MSG               "Hydrogel requires the first argument to be a mesh, 'grade' to be an integer grade, 'a', 'b', 'c' 'd', 'phi0' and 'phiref' to be numbers."
+#define HYDROGEL_PRP_MSG               "Hydrogel requires the first argument to be a mesh, 'grade' to be an integer grade, 'a', 'b', 'c' 'd', 'phiref' to be numbers and 'phi0' to be a number or a Field."
+
+#define HYDROGEL_FLDGRD                "HydrglFldGrd"
+#define HYDROGEL_FLDGRD_MSG            "Hydrogel has been given phi0 as a Field that lacks scalar elements in grade %u."
+
+#define HYDROGEL_ZEEROREFELEMENT       "HydrglZrRfVl"
+#define HYDROGEL_ZEEROREFELEMENT_MSG   "Reference element %u has tiny volume V=%g, V0=%g\n"
 
 #define GRADSQ_ARGS                    "GradSqArgs"
 #define GRADSQ_ARGS_MSG                "GradSq requires a field as the argument."

--- a/test/functionals/hydrogel/hydrogel_field_lacks_grade.morpho
+++ b/test/functionals/hydrogel/hydrogel_field_lacks_grade.morpho
@@ -1,0 +1,34 @@
+// Create a hydrogel phi0 with the wrong type of Field 
+
+import plot 
+import optimize
+import meshtools
+
+var mb = MeshBuilder() 
+mb.addvertex([0,0,0])
+mb.addvertex([1,0,0])
+mb.addvertex([0,1,0])
+mb.addvertex([0,0,1])
+mb.addelement(3,[0,1,2,3])
+
+var m=mb.build() 
+var mref = m.clone() 
+
+var phi0 = Field(m, grade=2) // Needs to have elements in grade 3 
+
+var fha = 0.0 
+var fhb = 1.0
+var fhc = 0.499 
+var fhd = -1.0 
+var phir = 0.0359465
+
+var lh=Hydrogel(mref,
+    a = fha,
+    b = fhb,
+    c = fhc,
+    d = fhd,
+    phiref=phir,
+    phi0=phi0)
+
+lh.total(m)
+// expect error 'HydrglFldGrd' 


### PR DESCRIPTION
Using Hydrogel with a Field was very error prone; the Field needs to have scalars on the same grade as the element. 

Added an error to alert the user if the Field didn't have the right information, and a test case to ensure the error is generated correctly.  

Fixes #124.