### PR TITLE
New hydrogel_gradient that works in any dimension

### DIFF
--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -709,9 +709,23 @@ bool functional_elementsize(vm *v, objectmesh *mesh, grade g, elementid id, int 
     return false;
 }
 
+bool length_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale);
+bool area_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale);
+bool volume_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale);
+
 bool length_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc);
 bool area_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc);
 bool volume_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc);
+
+/** Calculate a scaled element gradient */
+bool functional_elementgradient_scale(vm *v, objectmesh *mesh, grade g, elementid id, int nv, int *vid, objectmatrix *frc, double scale) {
+    switch (g) {
+        case 1: return length_gradient_scale(v, mesh, id, nv, vid, NULL, frc, scale);
+        case 2: return area_gradient_scale(v, mesh, id, nv, vid, NULL, frc, scale);
+        case 3: return volume_gradient_scale(v, mesh, id, nv, vid, NULL, frc, scale);
+    }
+    return false;
+}
 
 /** Calculate element gradient */
 bool functional_elementgradient(vm *v, objectmesh *mesh, grade g, elementid id, int nv, int *vid, objectmatrix *frc) {
@@ -810,8 +824,8 @@ bool length_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, v
     return true;
 }
 
-/** Calculate gradient */
-bool length_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+/** Calculate scaled gradient */
+bool length_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale) {
     double *x[nv], s0[mesh->dim], norm;
     for (int j=0; j<nv; j++) matrix_getcolumn(mesh->vert, vid[j], &x[j]);
 
@@ -819,10 +833,15 @@ bool length_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, vo
     norm=functional_vecnorm(mesh->dim, s0);
     if (norm<MORPHO_EPS) return false;
 
-    matrix_addtocolumn(frc, vid[0], -1.0/norm, s0);
-    matrix_addtocolumn(frc, vid[1], 1./norm, s0);
+    matrix_addtocolumn(frc, vid[0], -1.0/norm*scale, s0);
+    matrix_addtocolumn(frc, vid[1], 1./norm*scale, s0);
 
     return true;
+}
+
+/** Calculate gradient */
+bool length_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+    return length_gradient_scale(v, mesh, id, nv, vid, NULL, frc, 1.0); 
 }
 
 FUNCTIONAL_INIT(Length, MESH_GRADE_LINE)
@@ -901,8 +920,8 @@ bool area_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, voi
     return true;
 }
 
-/** Calculate gradient */
-bool area_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+/** Calculate scaled gradient */
+bool area_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale) {
     double *x[nv], s0[3], s1[3], s01[3], s010[3], s011[3];
     double norm;
     for (int j=0; j<nv; j++) matrix_getcolumn(mesh->vert, vid[j], &x[j]);
@@ -917,14 +936,19 @@ bool area_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void
     functional_veccross(s01, s0, s010);
     functional_veccross(s01, s1, s011);
 
-    matrix_addtocolumn(frc, vid[0], 0.5/norm, s011);
-    matrix_addtocolumn(frc, vid[2], 0.5/norm, s010);
+    matrix_addtocolumn(frc, vid[0], 0.5/norm*scale, s011);
+    matrix_addtocolumn(frc, vid[2], 0.5/norm*scale, s010);
 
     functional_vecadd(mesh->dim, s010, s011, s0);
 
-    matrix_addtocolumn(frc, vid[1], -0.5/norm, s0);
+    matrix_addtocolumn(frc, vid[1], -0.5/norm*scale, s0);
 
     return true;
+}
+
+/** Calculate gradient */
+bool area_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+    return area_gradient_scale(v, mesh, id, nv, vid, NULL, frc, 1.0); 
 }
 
 FUNCTIONAL_INIT(Area, MESH_GRADE_AREA)
@@ -1005,8 +1029,8 @@ bool volume_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, v
     return true;
 }
 
