### PR TITLE
Dictionary improvements and fix

### DIFF
--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -1445,7 +1445,7 @@ value dictionary_constructor(vm *v, int nargs, value *args) {
     return out;
 }
 
-/** Sets a dictionary entry */
+/** Gets a dictionary entry */
 value Dictionary_getindex(vm *v, int nargs, value *args) {
     objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args));
     value out=MORPHO_NIL;
@@ -1459,7 +1459,7 @@ value Dictionary_getindex(vm *v, int nargs, value *args) {
     return out;
 }
 
-/** Gets a dictionary entry */
+/** Sets a dictionary entry */
 value Dictionary_setindex(vm *v, int nargs, value *args) {
     objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args));
     
@@ -1474,7 +1474,7 @@ value Dictionary_setindex(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
-/** Sets a dictionary entry */
+/** Returns a Bool value for whether the Dictionary contains a given key */
 value Dictionary_contains(vm *v, int nargs, value *args) {
     objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args));
     value out=MORPHO_FALSE;
@@ -1484,6 +1484,17 @@ value Dictionary_contains(vm *v, int nargs, value *args) {
     }
     
     return out;
+}
+
+/** Removes a dictionary entry with a given key */
+value Dictionary_remove(vm *v, int nargs, value *args) {
+    objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args));
+    
+    if (nargs==1) {
+        dictionary_remove(&slf->dict, MORPHO_GETARG(args, 0));
+    }
+    
+    return MORPHO_NIL;
 }
 
 /** Prints a dictionary */
@@ -1572,6 +1583,15 @@ value Dictionary_clone(vm *v, int nargs, value *args) {
     return out;
 }
 
+/** Clears a Dictionary */
+value Dictionary_clear(vm *v, int nargs, value *args) {
+    objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args));
+    
+    dictionary_clear(&slf->dict);
+    
+    return MORPHO_NIL;
+}
+
 #define DICTIONARY_SETOP(op) \
 value Dictionary_##op(vm *v, int nargs, value *args) { \
     objectdictionary *slf = MORPHO_GETDICTIONARY(MORPHO_SELF(args)); \
