### PR TITLE
Return in try

### DIFF
--- a/morpho5/utils/error.h
+++ b/morpho5/utils/error.h
@@ -122,6 +122,9 @@ void morpho_unreachable(const char *explanation);
 #define VM_STCKOVFLW                      "StckOvflw"
 #define VM_STCKOVFLW_MSG                  "Stack overflow."
 
+#define VM_ERRSTCKOVFLW                   "ErrStckOvflw"
+#define VM_ERRSTCKOVFLW_MSG               "Error handler stack overflow."
+
 #define VM_INVLDOP                        "InvldOp"
 #define VM_INVLDOP_MSG                    "Invalid operands. Failed to %s %s and %s"
 

--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -3500,8 +3500,6 @@ void morpho_setbaseclass(value klss) {
 
 /** Initializes the compiler */
 void compile_initialize(void) {
-    baseclass=NULL;
-
     _selfsymbol=builtin_internsymbolascstring("self");
 
     /* Lex errors */

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1356,6 +1356,12 @@ callfunction: // Jump here if an instruction becomes a call
             if (v->openupvalues) { /* Close upvalues */
                 vm_closeupvalues(v, reg);
             }
+        
+            if (v->ehp) { /* Remove any error handlers from this call frame */
+                while (v->ehp->fp==v->fp &&
+                       v->ehp>=v->errorhandlers) v->ehp--;
+                if (v->ehp<v->errorhandlers) v->ehp=NULL; // If the stack is empty rest to NULL
+            }
 
             value retvalue;
 

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -1574,6 +1574,9 @@ callfunction: // Jump here if an instruction becomes a call
 
         CASE_CODE(PUSHERR):
             b=DECODE_Bx(bc);
+            if (v->ehp && v->ehp>=v->errorhandlers+MORPHO_ERRORHANDLERSTACKSIZE-1) {
+                ERROR(VM_ERRSTCKOVFLW);
+            }
             if (!v->ehp) v->ehp=v->errorhandlers; else v->ehp++; // Add new error handler to the error stack
             v->ehp->fp=v->fp; // Store the current frame pointer
             v->ehp->dict=v->konst[b]; // Store the error handler dictionary from the constant table
@@ -2215,6 +2218,7 @@ void morpho_initialize(void) {
 #endif
 
     morpho_defineerror(VM_STCKOVFLW, ERROR_HALT, VM_STCKOVFLW_MSG);
+    morpho_defineerror(VM_ERRSTCKOVFLW, ERROR_HALT, VM_ERRSTCKOVFLW_MSG);
     morpho_defineerror(VM_INVLDOP, ERROR_HALT, VM_INVLDOP_MSG);
     morpho_defineerror(VM_CNCTFLD, ERROR_HALT, VM_CNCTFLD_MSG);
     morpho_defineerror(VM_UNCALLABLE, ERROR_HALT, VM_UNCALLABLE_MSG);

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2216,8 +2216,8 @@ void morpho_initialize(void) {
     object_initialize(); // Must be first for zombie object tracking
     error_initialize();
     random_initialize();
+    builtin_initialize(); // Must come before initialization of any classes or similar
     compile_initialize();
-    builtin_initialize();
 
 #ifdef MORPHO_DEBUG_GCSIZETRACKING
     dictionary_init(&sizecheck);

--- a/test/try/err_stack_overflw.morpho
+++ b/test/try/err_stack_overflw.morpho
@@ -1,0 +1,11 @@
+
+fn func() {
+  try {
+    return func() 
+  } catch {
+  }
+  return false 
+}
+
+func() 
+// expect error 'ErrStckOvflw'

--- a/test/try/return_in_try.morpho
+++ b/test/try/return_in_try.morpho
@@ -8,7 +8,6 @@ fn func() {
 }
 
 for (i in 1..100) {
-  print i
   func()
 }
 

--- a/test/try/return_in_try.morpho
+++ b/test/try/return_in_try.morpho
@@ -1,0 +1,16 @@
+
+fn func() {
+  try {
+    return true
+  } catch {
+  }
+  return false 
+}
+
+for (i in 1..100) {
+  print i
+  func()
+}
+
+print "ok"
+// expect: ok


### PR DESCRIPTION
* PUSHERR now checks for err stack overflow. 
* RETURN now removes error handlers from the current call frame. 

The above now fixes a bug whereby using return in a try statement could generate a segfault. 
