### PR TITLE
Anonymous functions work in args

### DIFF
--- a/morpho5/vm/compile.c
+++ b/morpho5/vm/compile.c
@@ -2425,13 +2425,6 @@ static codeinfo compiler_function(compiler *c, syntaxtreenode *node, registerind
 #endif
         {
             compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1, 0), node); /* Add a return */
-        } else if (isanonymous) {
-            if (!CODEINFO_ISREGISTER(bodyinfo)) {
-                bodyinfo=compiler_movetoregister(c, node, bodyinfo, REGISTER_UNALLOCATED);
-                ninstructions+=bodyinfo.ninstructions;
-            }
-
-            compiler_addinstruction(c, ENCODE_DOUBLE(OP_RETURN, 1, bodyinfo.dest), node);
         } else {
             compiler_addinstruction(c, ENCODE_BYTE(OP_RETURN), node); /* Add a return */
         }

--- a/test/function/anonymous_in_args.morpho
+++ b/test/function/anonymous_in_args.morpho
@@ -1,0 +1,11 @@
+// Anonymous fn in the arguments of a function 
+
+fn f(g, x) {
+    print g(x)
+}
+
+f(fn (x) x, "Foo") // expect: Foo
+
+f(fn (x) "Boo", "Foo") // expect: Boo
+
+f(fn (x) { return x[0] }, "Foo") // expect: F

--- a/test/function/anonymous_in_optional_args.morpho
+++ b/test/function/anonymous_in_optional_args.morpho
@@ -1,0 +1,11 @@
+// Anonymous fn in the optional arguments of a function 
+
+fn f(x, g=nil) {
+    print g(x)
+}
+
+f("Foo", g=fn (x) x) // expect: Foo
+
+f("Foo", g=fn (x) "Boo") // expect: Boo
+
+f("Foo", g=fn (x) { return x[0] }) // expect: F


### PR DESCRIPTION
Improvements to parser and compiler: You can now specify anonymous functions in the arguments to a function. 