### PR TITLE
Morphowarning

### DIFF
--- a/morpho5/utils/error.c
+++ b/morpho5/utils/error.c
@@ -119,7 +119,7 @@ void morpho_writeusererror(error *err, errorid id, char *message) {
     err->id=id;
     size_t length = strlen(message);
     if (length>MORPHO_ERRORSTRINGSIZE-1) length = MORPHO_ERRORSTRINGSIZE-1;
-    strncpy(err->msg, message, length);
+    memcpy(err->msg, message, length);
     err->msg[length]='\0'; // Ensure null termination
 }
 


### PR DESCRIPTION
A small warning during the compilation of Morpho (see snapshot attached) is eliminated by replacing `strncpy` with `memcpy` (see [here](https://stackoverflow.com/a/56782476) for an explanation.
![morphocompilewarning](https://user-images.githubusercontent.com/16670570/192304939-d46d1427-abee-4527-9ec6-ad7dabeeb195.png)