-/** Calculate gradient */
-bool volume_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+/** Calculate scaled gradient */
+bool volume_gradient_scale(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc, double scale) {
     double *x[nv], s10[mesh->dim], s20[mesh->dim], s30[mesh->dim];
     double s31[mesh->dim], s21[mesh->dim], cx[mesh->dim], uu;
     for (int j=0; j<nv; j++) matrix_getcolumn(mesh->vert, vid[j], &x[j]);
@@ -1021,18 +1045,23 @@ bool volume_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, vo
     uu=functional_vecdot(mesh->dim, s10, cx);
     uu=(uu>0 ? 1.0 : -1.0);
 
-    matrix_addtocolumn(frc, vid[1], uu/6.0, cx);
+    matrix_addtocolumn(frc, vid[1], uu/6.0*scale, cx);
 
     functional_veccross(s31, s21, cx);
-    matrix_addtocolumn(frc, vid[0], uu/6.0, cx);
+    matrix_addtocolumn(frc, vid[0], uu/6.0*scale, cx);
 
     functional_veccross(s30, s10, cx);
-    matrix_addtocolumn(frc, vid[2], uu/6.0, cx);
+    matrix_addtocolumn(frc, vid[2], uu/6.0*scale, cx);
 
     functional_veccross(s10, s20, cx);
-    matrix_addtocolumn(frc, vid[3], uu/6.0, cx);
+    matrix_addtocolumn(frc, vid[3], uu/6.0*scale, cx);
 
     return true;
+}
+
+/** Calculate gradient */
+bool volume_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, objectmatrix *frc) {
+    return volume_gradient_scale(v, mesh, id, nv, vid, NULL, frc, 1.0); 
 }
 
 FUNCTIONAL_INIT(Volume, MESH_GRADE_VOLUME)
@@ -1511,11 +1540,9 @@ bool hydrogel_gradient(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, 
             info->c * phi*phi +
             info->d * (pr/phi0) * ((phi/pr)/3.0 - (2.0/3) * pow((phi/pr), (1.0/3)) ) );
 
-    // Compute element gradient
-    if (!functional_elementgradient(v, mesh, info->grade, id, nv, vid, frc)) return false;
+    // Compute grad * element gradient
+    if (!functional_elementgradient_scale(v, mesh, info->grade, id, nv, vid, frc, grad)) return false;
 
-    // Multiply by the integrand gradient
-    matrix_scale(frc, grad);
     return true;
 }
 

--- a/test/functionals/hydrogel/hydrogel1D.morpho
+++ b/test/functionals/hydrogel/hydrogel1D.morpho
@@ -1,0 +1,55 @@
+// Hydrogel mixing energy in 1D (modeled from Flory-Rehner theory)
+import meshtools 
+
+var mb = MeshBuilder()
+
+mb.addvertex(Matrix([-1/2,0,0]))
+mb.addvertex(Matrix([1/2,0,0]))
+mb.addedge([0,1])
+var m0 = mb.build()
+
+var vol0 = Length().total(m0)
+var phi0 = 0.5
+var phiref = 0.1
+var a = 0.1
+var b = 1.0
+var c = 0.25
+var d = 1.0
+var lh = Hydrogel(m0,
+                  a = a,
+                  b = b,
+                  c = c,
+                  d = d,
+                  phiref=phiref,
+                  phi0=phi0)
+
+var m = mb.build()
+// Expand m by a linear factor
+var f = 1.2
+var vert = m.vertexmatrix()
+for (i in 0...m.count()) m.setvertexposition(i, f*vert.column(i))
+
+var phi = phi0/(f) // New phi will be inversely proportional to the length
+var vol = vol0 * f
+
+
+var e1 = vol * (a*phi*log(phi) + b*(1-phi)*log((1-phi)) + c*phi*(1-phi))
+var e2 = vol0 * d * ( log(phiref/phi)/3 - (phiref/phi)^(2/3) + 1 )
+var expected = e1 + e2
+
+var tol = 1e-6
+print abs(lh.integrand(m)[0]-expected)<tol
+// expect: true
+
+print abs(lh.total(m)-expected)<tol
+// expect: true
+
+var grad = (-a * phi + b * ( phi + log(1-phi) ) + c * phi*phi +
+            d * (phiref/phi0) * ((phi/phiref)/3.0 - (2.0/3) * (phi/phiref)^(1.0/3) ) )
+
+var lengthgrad = Length().gradient(m)
+
+expected = grad * lengthgrad
+
+print (lh.gradient(m)-expected).norm()<tol
+// expect: true

