### PR TITLE
Improvements to color module

### DIFF
--- a/morpho5/docs/color.md
+++ b/morpho5/docs/color.md
@@ -14,11 +14,69 @@ Create a Color object from an RGB pair:
 
     var col = Color(0.5,0.5,0.5) // A 50% gray
 
+The `color` module also provides `ColorMap`s, which are give a sequence of colors as a function of a parameter; these are useful for plotting the values of a `Field` for example.
+
 [showsubtopics]: # (subtopics)
+
+## RGB
+[tagrgb]: # (rgb)
+
+Gets the rgb components of a `Color` or `ColorMap` object as a list. Takes a single argument in the range 0..1, although the result will only depend on this argument if the object is a `ColorMap`.
+
+    var col = Color(0.1,0.5,0.7)
+    print col.rgb(0)
+
+## Red
+[tagred]: # (red)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Green
+[taggreen]: # (green)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Blue
+[tagblue]: # (blue)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## White
+[tagwhite]: # (white)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Black
+[tagblack]: # (black)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Cyan
+[tagcyan]: # (cyan)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Magenta
+[tagmagenta]: # (magenta)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Yellow
+[tagyellow]: # (yellow)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Brown
+[tagbrown]: # (brown)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Orange
+[tagorange]: # (orange)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Pink
+[tagpink]: # (pink)
+Built in `Color` object for use with the `graphics` and `plot` modules.
+
+## Purple
+[tagpurple]: # (purple)
+Built in `Color` object for use with the `graphics` and `plot` modules.
 
 ## Colormap
 [tagcolormap]: # (colormap)
-The `color` module provides `ColorMap`s which are subclasses of `Color` that map a single parameter in the range 0..1 onto a continuum of colors. These include `GradientMap`,  `GrayMap` and `HueMap`. `Color`s and `Colormap`s have the same interface.
+The `color` module provides `ColorMap`s which are subclasses of `Color` that map a single parameter in the range 0..1 onto a continuum of colors. `Color`s and `Colormap`s have the same interface.
 
 Get the red, green or blue components of a color or colormap:
 
@@ -33,10 +91,42 @@ Create a grayscale:
 
     var c = Gray(0.2) // 20% gray
 
-## RGB
-[tagrgb]: # (rgb)
+Available ColorMaps: `GradientMap`,  `GrayMap`, `HueMap`, `ViridisMap`, `MagmaMap`, `InfernoMap` and `PlasmaMap`.
 
-Gets the rgb components of a `Color` or `ColorMap` object as a list. Takes a single argument in the range 0..1, although the result will only depend on this argument if the object is a `ColorMap`. 
+## GradientMap
+[taggradientmap]: # (gradientmap)
 
-    var col = Color(0.1,0.5,0.7)
-    print col.rgb(0)
+`GradientMap` is a `Colormap` that displays a white-green-purple sequence.
+
+## GrayMap
+[taggraymap]: # (graymap)
+
+`GrayMap` is a `Colormap` that displays grayscales.
+
+## HueMap
+[taghuemap]: # (huemap)
+
+`HueMap` is a `Colormap` that displays vivid colors. It is periodic on the interval 0..1.
+
+## ViridisMap
+[tagviridismap]: # (viridismap)
+
+`ViridisMap` is a `Colormap` that displays a purple-green-yellow sequence.
+It is perceptually uniform and intended to be improve the accessibility of visualizations for viewers with color vision deficiency.
+
+## MagmaMap
+[tagmagmamap]: # (magmamap)
+
+`MagmaMap` is a `Colormap` that displays a black-red-yellow sequence.
+It is perceptually uniform and intended to be improve the accessibility of visualizations for viewers with color vision deficiency.
+
+## InfernoMap
+[taginfernomap]: # (infernomap)
+
+`InfernoMap` is a `Colormap` that displays a black-red-yellow sequence.
+It is perceptually uniform and intended to be improve the accessibility of visualizations for viewers with color vision deficiency.
+
+## PlasmaMap
+[tagplasmamap]: # (plasmamap)
+
+`InfernoMap` is a `Colormap` that displays a blue-red-yellow sequence. It is perceptually uniform and intended to be improve the accessibility of visualizations for viewers with color vision deficiency.

