### PR TITLE
Respondsto

### DIFF
--- a/morpho5/builtin/veneer.c
+++ b/morpho5/builtin/veneer.c
@@ -63,7 +63,22 @@ value Object_respondsto(vm *v, int nargs, value *args) {
     value self = MORPHO_SELF(args);
     objectclass *klass=MORPHO_GETINSTANCE(self)->klass;
 
-    if (nargs==1 &&
+if (nargs == 0) {
+        value out = MORPHO_NIL;
+        objectlist *new = object_newlist(0, NULL);
+        if (new) {
+            list_resize(new, klass->methods.count);
+            for (unsigned int i=0; i<klass->methods.capacity; i++) {
+                if (MORPHO_ISSTRING(klass->methods.contents[i].key)) {
+                    list_append(new, klass->methods.contents[i].key);
+                }
+            }
+            out = MORPHO_OBJECT(new);
+            morpho_bindobjects(v, 1, &out);
+        } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
+        return out;
+
+    } else if (nargs==1 &&
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         return MORPHO_BOOL(dictionary_get(&klass->methods, MORPHO_GETARG(args, 0), NULL));
     } else MORPHO_RAISE(v, RESPONDSTO_ARG);
@@ -75,11 +90,27 @@ value Object_respondsto(vm *v, int nargs, value *args) {
 value Object_has(vm *v, int nargs, value *args) {
     value self = MORPHO_SELF(args);
 
-    if (nargs==1 &&
+    if (nargs == 0) {
+        value out = MORPHO_NIL;
+        objectlist *new = object_newlist(0, NULL);
+        if (new) {
+            objectinstance *slf = MORPHO_GETINSTANCE(self);
+            list_resize(new, MORPHO_GETINSTANCE(self)->fields.count);
+            for (unsigned int i=0; i<slf->fields.capacity; i++) {
+                if (MORPHO_ISSTRING(slf->fields.contents[i].key)) {
+                    list_append(new, slf->fields.contents[i].key);
+                }
+            }
+            out = MORPHO_OBJECT(new);
+            morpho_bindobjects(v, 1, &out);
+        } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
+        return out;
+
+    } else if (nargs==1 &&
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         return MORPHO_BOOL(dictionary_get(&MORPHO_GETINSTANCE(self)->fields, MORPHO_GETARG(args, 0), NULL));
         
-    } else MORPHO_RAISE(v, RESPONDSTO_ARG);
+    } else MORPHO_RAISE(v, HAS_ARG);
     
     return MORPHO_FALSE;
 }
@@ -1854,6 +1885,7 @@ void veneer_initialize(void) {
     morpho_defineerror(DICT_DCTSTARG, ERROR_HALT, DICT_DCTSTARG_MSG);
     morpho_defineerror(SETINDEX_ARGS, ERROR_HALT, SETINDEX_ARGS_MSG);
     morpho_defineerror(RESPONDSTO_ARG, ERROR_HALT, RESPONDSTO_ARG_MSG);
+    morpho_defineerror(HAS_ARG, ERROR_HALT, HAS_ARG_MSG);
     morpho_defineerror(ISMEMBER_ARG, ERROR_HALT, ISMEMBER_ARG_MSG);
     morpho_defineerror(CLASS_INVK, ERROR_HALT, CLASS_INVK_MSG);
     morpho_defineerror(LIST_ENTRYNTFND, ERROR_HALT, LIST_ENTRYNTFND_MSG);

--- a/morpho5/builtin/veneer.h
+++ b/morpho5/builtin/veneer.h
@@ -56,7 +56,10 @@
 #define DICT_DCTKYNTFND_MSG               "Key not found in dictionary."
 
 #define RESPONDSTO_ARG                    "RspndsToArg"
-#define RESPONDSTO_ARG_MSG                "Method respondsto expects a single string argument."
+#define RESPONDSTO_ARG_MSG                "Method respondsto expects a single string argument or no argrument."
+
+#define HAS_ARG                    		  "HasArg"
+#define HAS_ARG_MSG                		  "Method has expects a single string argument or no argument."
 
 #define ISMEMBER_ARG                      "IsMmbrArg"
 #define ISMEMBER_ARG_MSG                  "Method ismember expects a single argument."

--- a/test/object/has.morpho
+++ b/test/object/has.morpho
@@ -9,3 +9,6 @@ print a.has("things")
 
 print a.has("stuff")
 // expect: false
+
+print a.has()
+// expect: [ things ]

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -8,5 +8,8 @@ print a.respondsto("invoke")
 print a.respondsto("squiggle")
 // expect: false
 
+print a.respondsto()
+// expect: [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+
 print a.respondsto("squiggle","foo")
 // expect error 'RspndsToArg'

--- a/test/object/responds_to.morpho
+++ b/test/object/responds_to.morpho
@@ -9,7 +9,17 @@ print a.respondsto("squiggle")
 // expect: false
 
 print a.respondsto()
-// expect: [ "setindex", "clone", "index", "count", "prnt", "invoke", "clss", "serialize", "respondsto", "has", "superclass", "enumerate" ]
+// expect: [ setindex, clone, index, count, prnt, invoke, clss, serialize, respondsto, has, superclass, enumerate ]
+class bar {
+    method1(){
+        1+1
+    }
+}
+
+var b = bar()
+print b.respondsto()
+// expect: [ prnt, invoke, clss, has, setindex, clone, index, count, serialize, respondsto, method1, superclass, enumerate ]
+
 
 print a.respondsto("squiggle","foo")
 // expect error 'RspndsToArg'


### PR DESCRIPTION
adds .has() and .respondsto() for no arguments, returning a list of all properties for .has() and a list all methods for .respondsto()

I couldn't find where has  .has and .respondsto were previously document to add the new functionality

This change does not fix #182 

