### PR TITLE
Povray improvements

### DIFF
--- a/examples/povray/testCamera.morpho
+++ b/examples/povray/testCamera.morpho
@@ -1,0 +1,33 @@
+import meshtools
+import implicitmesh
+import plot
+import povray 
+
+var c = Matrix([0.1,0.2,0.3])
+var impl = ImplicitMeshBuilder(fn (x,y,z) (x-c[0])^2/(0.5^2)+(y-c[1])^2/(0.75^2)+(z-c[2])^2-1)
+
+var m = impl.build(stepsize=0.25)
+
+var g = plotmesh(m)
+
+var pov = POVRaytracer(g)
+
+pov.render("default.pov")
+
+var camera = Camera(look_at = c)
+
+pov = POVRaytracer(g, camera = camera)
+
+pov.render("centered.pov")
+
+pov.viewpoint = c + Matrix([-5,0,0])
+
+pov.render("centered_xview.pov")
+
+pov.viewpoint = c + Matrix([0,-5,0])
+
+pov.render("centered_yview.pov")
+
+pov.sky = Matrix([1,0,0])
+
+pov.render("centered_yview_fixed_rotated.pov")

--- a/morpho5/docs/povray.md
+++ b/morpho5/docs/povray.md
@@ -22,15 +22,59 @@ Create, render and display a scene using POVRay:
 
 This also creates the .png file for the scene.
 
-The `POVRaytracer` constructor supports a number of optional arguments:
+The `POVRaytracer` constructor supports an optional `camera` argument:
 
-* `antialias` - whether to antialias the output or not
-* `width` - image width
-* `height` - image height
-* `viewangle` - camera angle (higher means wider view)
-* `viewpoint` - position of camera
+* `camera` - a `Camera` object (see below / help) containing the
+  settings for the povray camera.
+
+The `Camera` object can be initialized as follows:
+
+    var camera = Camera()
+
+This object contains the default settings of the camera, which can be
+changed using the following optional arguments, or by just setting the
+attributes after instantiation:
+
+* `antialias` - whether to antialias the output or not (`true` by default)
+* `width` - image width (`2048` by default)
+* `height` - image height (`1536` by default)
+* `viewangle` - camera angle (higher means wider view) (`24` by default)
+* `viewpoint` - position of camera (`Matrix([0,0,-5])` by default)
+* `look_at` - coordinate to look at (`Matrix([0,0,0])` by defualt)
+* `sky` - orientation pointing to the sky (`Matrix([0,1,0])` by default)
+
+The default settings generate a reasonable centered view of the x-y
+plane.
+
+These attributes can also be set directly for the `POVRaytracer` object:
+
+    pov.look_at = Matrix([0,0,1])
 
 The `render` method supports two optional boolean arguments:
 
 * `quiet` - whether to suppress the parser and render statistics from `povray` or not (`false` by default)
 * `display` - whether to turn on the graphic display while rendering or not (`true` by default) 
+
+# Camera
+[tagpovray]: # (camera)
+
+The `Camera` object can be initialized as follows:
+
+    var camera = Camera()
+
+This object contains the default settings of the camera, which can be
+changed using the following optional arguments, or by just setting the
+attributes after instantiation:
+
+* `antialias` - whether to antialias the output or not (`true` by default)
+* `width` - image width (`2048` by default)
+* `height` - image height (`1536` by default)
+* `viewangle` - camera angle (higher means wider view) (`24` by default)
+* `viewpoint` - position of camera (`Matrix([0,0,-5])` by default)
+* `look_at` - coordinate to look at (`Matrix([0,0,0])` by defualt)
+* `sky` - orientation pointing to the sky (`Matrix([0,1,0])` by default)
+
+    camera.sky = Matrix([0,0,1])
+
+The default settings generate a reasonable centered view of the x-y
+plane.

--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -59,6 +59,28 @@ class POVRaytracer {
     return arg
   }
 