--- a/morpho5/docs/color.md
+++ b/morpho5/docs/color.md
@@ -21,7 +21,7 @@ The `color` module also provides `ColorMap`s, which are give a sequence of color
 ## RGB
 [tagrgb]: # (rgb)
 
-Gets the rgb components of a `Color` or `ColorMap` object as a list. Takes a single argument in the range 0..1, although the result will only depend on this argument if the object is a `ColorMap`.
+Gets the rgb components of a `Color` or `ColorMap` object as a list. Takes a single argument in the range 0 to 1, although the result will only depend on this argument if the object is a `ColorMap`.
 
     var col = Color(0.1,0.5,0.7)
     print col.rgb(0)
@@ -76,12 +76,12 @@ Built in `Color` object for use with the `graphics` and `plot` modules.
 
 ## Colormap
 [tagcolormap]: # (colormap)
-The `color` module provides `ColorMap`s which are subclasses of `Color` that map a single parameter in the range 0..1 onto a continuum of colors. `Color`s and `Colormap`s have the same interface.
+The `color` module provides `ColorMap`s which are subclasses of `Color` that map a single parameter in the range 0 to 1 onto a continuum of colors. `Color`s and `Colormap`s have the same interface.
 
 Get the red, green or blue components of a color or colormap:
 
     var col = HueMap()
-    print col.red(0.5) // argument can be in range 0..1
+    print col.red(0.5) // argument can be in range 0 to 1
 
 Get all three components as a list:
 