--- a/test/functionals/hydrogel/hydrogel1D_2elements.morpho
+++ b/test/functionals/hydrogel/hydrogel1D_2elements.morpho
@@ -1,0 +1,42 @@
+// Hydrogel mixing energy in 1D for a mesh with 2 segments (modeled from
+// Flory-Rehner theory)
+// Testing whether elementwise scaling by the gradient works
+import meshtools 
+
+var mb = MeshBuilder()
+
+mb.addvertex(Matrix([-0.6,0.1,0.3]))
+mb.addvertex(Matrix([0.2,-0.2,-0.1]))
+mb.addvertex(Matrix([1/2,0.3,0.1]))
+mb.addedge([0,1])
+mb.addedge([0,2])
+var m0 = mb.build()
+
+var vol0 = Length().total(m0)
+var phi0 = 0.5
+var phiref = 0.1
+var a = 0.1
+var b = 1.0
+var c = 0.25
+var d = 1.0
+var lh = Hydrogel(m0,
+                  a = a,
+                  b = b,
+                  c = c,
+                  d = d,
+                  phiref=phiref,
+                  phi0=phi0)
+
+var m = mb.build()
+// Expand m by a linear factor
+var f = 1.2
+var vert = m.vertexmatrix()
+for (i in 0...m.count()) m.setvertexposition(i, f*vert.column(i))
+
+var expected = Matrix([[ 0.10421, -0.0486482, -0.0555622 ],
+                       [ -0.00814071, 0.0182433, -0.0101026 ],
+                       [ -0.0344261, 0.0243235, 0.0101026 ]])
+
+var tol = 1e-5
+print (lh.gradient(m)-expected).norm()<tol
+// expect: true

--- a/test/functionals/hydrogel/hydrogel2D.morpho
+++ b/test/functionals/hydrogel/hydrogel2D.morpho
@@ -1,0 +1,60 @@
+// Hydrogel mixing energy in 2D (modeled from Flory-Rehner theory)
+import meshtools 
+
+var mb = MeshBuilder()
+
+mb.addvertex(Matrix([-1/2,0,0]))
+mb.addvertex(Matrix([1/2,0,0]))
+mb.addvertex(Matrix([0,sqrt(3)/2,0]))
+mb.addedge([0,1])
+mb.addedge([1,2])
+mb.addedge([2,0])
+mb.addface([0,1,2])
+
+var m0 = mb.build()
+
+var vol0 = Area().total(m0)
+var phi0 = 0.5
+var phiref = 0.1
+var a = 0.1
+var b = 1.0
+var c = 0.25
+var d = 1.0
+var lh = Hydrogel(m0,
+                  a = a,
+                  b = b,
+                  c = c,
+                  d = d,
+                  phiref=phiref,
+                  phi0=phi0)
+
+var m = mb.build()
+// Expand m by a linear factor
+var f = 1.2
+var vert = m.vertexmatrix()
+for (i in 0...m.count()) m.setvertexposition(i, f*vert.column(i))
+
+var phi = phi0/(f^2) // New phi will be inversely proportional to the area
+var vol = vol0 * f^2
+
+
+var e1 = vol * (a*phi*log(phi) + b*(1-phi)*log((1-phi)) + c*phi*(1-phi))
+var e2 = vol0 * d * ( log(phiref/phi)/3 - (phiref/phi)^(2/3) + 1 )
+var expected = e1 + e2
+
+var tol = 1e-6
+print abs(lh.integrand(m)[0]-expected)<tol
+// expect: true
+
+print abs(lh.total(m)-expected)<tol
+// expect: true
+
+var grad = (-a * phi + b * ( phi + log(1-phi) ) + c * phi*phi +
+            d * (phiref/phi0) * ((phi/phiref)/3.0 - (2.0/3) * (phi/phiref)^(1.0/3) ) )
+
+var areagrad = Area().gradient(m)
+
+expected = grad * areagrad
+
+print (lh.gradient(m)-expected).norm()<tol
+// expect: true

