### PR TITLE
Function calls can now raise a stack overflow

### DIFF
--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -69,7 +69,7 @@
 #define MORPHO_MAXIMUMFILENAMELENGTH 255
 
 /** @brief Size of the call frame stack. */
-#define MORPHO_CALLFRAMESTACKSIZE 64
+#define MORPHO_CALLFRAMESTACKSIZE 255
 
 /** @brief Size of the error handler stack. */
 #define MORPHO_ERRORHANDLERSTACKSIZE 64

--- a/morpho5/utils/error.h
+++ b/morpho5/utils/error.h
@@ -119,6 +119,9 @@ void morpho_unreachable(const char *explanation);
 * VM error messages
 * ********************************************************************** */
 
+#define VM_STCKOVFLW                      "StckOvflw"
+#define VM_STCKOVFLW_MSG                  "Stack overflow."
+
 #define VM_INVLDOP                        "InvldOp"
 #define VM_INVLDOP_MSG                    "Invalid operands. Failed to %s %s and %s"
 

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -230,6 +230,7 @@ struct svm {
     instruction *instructions; /* Base of instructions */
     value *konst; /* Current constant table */
     callframe *fp; /* Frame pointer saved on exit */
+    callframe *fpmax; /* Maximum value of the frame pointer */
     errorhandler *ehp; /* Error handler pointer */
     
     error err; /** An error struct that will be filled out when an error occurs */

--- a/test/function/stack_overflow.morpho
+++ b/test/function/stack_overflow.morpho
@@ -1,0 +1,7 @@
+// Cause stack overflow with a recursive function 
+
+fn f(n) {
+  return f(n + 1)
+}
+
+print f(1) // expect error 'StckOvflw'


### PR DESCRIPTION
VM now checks for stack overflow and reports an error when it occurs. Callframe stack increased to 255 levels]