### PR TITLE
Delaunay + MeshGen improvements

### DIFF
--- a/morpho5/docs/meshgen.md
+++ b/morpho5/docs/meshgen.md
@@ -39,6 +39,8 @@ There are also a number of properties of a `MeshGen` object that can be set prio
 * `fscale` an internal "pressure"
 * `ttol` how far the vertices are allowed to move before retriangulation
 * `etol` energy tolerance for optimization problem
+* `maxiterations` Maximum number of iterations of minimization +
+  retriangulation (default is 100)
 
 `MeshGen` picks default values that cover a reasonable range of uses.
 

--- a/morpho5/modules/delaunay.morpho
+++ b/morpho5/modules/delaunay.morpho
@@ -85,33 +85,6 @@ class Delaunay {
     return pts
   }
 
-  dedup(ext) { // Removes exterior simplices that appear twice from a list
-    var newext = []
-    var ignore = []
-    var n = ext.count()
-
-    fn issame(l1, l2) {
-      var c = 0 // Count number of elements in common with el
-      for (q in l1) if (l2.ismember(q)) c+=1
-      return (c==l1.count()) // i.e. were all of them in common?
-    }
-
-    for (i in 0...n) {
-      if (ignore.ismember(i)) continue
-      var copy = true
-      for (j in i+1...n) { // Check this simplex against all the remaining ones
-        if (issame(ext[i], ext[j])) {
-          copy=false
-          ignore.append(j)
-        }
-      }
-
-      if (copy) newext.append(ext[i])
-    }
-
-    return newext
-  }
-
   triangulate() { // Create Delaunay triangulation
     var sweep=self.picksweep() // Pick sweep dimension
 
@@ -132,60 +105,72 @@ class Delaunay {
 
     for (x in ssmplx) pts.append(x) // And add to the point cloud
 
-    var open = [Circumsphere(pts, List(n..n+self.dim))], // List of open simplices
-        closed = [] // List of finalized simplices
+    self.open = [Circumsphere(pts, List(n..n+self.dim))]// List of open simplices
+    self.closed = [] // List of finalized simplices
 
     // Incrementally add each point to the mesh
+    self.ext = Dictionary() // Exterior (n-1) simplices
     for (ix in indices) {
-      var ext = [] // Exterior (n-1) simplices
-
+      self.ext.clear()
       // For each open simplex, check to see if the current point is
       // inside its circumsphere. If it is, remove the triangle and add
       // its edges to an edge list.
-      var newopen = []
-      for (smplx in open) {
-        var dx = pts[ix][sweep] - smplx.x[sweep]
+      self.newopen = []
+      var dx, key, e
+      for (smplx in self.open) {
+        dx = pts[ix][sweep] - smplx.x[sweep]
 
         // If this point is to the right of this simplex's circumcircle,
         // then this simplex shouldn't get checked again. Add it to the
         // closed list and don't retain.
         if (dx > 0.0 && dx > smplx.r) {
-          closed.append(smplx)
+          self.closed.append(smplx)
           continue
         }
 
         // If we're outside the circumsphere, skip this simplex.
         if ((pts[ix] - smplx.x).norm() - smplx.r > self.eps) {
-          newopen.append(smplx)
+          self.newopen.append(smplx)
           continue
         }
 
         // Add the simplex's exterior to the exterior list and don't retain.
         // sets() generates sets of order dim from the element e.g. triangles use order 2
-        for (e in smplx.i.sets(self.dim)) ext.append(e)
+        for (e in smplx.i.sets(self.dim)) {
+            // Check if the key already exists. If so, assign a nil
+            // value to the key so that we can ignore it later. Else,
+            // add to dictionary. This removes the need for dedup
+            key = "${e}"
+            if (self.ext.contains(key)) {
+                self.ext.remove(key)
+            }
+            else {
+                self.ext[key] = e
+            }
+        }
       }
-      open = newopen
-
-      ext=self.dedup(ext) // remove any duplicate exterior simplices
+      self.open = self.newopen
 
       // Add a new simplex for each exterior (n-1) simplex.
-      for (e in ext) {
-        e.append(ix) // Include the vertex being added
-        open.append(Circumsphere(pts, e))
+      for (e in self.ext.keys()) {
+        self.extel = self.ext[e]
+        self.extel.append(ix) // Include the vertex being added*
+        self.open.append(Circumsphere(pts, self.extel))
       }
     }
 
     // Copy any remaining open triangles to the closed list
-    for (smplx in open) closed.append(smplx)
+    for (smplx in self.open) self.closed.append(smplx)
 
     // Select all simplices that don't have a vertex from the supersimplex
-    open = []
-    for (smplx in closed) {
-      var record = true
+    self.open = []
+    var record
+    for (smplx in self.closed) {
+      record = true
       for (ix in smplx.i) if (ix>=n) record = false
-      if (record) open.append(smplx.i)
+      if (record) self.open.append(smplx.i)
     }
 
-    return open
+    return self.open
   }
 }

--- a/morpho5/modules/delaunay.morpho
+++ b/morpho5/modules/delaunay.morpho
@@ -137,10 +137,8 @@ class Delaunay {
         // Add the simplex's exterior to the exterior list and don't retain.
         // sets() generates sets of order dim from the element e.g. triangles use order 2
         for (e in smplx.i.sets(self.dim)) {
-            // Check if the key already exists. If so, assign a nil
-            // value to the key so that we can ignore it later. Else,
-            // add to dictionary. This removes the need for dedup
             key = "${e}"
+            // Check if the key already exists. If so, remove the key.
             if (self.ext.contains(key)) {
                 self.ext.remove(key)
             }

--- a/morpho5/modules/meshgen.morpho
+++ b/morpho5/modules/meshgen.morpho
@@ -186,7 +186,6 @@ class MeshGen {
 
     self.stepsize = self.h0/5    // Stepsize for optimizer 
     self.steplimit = self.h0/2   // Steplm for optimizer 
-    if (self.dim>2) { self.stepsize/=2; self.steplimit/=2 }
 
     self.mesh = nil          // Mesh
     self.problem = nil       // Optimization problem
@@ -346,8 +345,19 @@ class MeshGen {
   optimize() { // Perform optimization
     var opt = MGShapeOptimizer(self.problem, self.mesh, ttol=self.ttol*self.h0, localcheck=self.method.ismember("LocalCheck"))
     opt.fix(self.selectbboxpts())
-    opt.stepsize = self.stepsize 
-    opt.steplimit = self.steplimit 
+    // set steplimit such that the first step doesn't take vertices
+    // further than ttol
+
+    // Calculate the initial force
+    var frc = opt.totalforcewithconstraints()
+    var normfrc = frc.norm()
+    // set initial force to be the minimum of the provided steplimit and
+    // the stepsize required to move a distance of ttol
+    opt.steplimit = min(self.steplimit, self.ttol/normfrc)
+    // Similar for stepsize
+    opt.stepsize = min(self.stepsize, self.ttol/normfrc/5)
+    // opt.steplimit = self.steplimit
+    // opt.stepsize = self.stepsize
     opt.etol = self.etol // Use a fairly loose convergence criterion
     opt.quiet = self.quiet
     if (self.method.ismember("FixedStepSize")) {

--- a/morpho5/modules/meshgen.morpho
+++ b/morpho5/modules/meshgen.morpho
@@ -356,8 +356,6 @@ class MeshGen {
     opt.steplimit = min(self.steplimit, self.ttol/normfrc)
     // Similar for stepsize
     opt.stepsize = min(self.stepsize, self.ttol/normfrc/5)
-    // opt.steplimit = self.steplimit
-    // opt.stepsize = self.stepsize
     opt.etol = self.etol // Use a fairly loose convergence criterion
     opt.quiet = self.quiet
     if (self.method.ismember("FixedStepSize")) {


### PR DESCRIPTION
* Delaunay triangulation that uses a Dictionary of exterior simplices instead of a List, thus eliminating the need for deduplication and accelerating the triangulation quite a bit.
* Includes few other small improvements like initializing variables outside a for loop /  making them attributes of the Delaunay object, etc.
* MeshGen's `MGShapeOptimizer` now uses a stepsize and steplimit that doesn't allow initial movement of vertices beyond the tolerance `ttol`. This fixes the failure of the current MeshGen for high resolution meshes.
* Small update to meshgen docs to include `maxiterations`