--- a/test/functionals/hydrogel/hydrogel2D_2elements.morpho
+++ b/test/functionals/hydrogel/hydrogel2D_2elements.morpho
@@ -1,0 +1,48 @@
+// Hydrogel mixing energy in 2D for a mesh with 2 facets (modeled from
+// Flory-Rehner theory)
+// Testing whether elementwise scaling by the gradient works
+import meshtools 
+
+var mb = MeshBuilder()
+
+mb.addvertex(Matrix([-1/2 ,0.1,0.1]))
+mb.addvertex(Matrix([0.6,-0.07,0]))
+mb.addvertex(Matrix([0,0.76,-0.2]))
+mb.addvertex(Matrix([0.25,-0.4,0.05]))
+mb.addedge([0,1])
+mb.addedge([1,2])
+mb.addedge([2,0])
+mb.addedge([3,0])
+mb.addedge([3,1])
+mb.addface([0,1,2])
+mb.addface([0,1,3])
+
+var m0 = mb.build()
+
+var vol0 = Area().total(m0)
+var phi0 = 0.5
+var phiref = 0.1
+var a = 0.1
+var b = 1.0
+var c = 0.25
+var d = 1.0
+var lh = Hydrogel(m0,
+                  a = a,
+                  b = b,
+                  c = c,
+                  d = d,
+                  phiref=phiref,
+                  phi0=phi0)
+
+var m = m0.clone()
+var f = 1.2
+var vert = m.vertexmatrix()
+for (i in 0...m.count()) m.setvertexposition(i, f*vert.column(i))
+
+var expected = Matrix([[ 0.0381971, -0.0394159, -0.00413374, 0.0053525 ],
+                       [ 0.00593282, -0.00787234, -0.0340045, 0.035944 ],
+                       [ -0.0104877, 0.000378424, 0.0123365, -0.00222724 ]])
+var tol = 1e-6
+
+print (lh.gradient(m)-expected).norm()<tol
+// expect: true

--- a/test/functionals/hydrogel/hydrogel3D_2elements.morpho
+++ b/test/functionals/hydrogel/hydrogel3D_2elements.morpho
@@ -1,0 +1,47 @@
+// Hydrogel mixing energy in 2D for a mesh with 2 facets (modeled from
+// Flory-Rehner theory)
+// Testing whether elementwise scaling by the gradient works
+import meshtools 
+
+var mb = MeshBuilder()
+
+mb.addvertex(Matrix([-1/2 ,0.1,0.1]))
+mb.addvertex(Matrix([0.6,-0.07,0]))
+mb.addvertex(Matrix([0,0.76,-0.2]))
+mb.addvertex(Matrix([0.35,0.3,0.85]))
+mb.addvertex(Matrix([0.29,0.34,-0.79]))
+mb.addvolume([0,1,2,3])
+mb.addvolume([0,1,2,4])
+var m0 = mb.build()
+
+m0.addgrade(1)
+m0.addgrade(2)
+
+var vol0 = Volume().total(m0)
+var phi0 = 0.5
+var phiref = 0.1
+var a = 0.1
+var b = 1.0
+var c = 0.25
+var d = 1.0
+var lh = Hydrogel(m0,
+                  a = a,
+                  b = b,
+                  c = c,
+                  d = d,
+                  phiref=phiref,
+                  phi0=phi0)
+
+var m = m0.clone()
+var f = 1.2
+var vert = m.vertexmatrix()
+for (i in 0...m.count()) m.setvertexposition(i, f*vert.column(i))
+
+var tol = 1e-6
+
+var expected = Matrix([[ 0.0186177, -0.0147269, -0.0038909, -0.00160984, 0.00160958 ],
+                       [ 0.0133731, 0.0115293, -0.0249025, -0.0038523, 0.00385234 ],
+                       [ -0.000354994, 0.000820056, -0.000465045, -0.0111579, 0.011158 ]])
+
+print (lh.gradient(m)-expected).norm()<tol
+// expect: true


### PR DESCRIPTION
* New `functional_elementgradient` helper method added. Gradient methods can now be made dimensionally independent easily. 
* The new hydrogel_gradient method is now fixed to work in any dimension
* Added tests for hydrogel in 1D and 2D.

This fixes #174 