@@ -106,7 +106,7 @@ Available ColorMaps: `GradientMap`,  `GrayMap`, `HueMap`, `ViridisMap`, `MagmaMa
 ## HueMap
 [taghuemap]: # (huemap)
 
-`HueMap` is a `Colormap` that displays vivid colors. It is periodic on the interval 0..1.
+`HueMap` is a `Colormap` that displays vivid colors. It is periodic on the interval 0 to 1.
 
 ## ViridisMap
 [tagviridismap]: # (viridismap)

--- a/morpho5/modules/color.morpho
+++ b/morpho5/modules/color.morpho
@@ -34,19 +34,24 @@ fn Gray(x) {
 
 /* Basic color maps */
 
-class GradientMap is Color {
+class ColorMap {
+  init() { }
+  rgb(x) { return [self.red(x), self.green(x), self.blue(x)] }
+}
+
+class GradientMap is ColorMap {
   red(x) { return 0.29+0.04*x+0.66*x^2 }
   green(x) { return 0.33+0.42*x+0.24*x^2 }
   blue(x) { return 0.46-0.55*x+x^2 }
 }
 
-class GrayMap is Color {
+class GrayMap is ColorMap {
   red(x) { return x }
   green(x) { return x }
   blue(x) { return x }
 }
 
-class HueMap is Color {
+class HueMap is ColorMap {
   red(x) { return (sin(2*Pi*(x+1/4))+1)/2 }
   green(x) { return (sin(2*Pi*x)+1)/2 }
   blue(x) { return (sin(2*Pi*(x-0.4))+1)/2 }

--- a/morpho5/modules/color.morpho
+++ b/morpho5/modules/color.morpho
@@ -1,6 +1,4 @@
-/*
- * Color
- */
+/* Color module */
 
 import constants
 
@@ -10,18 +8,10 @@ class Color {
     self.g = g
     self.b = b
   }
-  red(x) {
-    return self.r
-  }
-  green(x) {
-    return self.g
-  }
-  blue(x) {
-    return self.b
-  }
-  rgb(x) {
-    return [self.red(x), self.green(x), self.blue(x)]
-  }
+  red(x) { return self.r }
+  green(x) { return self.g }
+  blue(x) { return self.b }
+  rgb(x) { return [self.r, self.g, self.b] }
 }
 
 // Some predefined colors
@@ -30,54 +20,145 @@ var Green = Color(0,1,0)
 var Blue = Color(0,0,1)
 var White = Color(1,1,1)
 var Black = Color(0,0,0)
+var Cyan = Color(0,1,1)
+var Magenta = Color(1,0,1)
+var Yellow = Color(1,1,0)
+var Brown = Color(0.6,0.4,0.2)
+var Orange = Color(1,0.5,0)
+var Pink = Color(1,0.5,0.5) 
+var Purple = Color(0.5,0,0.5)
 
 fn Gray(x) {
   return Color(x,x,x)
 }
 
-/*
- * Color maps
- */
+/* Basic color maps */
 
-class GradientMap < Color {
-  init() {
+class GradientMap is Color {
+  red(x) { return 0.29+0.04*x+0.66*x^2 }
+  green(x) { return 0.33+0.42*x+0.24*x^2 }
+  blue(x) { return 0.46-0.55*x+x^2 }
+}
+
+class GrayMap is Color {
+  red(x) { return x }
+  green(x) { return x }
+  blue(x) { return x }
+}
+
+class HueMap is Color {
+  red(x) { return (sin(2*Pi*(x+1/4))+1)/2 }
+  green(x) { return (sin(2*Pi*x)+1)/2 }
+  blue(x) { return (sin(2*Pi*(x-0.4))+1)/2 }
+}
+
+/* Color maps expanded onto Chebyshev polynomials */
+
+var _errChebyShevOrderInconsistent = Error("ClrChbyshvOrdr", "Order of Chebyshev approximation inconsistent.") 
+
+class ChebyshevMap is Color {
+  init(R,G,B) {
+    self.R = R 
+    self.G = G
+    self.B = B
+    self.order = R.count() 
+    if (G.count()!=self.order || B.count()!=self.order) _errChebyShevOrderInconsistent.throw()  
   }
-  red(x) {
-    return 0.29+0.04*x+0.66*x^2
+
+  _chebyshev(t) {
+    var n = self.order
+    var c[n]
+    c[0]=1
+    c[1]=t
+    for (var i=2; i<n; i+=1) c[i]=2*t*c[i-1]-c[i-2]
+    return c 
+  } 
+
+  _component(x, table) {
+    var r=0
+    var c = self._chebyshev(2*x-1)
+    for (var i=0; i<self.order; i+=1) r+=c[i]*table[i]
+    return r
   }
-  green(x) {
-    return 0.33+0.42*x+0.24*x^2
-  }
-  blue(x) {
-    return 0.46-0.55*x+x^2
+
+  red(x) { return self._component(x, self.R) }
+  green(x) { return self._component(x, self.G) }
+  blue(x) { return self._component(x, self.B) }
+
+  rgb(x) { 
+    var r=0,g=0,b=0
+    var c = self._chebyshev(2*x-1)
+  
+    for (var i=0; i<self.order; i+=1) {
+      r+=c[i]*self.R[i]
+      g+=c[i]*self.G[i]
+      b+=c[i]*self.B[i]
+    }
+
+    return [r,g,b]
   }
 }
 
-class GrayMap < Color {
-  init() {
+/* Colormaps corresponding to the MPL colormaps:
+   http://bids.github.io/colormap/ 
+   Here approximated by an expension in Chebyshev polynomials */
 
-  }
-  red(x) {
-    return x
-  }
-  green(x) {
-    return x
-  }
-  blue(x) {
-    return x
+class ViridisMap is ChebyshevMap {
+  init() {
+    super.init(
+      [0.4088232360482251,0.29914951760096953,0.2552612533555949,0.08113280407487648,
+   -0.03283479810992292,-0.018577351334051494,-0.0013733172532640688,
+   0.008117622664142014,0.002682386480442547], 
+      [0.5186919867937394,0.4546669273087233,-0.057431691996312643,-0.0048541541888066884,
+   -0.00853841982404364,0.0007461158760058021,0.002057901604696167,0.0008255497724669167,
+   -0.0004372356619719562], 
+      [0.3760062927570685,-0.1469374708776625,-0.1704154003941636,0.02090430542528263,
+   0.01510258354582896,0.028525837271586568,0.015009580468626441,0.004431992972452413,
+   0.004574724100591803]) 
   }
 }
 
-class HueMap < Color {
+class MagmaMap is ChebyshevMap {
   init() {
+    super.init(
+      [0.5907866331910908,0.5512722667670491,-0.11869056394186639,-0.06195808758016048,
+   0.016174879132276762,0.007825552776936756,0.007068023322676562,-0.005405791682135656,
+   -0.004289466821398506,0.0022896263057962762],
+      [0.36985521972760765,0.4798725290845796,0.14385739700946584,0.020144429166912035,
+   -0.01966766336743611,-0.0077647799258502605,-0.0036190850643826634,
+   0.007536496657360997,0.0041760071789883136,-0.008101991902176933],
+      [0.4146808525196039,0.24602997042802613,-0.042495725202417074,0.15341588488121402,
+   0.00805152051307142,-0.02717096384766588,0.00206961352997524,-0.007127547734556673,
+   0.010044740905955626,0.005726967451785381])
   }
-  red(x) {
-    return (sin(2*Pi*(x+1/4))+1)/2
+}
+
+class InfernoMap is ChebyshevMap {
+  init() {
+    super.init(
+      [0.5907686152333599,0.5320419550621178,-0.13225772363892413,-0.05035373817114475,
+   0.020359465701464984,0.008683202802651958,0.013948075520974724,0.0012246769354433988,
+   0.003564440313191328,0.002701158080654896,-0.000037446824389489684],
+      [0.3770580923537784,0.4998367210000978,0.14598165233845511,0.006395013608917966,
+   -0.019063425717928677,-0.006515765659684996,-0.005998826303670322,
+   0.003984370877431411,-0.0008735684997286814,-0.004013362650016195,
+   0.0037589348986688206],
+      [0.28127942085373586,0.10733379064741418,0.007259209326938936,0.23027957313656874,
+   0.05122756917452243,-0.0030648367795109203,-0.009391178685969673,-0.02397409152798162,
+   0.0029394603983608457,0.003505946325128027,0.004817080753431645])
   }
-  green(x) {
-    return (sin(2*Pi*x)+1)/2
-  }
-  blue(x) {
-    return (sin(2*Pi*(x-0.4))+1)/2
+}
+
+class PlasmaMap is ChebyshevMap {
+  init() {
+    super.init(
+      [0.6564978820568728,0.4513005610828885,-0.1474582018543978,-0.012551792337212387,
+   -0.008412202382930323,-0.00023645100725124183,-0.0017694446884859137,
+   0.003097797063542014],
+      [0.37647105842658246,0.49541894108110207,0.119596669297474,-0.02693358423260891,
+   0.010579792365637941,0.007309311031239827,-0.011188674500084088,0.004301686509917261],
+      [0.410228609925941,-0.26056803832126973,-0.07193502017900728,0.0713778851634931,
+   0.0007021465182023984,0.00034857192848406334,0.0088834869199995,-0.00152187260983132]
+    )
   }
 }


### PR DESCRIPTION
Improvements to the color module:

A number of additional named colors: Cyan, Orange, Magenta, etc.

Four new ColorMaps MagmaMap, ViridisMap, InfernoMap, PlasmaMap that are derived from efforts to make color vision deficiency friendly schemes [https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html#the-color-scales]

The new color maps are based on chebyshev expansion, and additional maps can easily be added as subclasses of ChebyshevMap.

Documentation updated to reflect the above and improve the coverage of the help.