+  visittext(item, out) {
+    var arg = self.optionalarg(item)
+    out.write("text {" +
+              "  ttf \"timrom.ttf\" \"${item.string}\" 0.1, 0 \n" + 
+              "  pigment { rgb ${self.color(item.color)} ${arg} }")
+    out.write("  translate ${item.posn[0]}*x + ${item.posn[1]}*y + ${item.posn[2]}*z ")
+    out.write("  scale ${item.size / 48} ")
+    var m = item.transformationmatrix() 
+    if (m) {
+      var str = "  matrix <"
+      for (i in 0..3) {
+        for (j in 0..2) {
+          str+=" "+String(m[i,j])
+          if (i==3 && j==2) str += "> \n }"
+          else str += ", "
+          if (j==2) str +="\n"
+        }
+      }
+      out.write(str)
+    }
+  }
+
   visitsphere(item, out) {
     var arg = self.optionalarg(item)
     out.write("sphere {"+

--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -1,14 +1,36 @@
 
+class Camera {
+    init(antialias = true, width = 2048, height = 1536, viewangle = 24, viewpoint = nil, look_at = nil, sky = nil) {
+        self.antialias = antialias
+        self.width = width
+        self.height = height
+        self.viewangle = viewangle
+        self.viewpoint = viewpoint
+        self.look_at = look_at
+        self.sky = sky
+        self.light = nil
+        if (!self.viewpoint) self.viewpoint = Matrix([0,0,-5])
+        if (!self.look_at) self.look_at = Matrix([0,0,0])
+        if (!self.sky) self.sky = Matrix([0,1,0])
+    }
+}
+
+
 class POVRaytracer {
-  init(graphic, antialias = true, width = 2048, height = 1536, viewangle = 24, viewpoint = nil) {
+  init(graphic, camera = nil) {
+
+    self.camera = camera
+    if (!self.camera) self.camera = Camera() // Default Camera
     self.graphic = graphic
-    self.antialias = antialias
-    self.width = width
-    self.height = height
-    self.viewangle = viewangle
-    self.viewpoint = viewpoint
+
+    self.antialias = self.camera.antialias
+    self.width = self.camera.width
+    self.height = self.camera.height
+    self.viewangle = self.camera.viewangle
+    self.viewpoint = self.camera.viewpoint
+    self.look_at = self.camera.look_at
+    self.sky = self.camera.sky
     self.light = nil
-    if (!self.viewpoint) self.viewpoint = Matrix([0,0,-5])
   }
 
   vector(v) {
@@ -139,9 +161,9 @@ class POVRaytracer {
     out.write("#include \"colors.inc\"")
     out.write("background { rgb ${self.vector(self.graphic.background.rgb(0))} }")
     out.write("camera {"+
-              "location ${self.vector(-self.viewpoint)}"+
+              "location ${self.vector(self.viewpoint)}"+
               "up <0,1,0> right <-1.33,0,0> angle ${self.viewangle}"+
-              "look_at <0, 0, 0> }")
+              "look_at ${self.vector(self.look_at)} sky ${self.vector(self.sky)} }")
 
     for (item in self.graphic.displaylist) item.accept(self, out)
 


### PR DESCRIPTION
This PR makes a few small improvements to the `povray` module:

* The camera settings for povray are now passed through a single `Camera` object, making it convenient to create settings once and use in a loop, for example. All the original attributes of povray are still the same, so the previous codes should work fine, as long as the attribute is set after initialization, like `pov.viewpoint = Matrix([0,0,5])`, for example. 
* The povray settings called `look_at` and `sky` can now be set in `POVRaytracer`/`Camera` (as opposed to being hard-coded before). See povray documentation [here](https://www.povray.org/documentation/view/3.7.0/246/) for details.
* The new Text object in graphics can now be rendered in povray as well, via an initial implementation of the `visittext` method for `POVRaytracer`
* Updated docs and added an example for the Camera settings.