@@ -1599,6 +1619,8 @@ MORPHO_BEGINCLASS(Dictionary)
 MORPHO_METHOD(MORPHO_GETINDEX_METHOD, Dictionary_getindex, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_SETINDEX_METHOD, Dictionary_setindex, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(DICTIONARY_CONTAINS_METHOD, Dictionary_contains, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(DICTIONARY_REMOVE_METHOD, Dictionary_remove, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(DICTIONARY_CLEAR_METHOD, Dictionary_clear, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_PRINT_METHOD, Dictionary_print, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_COUNT_METHOD, Dictionary_count, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_ENUMERATE_METHOD, Dictionary_enumerate, BUILTIN_FLAGSEMPTY),

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -40,6 +40,8 @@
 
 #define DICTIONARY_KEYS_METHOD "keys"
 #define DICTIONARY_CONTAINS_METHOD "contains"
+#define DICTIONARY_REMOVE_METHOD "remove"
+#define DICTIONARY_CLEAR_METHOD "clear"
 
 #define RANGE_ARGS                        "RngArgs"
 #define RANGE_ARGS_MSG                    "Range expects numerical arguments: a start, an end and an optional stepsize."

--- a/morpho5/datastructures/dictionary.c
+++ b/morpho5/datastructures/dictionary.c
@@ -273,7 +273,9 @@ static bool dictionary_find(dictionary *dict, value key, bool intern, dictionary
         if (MORPHO_ISNIL(e->key)) {
             if (MORPHO_ISEQUAL(e->val, DICTIONARY_TOMBSTONEVALUE)) {
                 if (!tombstone) tombstone = e; /* We found a tombstone */
-            } else {
+                *entry = (tombstone ? tombstone : e);
+            }
+            else {
                 /* Otherwise, this is an empty slot. Return this, or the tombstone */
                 *entry = (tombstone ? tombstone : e);
                 return false;

--- a/morpho5/datastructures/dictionary.c
+++ b/morpho5/datastructures/dictionary.c
@@ -312,12 +312,10 @@ static inline bool _dictionary_insert(dictionary *dict, value key, value val, bo
             return true;
         } else {
             /* Entry doesn't exist, */
-            if (entry) {
-                entry->key=key;
-                entry->val=val;
-                dict->count++;
-                return true;
-            }
+            entry->key=key;
+            entry->val=val;
+            dict->count++;
+            return true;
         }
     }
     

--- a/morpho5/datastructures/dictionary.c
+++ b/morpho5/datastructures/dictionary.c
@@ -274,8 +274,7 @@ static bool dictionary_find(dictionary *dict, value key, bool intern, dictionary
             if (MORPHO_ISEQUAL(e->val, DICTIONARY_TOMBSTONEVALUE)) {
                 if (!tombstone) tombstone = e; /* We found a tombstone */
                 *entry = (tombstone ? tombstone : e);
-            }
-            else {
+            } else {
                 /* Otherwise, this is an empty slot. Return this, or the tombstone */
                 *entry = (tombstone ? tombstone : e);
                 return false;

--- a/morpho5/docs/dictionary.md
+++ b/morpho5/docs/dictionary.md
@@ -27,3 +27,25 @@ Create an empty dictionary using the `Dictionary` constructor function:
 Loop over keys in a dictionary:
 
     for (k in dict) print k
+
+The `keys` method returns a Morpho List of the keys.
+
+    var keys = dict.keys() // will return ["Massachusetts", "New York", "Vermont"]
+
+The `contains` method returns a Bool value for whether the Dictionary
+contains a given key.
+
+    print dict.contains("Vermont") // true
+    print dict.contains("New Hampshire") // false
+
+The `remove` method removes a given key from the Dictionary.
+
+    dict.remove("Vermont")
+    print dict // { New York : Albany, Massachusetts : Boston }
+
+The `clear` method removes all the (key, value) pairs fromt the
+dictionary, resulting in an empty dictionary. 
+
+    dict.clear()
+
+    print dict // {  }

--- a/test/dictionary/clear.morpho
+++ b/test/dictionary/clear.morpho
@@ -1,0 +1,8 @@
+// Test Dictionary clear method
+
+var mass = { "Capital" : "Boston", "Population" : 6892503 }
+
+mass.clear()
+
+mass["Abbreviation"] = "MA"
+print mass // expect: { Abbreviation : MA }

--- a/test/dictionary/remove.morpho
+++ b/test/dictionary/remove.morpho
@@ -1,0 +1,7 @@
+// Test Dictionary remove method
+
+var mass = { "Capital" : "Boston", "Population" : 6892503 }
+
+mass.remove("Capital")
+
+print mass // expect: { Population : 6892503 }

--- a/test/dictionary/tombstone.morpho
+++ b/test/dictionary/tombstone.morpho
@@ -1,0 +1,31 @@
+// This test makes sure that dictionary insertion happens even if there
+// are only tombstones and no blank entries left.
+
+var d = Dictionary()
+
+var N = 16 // This is chosen because it's the minimum and defualt capacity of the Morpho dictionary.
+
+var n = floor(0.75*N) // This is the maximum number of entries that can be added to the dictionary  without triggering a resize to 2*N
+
+// Add n items
+var key 
+for (i in 1..n) {
+    key = "${i}"
+    d[key] = i
+}
+
+// Now, remove a single key, followed by addition of another key, for
+// all these keys. This triggers a situation at i=n-1 that all the blank
+// entries have been replaced with tombstones. The old
+// implementation of dictionary_find returns a NULL pointer for entry,
+// and _dictionary_insert in turn doesn't handle that scenario. Hence,
+// the last assignment of d[newkey] fails silently. The current
+// implementation should handle this scenario.
+var newkey
+for (i in 1..n) {
+    key = "${i}"
+    d.remove(key)
+    newkey = "new_${i}"
+    d[newkey] = i
+}
+print d[newkey] // expect: 12


### PR DESCRIPTION
* `clear` and `remove` methods added to the Morpho Dictionary object
* Updated docs and added new corresponding tests
* Small comment fixes
* Possible fix for a tombstone-related bug

The `clear` method is useful when you need a new blank dictionary inside a loop, avoiding the creation of a new Dictionary object every time. The combination of `remove` and `clear` could be very useful (if the bug is fixed) in accelerating the delaunay / meshgen modules.

I have also attempted to fix a rather tricky bug which was resulting in the silent failing of dictionary insertion when enough remove and add operations have been performed. I am not sure whether my fix is the right one. I have added a test for it, and all the other tests are passing.

What's happening in the current implementation is that `_dictionary_insert` (dictionary.c:297) silently fails if `dictionary_find` doesn't assign a value to `entry` (the `else` case for dictionary.c:314 is not handled). `dictionary_find` currently doesn't assign a value to `entry` if there are no blank entries and only tombstones. This is the part I am not sure of, and my fix is to assign the tombstone value in that case. I think `entry` should always be assigned a value, and the check at  dictionary.c:314 should be unnecessary, but I might be wrong.