### PR TITLE
Fixed warning in morphoview installation

### DIFF
--- a/morphoview/command.c
+++ b/morphoview/command.c
@@ -31,7 +31,11 @@ void command_removefile(const char *in) {
     char remove[len+4];
     strcpy(remove, "rm ");
     strcpy(remove+3, in);
-    system(remove);
+    int systemRet = system(remove);
+    if(systemRet == -1){
+        // The system method failed
+        printf("Warning: the system method to remove a temporary file (command.c:34.5) has failed.");
+    }
 }
 
 /** Returns the contents of a file as a string


### PR DESCRIPTION
The warning appearing during morphoview installation is due to not checking the return value of a `system` call. The `system` call in this case (command.c:34.5) is meant to delete a temporary command file, which I believe is not critical to the functioning of Morpho? I have for now modified the file so that it prints a warning if the `system` call fails. Should we produce an error instead?

This fixed #137 