### PR TITLE
Simple Profiler

### DIFF
--- a/morpho5/Makefile.linux
+++ b/morpho5/Makefile.linux
@@ -6,7 +6,7 @@ MODULESDIR = /usr/local/share/morpho/modules
 help = $(wildcard docs/*.md)
 modules = $(wildcard modules/*)
 
-LDFLAGS  = -lm -lblas -llapacke -lcxsparse
+LDFLAGS  = -lm -lblas -llapacke -lcxsparse -lpthread
 CFLAGS   = -std=c99 -O3 -I. -I/usr/include/suitesparse -I./datastructures -I./geometry -I./interface -I./utils -I./vm -I./builtin
 
 morpho5: $(obj)

--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -167,6 +167,9 @@
 /** @brief Diagnose opcode usage */
 //#define MORPHO_OPCODE_USAGE
 
+/** @brief Buiild with profile support */
+#define MORPHO_PROFILER
+
 /* **********************************************************************
 * UI
 * ********************************************************************** */

--- a/morpho5/builtin/builtin.c
+++ b/morpho5/builtin/builtin.c
@@ -49,6 +49,7 @@ static void builtin_init(objectbuiltinfunction *func) {
     func->flags=BUILTIN_FLAGSEMPTY;
     func->function=NULL;
     func->name=MORPHO_NIL;
+    func->klass=NULL;
 }
 
 /** @brief An enumerate loop.
@@ -215,6 +216,7 @@ value builtin_addclass(char *name, builtinclassentry desc[], value superclass) {
             objectbuiltinfunction *method = (objectbuiltinfunction *) object_new(sizeof(objectbuiltinfunction), OBJECT_BUILTINFUNCTION);
             builtin_init(method);
             method->function=desc[i].function;
+            method->klass=new;
             method->name=object_stringfromcstring(desc[i].name, strlen(desc[i].name));
             method->flags=desc[i].flags;
             

--- a/morpho5/builtin/builtin.h
+++ b/morpho5/builtin/builtin.h
@@ -35,6 +35,7 @@ typedef struct  {
     value name;
     builtinfunctionflags flags;
     builtinfunction function;
+    objectclass *klass; 
 } objectbuiltinfunction;
 
 /** Gets an objectfunction from a value */

--- a/morpho5/datastructures/object.c
+++ b/morpho5/datastructures/object.c
@@ -196,6 +196,7 @@ objectfunction *object_newfunction(indx entry, value name, objectfunction *paren
         new->nargs=nargs;
         new->varg=-1; // No vargs
         new->parent=parent;
+        new->klass=NULL; 
         varray_optionalparaminit(&new->opt);
     }
     

--- a/morpho5/datastructures/object.h
+++ b/morpho5/datastructures/object.h
@@ -119,6 +119,33 @@ DECLARE_VARRAY(upvalue, upvalue)
 DECLARE_VARRAY(varray_upvalue, varray_upvalue)
 
 /* ---------------------------
+ * Classes
+ * --------------------------- */
+
+extern objecttype objectclasstype;
+#define OBJECT_CLASS objectclasstype
+
+typedef struct sobjectclass {
+    object obj;
+    struct sobjectclass *superclass;
+    value name;
+    dictionary methods;
+} objectclass;
+
+/** Tests whether an object is a class */
+#define MORPHO_ISCLASS(val) object_istype(val, OBJECT_CLASS)
+
+/** Gets the object as a class */
+#define MORPHO_GETCLASS(val)   ((objectclass *) MORPHO_GETOBJECT(val))
+
+/** Gets the superclass */
+#define MORPHO_GETSUPERCLASS(val)   (MORPHO_GETCLASS(val)->superclass)
+
+objectclass *object_newclass(value name);
+
+objectclass *morpho_lookupclass(value obj);
+
+/* ---------------------------
  * Functions
  * --------------------------- */
 
@@ -143,6 +170,7 @@ typedef struct sobjectfunction {
     struct sobjectfunction *parent;
     int nupvalues;
     int nregs;
+    objectclass *klass; 
     varray_value konst;
     varray_varray_upvalue prototype;
     varray_optionalparam opt;
@@ -211,33 +239,6 @@ objectclosure *object_newclosure(objectfunction *sf, objectfunction *func, indx 
 
 /** Retrieve the function object from a closure */
 #define MORPHO_GETCLOSUREFUNCTION(val)  (((objectclosure *) MORPHO_GETOBJECT(val))->func)
-
-/* ---------------------------
- * Classes
- * --------------------------- */
-
-extern objecttype objectclasstype;
-#define OBJECT_CLASS objectclasstype
-
-typedef struct sobjectclass {
-    object obj;
-    struct sobjectclass *superclass;
-    value name;
-    dictionary methods;
-} objectclass;
-
-/** Tests whether an object is a class */
-#define MORPHO_ISCLASS(val) object_istype(val, OBJECT_CLASS)
-
-/** Gets the object as a class */
-#define MORPHO_GETCLASS(val)   ((objectclass *) MORPHO_GETOBJECT(val))
-
-/** Gets the superclass */
-#define MORPHO_GETSUPERCLASS(val)   (MORPHO_GETCLASS(val)->superclass)
-
-objectclass *object_newclass(value name);
-
-objectclass *morpho_lookupclass(value obj);
 
 /* ---------------------------
  * Instances

--- a/morpho5/interface/cli.c
+++ b/morpho5/interface/cli.c
@@ -321,7 +321,11 @@ void cli_run(const char *in, clioptions opt) {
                 }
             }
             if (opt & CLI_RUN) {
-                success=morpho_run(v, p);
+                if (opt & CLI_PROFILE) {
+                    success=morpho_profile(v, p);
+                } else {
+                    success=morpho_run(v, p);
+                }
                 if (!success) cli_reporterror(morpho_geterror(v), v);
             }
         } else {

--- a/morpho5/interface/cli.h
+++ b/morpho5/interface/cli.h
@@ -36,6 +36,7 @@
 #define CLI_DISASSEMBLE         0x2
 #define CLI_DISASSEMBLESHOWSRC  0x4
 #define CLI_DEBUG               0x8
+#define CLI_PROFILE             0x10
 
 typedef unsigned int clioptions;
 

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -39,7 +39,11 @@ int main(int argc, const char * argv[]) {
                     }
                     break;
                 case 'p':
-                    opt |= CLI_PROFILE;
+#ifdef MORPHO_PROFILER
+                    if (strncmp(option+1, "profile", strlen("profile"))==0) {
+                        opt |= CLI_PROFILE;
+                    }
+#endif
                     break;
             }
         } else {

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -38,6 +38,9 @@ int main(int argc, const char * argv[]) {
                         }
                     }
                     break;
+                case 'p':
+                    opt |= CLI_PROFILE;
+                    break;
             }
         } else {
             file = option;

--- a/morpho5/modules/graphics.morpho
+++ b/morpho5/modules/graphics.morpho
@@ -688,19 +688,20 @@ class Show {
     } else if (isobject(col) && !islist(col)) col = col.rgb(0)
 
     out.write("v \"xnc\"")
-    for (var i=0; i<nv; i+=1) {
-      for (var j=0; j<dim; j+=1) {
-        out.write("${x[j,i]} ")
+    for (i in 0...nv) {
+      var line = ""
+      for (j in 0...dim) {
+        line+="${x[j,i]} "
       }
-      for (var j=0; j<dim; j+=1) {
-        out.write("${n[j,i]} ")
+      for (j in 0...dim) {
+        line+="${n[j,i]} "
       }
       if (localcolor) {
-        for (var j=0; j<3; j+=1) out.write("${col[j,i]} ")
+        for (j in 0...3) line+="${col[j,i]} "
       } else {
-        var count = item.colors.count()
-        for (var j=0; j<count; j+=1) out.write("${col[j]} ")
+        for (j in 0...item.colors.count()) line+="${col[j]} "
       }
+      out.write(line)
     }
 
     out.write("f")
@@ -709,11 +710,11 @@ class Show {
     var nf=f.dimensions()[1]
 
     for (i in 0...nf) {
-      //var line = ""
+      var line = ""
       for (j in 0...nv) {
-        if (f[j,i]!=0) out.write("${j} ")
+        if (f[j,i]!=0) line+="${j} "
       }
-      //out.write(line)
+      out.write(line)
     }
   }
 

--- a/morpho5/modules/graphics.morpho
+++ b/morpho5/modules/graphics.morpho
@@ -688,20 +688,19 @@ class Show {
     } else if (isobject(col) && !islist(col)) col = col.rgb(0)
 
     out.write("v \"xnc\"")
-    for (i in 0...nv) {
-      var line = ""
-      for (j in 0...dim) {
-        line+="${x[j,i]} "
+    for (var i=0; i<nv; i+=1) {
+      for (var j=0; j<dim; j+=1) {
+        out.write("${x[j,i]} ")
       }
-      for (j in 0...dim) {
-        line+="${n[j,i]} "
+      for (var j=0; j<dim; j+=1) {
+        out.write("${n[j,i]} ")
       }
       if (localcolor) {
-        for (j in 0...3) line+="${col[j,i]} "
+        for (var j=0; j<3; j+=1) out.write("${col[j,i]} ")
       } else {
-        for (j in 0...item.colors.count()) line+="${col[j]} "
+        var count = item.colors.count()
+        for (var j=0; j<count; j+=1) out.write("${col[j]} ")
       }
-      out.write(line)
     }
 
     out.write("f")
@@ -710,11 +709,11 @@ class Show {
     var nf=f.dimensions()[1]
 
     for (i in 0...nf) {
-      var line = ""
+      //var line = ""
       for (j in 0...nv) {
-        if (f[j,i]!=0) line+="${j} "
+        if (f[j,i]!=0) out.write("${j} ")
       }
-      out.write(line)
+      //out.write(line)
     }
   }
 

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -134,6 +134,7 @@ void morpho_resetentry(program *p);
 
 /* Interpreting */
 bool morpho_run(vm *v, program *p);
+bool morpho_profile(vm *v, program *p);
 bool morpho_lookupmethod(value obj, value label, value *method);
 bool morpho_countparameters(value f, int *nparams);
 bool morpho_call(vm *v, value fn, int nargs, value *args, value *ret);

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -2361,6 +2361,9 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
     
     objectfunction *func = object_newfunction(bindx+1, node->content, compiler_getcurrentfunction(c), 0);
     
+    /* Record the class if a method */
+    if (ismethod) func->klass=compiler_getcurrentclass(c);
+    
     /* Add the function as a constant */
     kindx=compiler_addconstant(c, node, MORPHO_OBJECT(func), false, false);
     

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -266,6 +266,7 @@ struct svm {
     
 #ifdef MORPHO_PROFILER
     profiler *profiler;
+    enum { VM_RUNNING, VM_INGC } status; 
 #endif
     
     objectupvalue *openupvalues; /** Linked list of open upvalues */

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -136,7 +136,10 @@ typedef struct {
     instruction *pc;
     unsigned int stackcount;
     unsigned int returnreg; // Stores where any return value should be placed
-    bool ret; // Should the interpreter return from this frame? 
+    bool ret; // Should the interpreter return from this frame?
+#ifdef MORPHO_PROFILER
+    objectbuiltinfunction *inbuiltinfunction; // Keep track if we're in a built in function
+#endif
 } callframe;
 
 /* **********************************************************************
@@ -205,6 +208,24 @@ struct sprogram {
 };
 
 /* **********************************************************************
+ * Profiler
+ * ********************************************************************** */
+
+#ifdef MORPHO_PROFILER
+#include <pthread.h>
+/** @brief Morpho profiler */
+typedef struct {
+    pthread_t profiler;
+    bool profiler_quit;
+    pthread_mutex_t profile_lock;
+    dictionary profile_dict;
+    clock_t start;
+    clock_t end;
+    program *program; 
+} profiler;
+#endif
+
+/* **********************************************************************
  * Virtual machines
  * ********************************************************************** */
 
@@ -242,6 +263,10 @@ struct svm {
     size_t nextgc; /** Next garbage collection threshold */
     
     bool debug; /** Is the debugger active or not */
+    
+#ifdef MORPHO_PROFILER
+    profiler *profiler;
+#endif
     
     objectupvalue *openupvalues; /** Linked list of open upvalues */
 };

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2055,7 +2055,7 @@ size_t profiler_calculatelength(profiler *p, value func) {
         if (MORPHO_ISSTRING(name)) {
             length+=MORPHO_GETSTRINGLENGTH(name);
         } else if (MORPHO_ISNIL(name)) {
-            if (func==MORPHO_OBJECT(p->program->global)) length+=strlen(PROFILER_GLOBAL);
+            if (MORPHO_ISSAME(func, MORPHO_OBJECT(p->program->global))) length+=strlen(PROFILER_GLOBAL);
             else length+=strlen(PROFILER_ANON);
         }
                  
@@ -2077,7 +2077,7 @@ void profiler_display(profiler *p, value func) {
         if (MORPHO_ISSTRING(name)) {
             morpho_printvalue(name);
         } else if (MORPHO_ISNIL(name)) {
-            if (func==MORPHO_OBJECT(p->program->global)) printf(PROFILER_GLOBAL);
+            if (MORPHO_ISSAME(func, MORPHO_OBJECT(p->program->global))) printf(PROFILER_GLOBAL);
             else printf(PROFILER_ANON);
         }
     }

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2119,6 +2119,12 @@ bool morpho_profile(vm *v, program *p) {
     return success;
 }
 
+#else
+
+bool morpho_profile(vm *v, program *p) {
+    return morpho_run(v, p);
+}
+
 #endif
 
 /* **********************************************************************


### PR DESCRIPTION
Implements a simple profiler: A second thread watches the VM as it continues and logs the current function from the call frame. There's little to no overhead for this. The output is a histogram of samples indicating where the program is spending its time. 

To use, run morpho with the -profile flag. The profile info is output after execution is finished. 