### PR TITLE
Improvements to utf8 support in interactive mode

### DIFF
--- a/morpho5/interface/linedit.c
+++ b/morpho5/interface/linedit.c
@@ -868,7 +868,7 @@ void linedit_setposition(lineditor *edit, int posn) {
 
 /** Checks if we're at the end of the line */
 bool lineedit_atendofline(lineditor *edit) {
-    return (edit->posn==edit->current.length);
+    return (edit->posn==linedit_stringwidth(&edit->current));
 }
 
 /** @brief Advances the position by delta

--- a/morpho5/interface/linedit.h
+++ b/morpho5/interface/linedit.h
@@ -138,7 +138,7 @@ typedef enum {
 /** Holds all state information needed for a line editor */
 typedef struct {
     lineditormode mode;      /* Current editing mode */
-    int posn;                /* Position of the cursor */
+    int posn;                /* Position of the cursor in characters */
     int sposn;               /* Starting point of a selection */
     int ncols;               /* Number of columns */
     linedit_string prompt;   /* The prompt */

--- a/morpho5/interface/linedit.h
+++ b/morpho5/interface/linedit.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdint.h>
 
 #include <termios.h>
 #include <unistd.h>

--- a/morpho5/interface/linedit.h
+++ b/morpho5/interface/linedit.h
@@ -23,10 +23,10 @@
 
 /** lineditor strings */
 typedef struct slinedit_string {
-    size_t capacity;
-    size_t length;
-    char *string;
-    struct slinedit_string *next;
+    size_t capacity;  /** Capacity of the string in bytes */
+    size_t length; /** Length in bytes */
+    char *string; /** String data */
+    struct slinedit_string *next; /** Enable strings to be chained together */
 } linedit_string;
 
 /** A list of strings */
@@ -173,6 +173,10 @@ void linedit_syntaxcolor(lineditor *edit, linedit_tokenizer tokenizer, linedit_c
  *  @param edit         Line editor to configure
  *  @param completer    a function */
 void linedit_autocomplete(lineditor *edit, linedit_completer completer);
+
+/** @brief Configures multiline editing
+ *  @param edit         Line editor to configure */
+void linedit_multiline(lineditor *edit);
 
 /** @brief Adds a completion suggestion
  *  @param completion   completion data structure


### PR DESCRIPTION
Insertion of UTF8 characters would previously cause problems in interactive mode. This PR partially fixes the problem: linedit is now utf8 aware and correctly parses wide characters. There are still further improvements—the display width of the character is not established here, for example, but this is still a worthwhile improvement. 