### PR TITLE
Multithreaded force and energy calculations

### DIFF
--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -121,7 +121,7 @@
 #define MORPHO_MULTITHREAD
 
 /** @brief Default number of threads */
-#define MORPHO_DEFAULTTHREADNUMBER 1
+#define MORPHO_DEFAULTTHREADNUMBER 0
 
 /** @brief Size of L1 cache line */
 #define _MORPHO_L1CACHELINESIZE 128 // M1/M2 is 128; most intel are 64

--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -123,6 +123,12 @@
 /** @brief Default number of threads */
 #define MORPHO_DEFAULTTHREADNUMBER 1
 
+/** @brief Size of L1 cache line */
+#define _MORPHO_L1CACHELINESIZE 128 // M1/M2 is 128; most intel are 64
+
+/** @brief Pad data structures involved in multiprocessing */
+#define _MORPHO_PADDING char __padding[_MORPHO_L1CACHELINESIZE]
+
 /* **********************************************************************
  * Libraries
  * ********************************************************************** */

--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -117,9 +117,6 @@
 /** @brief Avoid using global variables (suitable for small programs only) */
 //#define MORPHO_NOGLOBALS
 
-/** @brief Use multithreaded code */
-#define MORPHO_MULTITHREAD
-
 /** @brief Default number of threads */
 #define MORPHO_DEFAULTTHREADNUMBER 0
 

--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -117,6 +117,12 @@
 /** @brief Avoid using global variables (suitable for small programs only) */
 //#define MORPHO_NOGLOBALS
 
+/** @brief Use multithreaded code */
+#define MORPHO_MULTITHREAD
+
+/** @brief Default number of threads */
+#define MORPHO_DEFAULTTHREADNUMBER 1
+
 /* **********************************************************************
  * Libraries
  * ********************************************************************** */

--- a/morpho5/builtin/builtin.c
+++ b/morpho5/builtin/builtin.c
@@ -302,6 +302,7 @@ void builtin_finalize(void) {
     dictionary_clear(&builtin_symboltable);
     varray_valueclear(&builtin_objects);
     
+    functional_finalize();
     file_finalize();
     system_finalize();
 }

--- a/morpho5/geometry/field.c
+++ b/morpho5/geometry/field.c
@@ -216,7 +216,7 @@ void field_zero(objectfield *f) {
 /** Adds the object pool. This is a collection of statically allocated objects */
 bool field_addpool(objectfield *f) {
     unsigned int nel = f->nelements;
-    if (MORPHO_ISMATRIX(f->prototype)) {
+    if (!f->pool && MORPHO_ISMATRIX(f->prototype)) {
         objectmatrix *prototype=MORPHO_GETMATRIX(f->prototype);
         f->pool=MORPHO_MALLOC(sizeof(objectmatrix)*nel);
         if (f->pool) {

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -83,6 +83,8 @@ objectfield *object_newfield(objectmesh *mesh, value prototype, unsigned int *do
 #define FIELD_MESHARG                    "FldMshArg"
 #define FIELD_MESHARG_MSG                "Field expects a mesh as its first argurment"
 
+objectfield *field_clone(objectfield *f);
+
 void field_zero(objectfield *field);
 bool field_addpool(objectfield *field);
 

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -84,6 +84,7 @@ objectfield *object_newfield(objectmesh *mesh, value prototype, unsigned int *do
 #define FIELD_MESHARG_MSG                "Field expects a mesh as its first argurment"
 
 void field_zero(objectfield *field);
+bool field_addpool(objectfield *field);
 
 unsigned int field_dofforgrade(objectfield *f, grade g);
 bool field_getelement(objectfield *field, grade grade, elementid el, int indx, value *out);

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -1172,6 +1172,7 @@ bool functional_numericalgrad(vm *v, objectmesh *mesh, elementid eid, elementid 
 
 /** Computes the gradient of element id with respect to its constituent vertices and any dependencies */
 bool functional_numericalgradientmapfn(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, void *out) {
+    bool success=true;
     functional_mapinfo *info=(functional_mapinfo *) ref;
     
     for (int i=0; i<nv; i++) {
@@ -1186,14 +1187,15 @@ bool functional_numericalgradientmapfn(vm *v, objectmesh *mesh, elementid id, in
         // Get list of vertices this element depends on
         if ((info->dependencies) (info, id, &dependencies)) {
             for (int j=0; j<dependencies.count; j++) {
-                functional_numericalgrad(v, mesh, id, dependencies.data[j], nv, vid, info->integrand, info->ref, out);
+                if (functional_containsvertex(nv, vid, dependencies.data[j])) continue;
+                if (!functional_numericalgrad(v, mesh, id, dependencies.data[j], nv, vid, info->integrand, info->ref, out)) success=false;
             }
         }
         
         varray_elementidclear(&dependencies);
     }
     
-    return true;
+    return success;
 }
 
 /** Compute the gradient numerically */

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -854,7 +854,7 @@ void functionaltask_init(functional_task *task, elementid start, elementid end, 
     task->processfn=NULL;
     
     task->mesh=(info ? info->mesh : NULL);
-    task->selection=NULL;
+    task->selection=(info ? info->sel : NULL);
     
     task->v=NULL;
     task->ref=(info ? info->ref : NULL);
@@ -957,8 +957,13 @@ int functional_preparetasks(vm *v, functional_mapinfo *info, int ntask, function
     /* Work out the number of elements */
     if (!functional_countelements(v, info->mesh, info->g, &nel, &conn)) return false;
     
+    int cmax=nel;
+    if (info->sel) {
+        cmax=info->sel[info->g].selected->capacity;
+    }
+    
     int bins[ntask+1];
-    functional_binbounds(nel, ntask, bins);
+    functional_binbounds(cmax, ntask, bins);
     
     /* Find any image elements so they can be skipped */
     functional_symmetryimagelist(info->mesh, info->g, true, imageids);

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -193,7 +193,7 @@ bool functional_containsvertex(int nv, int *vid, elementid id) {
  * @param[in] info - map info
  * @param[out] out - a matrix of integrand values
  * @returns true on success, false otherwise. Error reporting through VM. */
-bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
+bool functional_sumintegrandX(vm *v, functional_mapinfo *info, value *out) {
     bool success=false;
     objectmesh *mesh = info->mesh;
     objectselection *sel = info->sel;
@@ -798,6 +798,196 @@ functional_mapnumericalhessian_cleanup:
     if (!ret) object_free((object *) hess);
 
     return ret;
+}
+
+/* **********************************************************************
+ * Multithreaded map functions
+ * ********************************************************************** */
+
+/** Gradient function */
+typedef bool (functional_mapfn) (vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, void *out);
+
+typedef bool (functional_processfn) (void *task);
+
+typedef struct {
+    elementid start, end; /* Start and end indices for the task */
+    grade g; /* Grade of element */
+    
+    varray_elementid *skip; /* Sorted list of element ids to skip; set to NULL if not needed */
+    unsigned int sindx;
+    
+    objectsparse *conn; /* Connectivity matrix */
+    
+    functional_mapfn *mapfn; /* Map function */
+    functional_processfn *processfn; /* Post process results */
+    
+    objectmesh *mesh; /* Mesh in use */
+    vm *v; /* Virtual machine in use */
+    void *ref; /* Ref as an opaque pointer */
+    void *result; /* Result of individual element as an opaque pointer */
+    void *out; /* Overall output as an opaque pointer */
+} functional_task;
+
+/* Initialize a task structure */
+void functionaltask_init(functional_task *task, elementid start, elementid end, functional_mapinfo *info)  {
+    task->start=start;
+    task->end=end;
+    task->g=(info ? info->g : 0);
+    
+    task->skip=NULL;
+    task->sindx=0;
+    
+    task->conn=NULL;
+    
+    task->mapfn=NULL;
+    task->processfn=NULL;
+    
+    task->mesh=(info ? info->mesh : NULL);
+    task->v=NULL;
+    task->ref=(info ? info->ref : NULL);
+    task->out=NULL;
+    task->result=NULL;
+}
+
+/** Check if we should skip element id */
+bool functional_checkskip(functional_task *task, elementid i) {
+    if ((task->skip) &&
+        (task->sindx<task->skip->count) &&
+        task->skip->data[task->sindx]==i) {
+        task->sindx++;
+        return true;
+    }
+    return false;
+}
+
+/* Do work
+ 
+ // Integrand:
+ if ((*integrand) (v, mesh, i, nv, vid, ref, &result)) {
+     matrix_setelement(new, 0, i, result);
+ } else goto functional_mapintegrand_cleanup;
+ 
+ // Gradient:
+ if (!(*grad) (v, mesh, i, nv, vid, ref, frc)) goto functional_mapgradient_cleanup;
+ */
+
+bool functional_mapoverselection(functional_task *task) {
+    
+    return true;
+}
+
+/* Maps a function over elements */
+bool functional_mapoverelements(void *arg) {
+    functional_task *task = (functional_task *) arg;
+    elementid i; /* Counter */
+    elementid *vid=&i; /* Will hold element definition */
+    int nv=1; /* Number of vertices per element; default to 1  */
+    
+    for (i=task->start; i<task->end; i++) {
+        // Skip this element if it's an image element
+        if (functional_checkskip(task, i)) continue;
+        
+        // Fetch element definition
+        if (task->conn) {
+            if (!sparseccs_getrowindices(&task->conn->ccs, i, &nv, &vid)) return false;
+        }
+        
+        // Perform the map function
+        if (!(*task->mapfn) (task->v, task->mesh, i, nv, vid, task->ref, task->result)) return false;
+        
+        // Perform post-processing if needed
+        if (task->processfn) if (!(*task->processfn) (task)) return false;
+    }
+    return true;
+}
+
+/** Maps tasks */
+bool functional_parallelmap(int ntasks, functional_task *tasks) {
+    threadpool pool;
+    
+    threadpool_init(&pool, 4);
+    
+    for (int i=0; i<ntasks; i++) {
+        threadpool_add_task(&pool, functional_mapoverelements, (void *) &tasks[i]);
+    }
+
+    threadpool_fence(&pool);
+    threadpool_clear(&pool);
+    
+    return true;
+}
+
+typedef struct {
+    double c;
+    double sum;
+} kahansum;
+
+/** Perform Kahan summation for total */
+bool functional_sumprocessfn(void *arg) {
+    functional_task *task = (functional_task *) arg;
+    double result = *((double *) task->result);
+    kahansum *ks = (kahansum *) task->out;
+    double y=result-ks->c;
+    double t=ks->sum+y;
+    ks->c=(t-ks->sum)-y;
+    ks->sum=t; // Kahan summation
+    return true;
+}
+
+/** Set relevant matrix element to the result of the integrand */
+bool functional_integrandprocessfn(void *arg) {
+    functional_task *task = (functional_task *) arg;
+    //matrix_setelement(new, 0, i, (double *) task->result);
+    return true;
+}
+
+/** Parallelized version of sum integrand */
+bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
+    int ntask = 1;
+    functional_task task[ntask];
+    double results[ntask];
+    kahansum sums[ntask];
+    
+    int nel=0;               // Number of elements
+    objectsparse *conn=NULL; // The associated connectivity matrix if any
+    
+    /* Work out the number of elements */
+    if (!functional_countelements(v, info->mesh, info->g, &nel, &conn)) return false;
+    
+    /* Find any image elements so they can be skipped */
+    varray_elementid imageids;
+    varray_elementidinit(&imageids);
+    functional_symmetryimagelist(info->mesh, info->g, true, &imageids);
+    
+    for (int i=0; i<ntask; i++) {
+        functionaltask_init(&task[i], 0, nel, info); // Setup the task
+        
+        task[i].v=v;
+        task[i].conn=conn;
+        if (imageids.count>0) task[i].skip=&imageids;
+        
+        task[i].mapfn=(functional_mapfn *) info->integrand;
+        task[i].processfn=functional_sumprocessfn;
+        
+        task[i].result=(void *) &results[i];
+        task[i].out=(void *) &sums[i];
+        
+        results[i]=0.0;
+        sums[i].c=0.0; sums[i].sum=0.0;
+    }
+    
+    functional_parallelmap(ntask, task);
+    
+    // Sum up the results from each task...
+    double sumlist[ntask];
+    for (int i=0; i<ntask; i++) sumlist[i]=sums[i].sum;
+    
+    // ...and return the result
+    *out = MORPHO_FLOAT(functional_sumlist(sumlist, ntask));
+    
+    varray_elementidclear(&imageids);
+    
+    return true;
 }
 
 /* **********************************************************************

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -1132,6 +1132,9 @@ bool functional_mapgradient(vm *v, functional_mapinfo *info, value *out) {
     /* Then add up all the matrices */
     for (int i=1; i<ntask; i++) matrix_add(new[0], new[i], new[0]);
     
+    // Use symmetry actions
+    if (info->sym==SYMMETRY_ADD) functional_symmetrysumforces(info->mesh, new[0]);
+    
     success=true;
     
 functional_mapgradient_cleanup:
@@ -1235,6 +1238,9 @@ bool functional_mapnumericalgradient(vm *v, functional_mapinfo *info, value *out
     for (int i=1; i<ntask; i++) matrix_add(new[0], new[i], new[0]);
     
     success=true;
+    
+    // Use symmetry actions
+    if (info->sym==SYMMETRY_ADD) functional_symmetrysumforces(info->mesh, new[0]);
     
     // ...and return the result
     *out = MORPHO_OBJECT(new[0]);

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -884,15 +884,13 @@ bool functional_mapfn_elements(void *arg) {
     
     // Loop over required elements
     for (elementid i=task->start; i<task->end; i++) {
-        if (!selected) {
-            task->id = i;
-        } else {
+        if (selected) {
             // Skip empty dictionary entries
             if (!MORPHO_ISINTEGER(selected->contents[i].key)) continue;
             
             // Fetch the element id from the dictionary
             task->id = MORPHO_GETINTEGERVALUE(selected->contents[i].key);
-        }
+        } else task->id = i;
         
         // Skip this element if it's an image element
         if (functional_checkskip(task)) continue;
@@ -967,7 +965,7 @@ bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
     /* Work out the number of elements */
     if (!functional_countelements(v, info->mesh, info->g, &nel, &conn)) return false;
     
-    int ntask = 4;
+    int ntask = 16;
     functional_task task[ntask];
     
     int bins[ntask+1];

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -976,6 +976,13 @@ int functional_preparetasks(vm *v, functional_mapinfo *info, int ntask, function
     return true;
 }
 
+/** Cleans up task structures after executing them. */
+void functional_cleanuptasks(vm *v, int ntask, functional_task *task) {
+    for (int i=0; i<ntask; i++) {
+        if (task[i].v!=v) vm_releasesubkernel(task[i].v);
+    }
+}
+
 /* ----------------------------
  * Sum integrands
  * ---------------------------- */
@@ -1029,6 +1036,7 @@ bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
     // ...and return the result
     *out = MORPHO_FLOAT(functional_sumlist(sumlist, ntask));
     
+    functional_cleanuptasks(v, ntask, task);
     varray_elementidclear(&imageids);
     return true;
 }
@@ -1078,6 +1086,7 @@ bool functional_mapintegrand(vm *v, functional_mapinfo *info, value *out) {
     // ...and return the result
     *out = MORPHO_OBJECT(new);
     
+    functional_cleanuptasks(v, ntask, task);
     varray_elementidclear(&imageids);
     return true;
 }
@@ -1123,6 +1132,7 @@ functional_mapgradient_cleanup:
     // ...and return the result
     *out = MORPHO_OBJECT(new[0]);
     
+    functional_cleanuptasks(v, ntask, task);
     varray_elementidclear(&imageids);
     return success;
 }

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -908,6 +908,9 @@ bool functional_mapfn_elements(void *arg) {
         
         // Perform post-processing if needed
         if (task->processfn) if (!(*task->processfn) (task)) return false;
+        
+        // Clean out temporary objects
+        vm_cleansubkernel(task->v);
     }
     return true;
 }

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -3623,6 +3623,13 @@ bool integral_prepareref(objectinstance *self, objectmesh *mesh, grade g, object
         objectlist *list = MORPHO_GETLIST(field);
         ref->nfields=list->val.count;
         ref->fields=list->val.data;
+        
+        for (int i=0; i<ref->nfields; i++) {
+            if (MORPHO_ISFIELD(ref->fields[i])) {
+                objectfield *fld = MORPHO_GETFIELD(ref->fields[i]);
+                field_addpool(fld);
+            }
+        }
     }
     return success;
 }

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -1030,6 +1030,8 @@ bool functional_sumintegrandprocessfn(void *arg) {
 /** Sum the integrand, mapping over integrand function */
 bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
     int ntask=morpho_threadnumber();
+    if (!ntask) return functional_sumintegrandX(v, info, out);
+    
     functional_task task[ntask];
     
     varray_elementid imageids;
@@ -1077,6 +1079,7 @@ bool functional_mapintegrandprocessfn(void *arg) {
 /** Map integrand function, storing the results in a matrix */
 bool functional_mapintegrand(vm *v, functional_mapinfo *info, value *out) {
     int ntask=morpho_threadnumber();
+    if (!ntask) return functional_mapintegrandX(v, info, out);
     functional_task task[ntask];
     
     varray_elementid imageids;
@@ -1120,6 +1123,7 @@ bool functional_mapintegrand(vm *v, functional_mapinfo *info, value *out) {
 bool functional_mapgradient(vm *v, functional_mapinfo *info, value *out) {
     int success=false;
     int ntask=morpho_threadnumber();
+    if (!ntask) return functional_mapgradientX(v, info, out);
     functional_task task[ntask];
     
     varray_elementid imageids;
@@ -1218,6 +1222,7 @@ bool functional_numericalgradientmapfn(vm *v, objectmesh *mesh, elementid id, in
 bool functional_mapnumericalgradient(vm *v, functional_mapinfo *info, value *out) {
     int success=false;
     int ntask=morpho_threadnumber();
+    if (!ntask) return functional_mapnumericalgradientX(v, info, out);
     functional_task task[ntask];
     
     varray_elementid imageids;
@@ -1322,6 +1327,7 @@ bool functional_numericalfieldgradientmapfn(vm *v, objectmesh *mesh, elementid i
 bool functional_mapnumericalfieldgradient(vm *v, functional_mapinfo *info, value *out) {
     int success=false;
     int ntask=morpho_threadnumber();
+    if (!ntask) return functional_mapnumericalfieldgradientX(v, info, out);
     functional_task task[ntask];
     
     varray_elementid imageids;

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -3972,13 +3972,13 @@ MORPHO_ENDCLASS
 
 /** Integrate a function over an area */
 bool areaintegral_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, double *out) {
-    integralref *iref = ref;
+    integralref iref = *(integralref *) ref;
     double *x[3], size;
     bool success;
 
     if (!functional_elementsize(v, mesh, MESH_GRADE_AREA, id, nv, vid, &size)) return false;
 
-    iref->v=v;
+    iref.v=v;
     for (unsigned int i=0; i<nv; i++) {
         mesh_getvertexcoordinatesaslist(mesh, vid[i], &x[i]);
     }
@@ -4001,15 +4001,15 @@ bool areaintegral_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *
     objectmatrix mgrad = MORPHO_STATICMATRIX(grad, mesh->dim, 1);
     gradfn = MORPHO_OBJECT(&mgrad);*/
 
-    value q0[iref->nfields+1], q1[iref->nfields+1], q2[iref->nfields+1];
+    value q0[iref.nfields+1], q1[iref.nfields+1], q2[iref.nfields+1];
     value *q[3] = { q0, q1, q2 };
-    for (unsigned int k=0; k<iref->nfields; k++) {
+    for (unsigned int k=0; k<iref.nfields; k++) {
         for (unsigned int i=0; i<nv; i++) {
-            field_getelement(MORPHO_GETFIELD(iref->fields[k]), MESH_GRADE_VERTEX, vid[i], 0, &q[i][k]);
+            field_getelement(MORPHO_GETFIELD(iref.fields[k]), MESH_GRADE_VERTEX, vid[i], 0, &q[i][k]);
         }
     }
 
-    success=integrate_integrate(integral_integrandfn, mesh->dim, MESH_GRADE_AREA, x, iref->nfields, q, iref, out);
+    success=integrate_integrate(integral_integrandfn, mesh->dim, MESH_GRADE_AREA, x, iref.nfields, q, &iref, out);
     if (success) *out *=size;
 
     return success;
@@ -4056,26 +4056,26 @@ MORPHO_ENDCLASS
 
 /** Integrate a function over a volume */
 bool volumeintegral_integrand(vm *v, objectmesh *mesh, elementid id, int nv, int *vid, void *ref, double *out) {
-    integralref *iref = ref;
+    integralref iref = *(integralref *) ref;
     double *x[4], size;
     bool success;
 
     if (!functional_elementsize(v, mesh, MESH_GRADE_VOLUME, id, nv, vid, &size)) return false;
 
-    iref->v=v;
+    iref.v=v;
     for (unsigned int i=0; i<nv; i++) {
         mesh_getvertexcoordinatesaslist(mesh, vid[i], &x[i]);
     }
 
-    value q0[iref->nfields+1], q1[iref->nfields+1], q2[iref->nfields+1], q3[iref->nfields+1];
+    value q0[iref.nfields+1], q1[iref.nfields+1], q2[iref.nfields+1], q3[iref.nfields+1];
     value *q[4] = { q0, q1, q2, q3 };
-    for (unsigned int k=0; k<iref->nfields; k++) {
+    for (unsigned int k=0; k<iref.nfields; k++) {
         for (unsigned int i=0; i<nv; i++) {
-            field_getelement(MORPHO_GETFIELD(iref->fields[k]), MESH_GRADE_VERTEX, vid[i], 0, &q[i][k]);
+            field_getelement(MORPHO_GETFIELD(iref.fields[k]), MESH_GRADE_VERTEX, vid[i], 0, &q[i][k]);
         }
     }
 
-    success=integrate_integrate(integral_integrandfn, mesh->dim, MESH_GRADE_VOLUME, x, iref->nfields, q, iref, out);
+    success=integrate_integrate(integral_integrandfn, mesh->dim, MESH_GRADE_VOLUME, x, iref.nfields, q, &iref, out);
     if (success) *out *=size;
 
     return success;

--- a/morpho5/geometry/functional.c
+++ b/morpho5/geometry/functional.c
@@ -966,7 +966,7 @@ bool functional_sumintegrand(vm *v, functional_mapinfo *info, value *out) {
     /* Work out the number of elements */
     if (!functional_countelements(v, info->mesh, info->g, &nel, &conn)) return false;
     
-    int ntask = 4;
+    int ntask = morpho_threadnumber();
     functional_task task[ntask];
     
     int bins[ntask+1];
@@ -3725,7 +3725,7 @@ void functional_initialize(void) {
     morpho_defineerror(LINEINTEGRAL_ARGS, ERROR_HALT, LINEINTEGRAL_ARGS_MSG);
     morpho_defineerror(LINEINTEGRAL_NFLDS, ERROR_HALT, LINEINTEGRAL_NFLDS_MSG);
     
-    threadpool_init(&functional_pool, 4);
+    threadpool_init(&functional_pool, morpho_threadnumber());
 }
 
 void functional_finalize(void) {

--- a/morpho5/geometry/functional.h
+++ b/morpho5/geometry/functional.h
@@ -118,5 +118,6 @@
 #define FUNCTIONAL_ARGS_MSG            "Invalid args passed to method."
 
 void functional_initialize(void);
+void functional_finalize(void);
 
 #endif /* functional_h */

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -14,8 +14,6 @@
 #include "sparse.h"
 
 int main(int argc, const char * argv[]) {
-    morpho_initialize();
-    
     clioptions opt = CLI_RUN;
     const char *file = NULL;
     
@@ -48,11 +46,24 @@ int main(int argc, const char * argv[]) {
                     }
 #endif
                     break;
+                case 'w': /* Workers */
+                    {
+                        const char *c=option+2;
+                        int nw=0;
+                        while (!isdigit(*c) && *c!='\0') c++;
+                        if (isdigit(*c)) nw=atoi(c);
+                        if (nw==0) nw=1; /* Use one thread by default */
+                        morpho_setthreadnumber(nw);
+                    }
+                    
+                    break;
             }
         } else {
             file = option;
         }
     }
+    
+    morpho_initialize();
     
     if (file) cli_run(file, opt);
     else cli(opt);

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -52,7 +52,7 @@ int main(int argc, const char * argv[]) {
                         int nw=0;
                         while (!isdigit(*c) && *c!='\0') c++;
                         if (isdigit(*c)) nw=atoi(c);
-                        if (nw==0) nw=1; /* Use one thread by default */
+                        if (nw<0) nw=0;
                         morpho_setthreadnumber(nw);
                     }
                     

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -63,6 +63,7 @@ int main(int argc, const char * argv[]) {
         }
     }
     
+    /* Initialize program and run */
     morpho_initialize();
     
     if (file) cli_run(file, opt);

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -146,6 +146,10 @@ void morpho_printvalue(value v);
 void morpho_disassemble(program *code, int *matchline);
 void morpho_stacktrace(vm *v);
 
+/* Multithreading */
+void morpho_setthreadnumber(int nthreads);
+int morpho_threadnumber(void);
+
 /* Initialization and finalization */
 void morpho_setbaseclass(value clss);
 void morpho_initialize(void);

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -157,6 +157,6 @@ void morpho_finalize(void);
 
 /* Obtain subkernels [for internal use only] */
 bool vm_subkernels(vm *v, int nkernels, vm **subkernels);
-void vm_releasesubkernels(vm *v, int nkernels, vm *subkernels);
+void vm_releasesubkernel(vm *subkernel);
 
 #endif /* morpho_h */

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -155,4 +155,8 @@ void morpho_setbaseclass(value clss);
 void morpho_initialize(void);
 void morpho_finalize(void);
 
+/* Obtain subkernels [for internal use only] */
+bool vm_subkernels(vm *v, int nkernels, vm **subkernels);
+void vm_releasesubkernels(vm *v, int nkernels, vm *subkernels);
+
 #endif /* morpho_h */

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -160,4 +160,9 @@ bool vm_subkernels(vm *v, int nkernels, vm **subkernels);
 void vm_releasesubkernel(vm *subkernel);
 void vm_cleansubkernel(vm *subkernel);
 
+/* Thread local storage [for internal use only] */
+int vm_addtlvar(void);
+bool vm_settlvar(vm *v, int handle, value val);
+bool vm_gettlvar(vm *v, int handle, value *out);
+
 #endif /* morpho_h */

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -155,8 +155,9 @@ void morpho_setbaseclass(value clss);
 void morpho_initialize(void);
 void morpho_finalize(void);
 
-/* Obtain subkernels [for internal use only] */
+/* Obtain and use subkernels [for internal use only] */
 bool vm_subkernels(vm *v, int nkernels, vm **subkernels);
 void vm_releasesubkernel(vm *subkernel);
+void vm_cleansubkernel(vm *subkernel);
 
 #endif /* morpho_h */

--- a/morpho5/utils/common.c
+++ b/morpho5/utils/common.c
@@ -332,6 +332,18 @@ bool morpho_tuples(unsigned int nval, value *list, unsigned int n, unsigned int 
 * Thread pools
 * ********************************************************************** */
 
+int threadpool_nthreads = MORPHO_DEFAULTTHREADNUMBER;
+
+/** Sets the number of worker threads to use */
+void morpho_setthreadnumber(int nthreads) {
+    threadpool_nthreads = nthreads;
+}
+
+/** Returns the number of worker threads to use */
+int morpho_threadnumber(void) {
+    return threadpool_nthreads;
+}
+
 DEFINE_VARRAY(task, task);
 
 /* Worker thread */
@@ -435,6 +447,7 @@ void threadpool_fence(threadpool *pool) {
     pthread_mutex_unlock(&pool->lock_mutex);
 }
 
+/*
 bool worker(void *arg) {
     int *val = arg;
     int  old = *val;
@@ -468,3 +481,4 @@ void threadpool_test(void) {
     
     threadpool_clear(&pool);
 }
+*/

--- a/morpho5/utils/common.c
+++ b/morpho5/utils/common.c
@@ -328,4 +328,140 @@ bool morpho_tuples(unsigned int nval, value *list, unsigned int n, unsigned int 
     return true;
 }
 
+/* **********************************************************************
+* Thread pools
+* ********************************************************************** */
 
+DEFINE_VARRAY(task, task);
+
+/* Worker thread */
+void *threadpool_worker(void *ref) {
+    threadpool *pool = (threadpool *) ref;
+    task t = { .func = NULL, .arg = NULL };
+    
+    while (true) {
+        /* Await a task */
+        pthread_mutex_lock(&pool->lock_mutex);
+        while (pool->queue.count == 0 && !pool->stop)
+            pthread_cond_wait(&pool->work_available_cond, &pool->lock_mutex);
+        
+        if (pool->stop) break; /* Terminate if asked to do so */
+        
+        varray_taskpop(&pool->queue, &t); /* Get the task */
+        pool->nprocessing++;
+        pthread_mutex_unlock(&pool->lock_mutex);
+        
+        if (t.func) (t.func) (t.arg); /* Perform the assigned task */
+        
+        pthread_mutex_lock(&pool->lock_mutex);
+        pool->nprocessing--;
+        if (!pool->stop && pool->nprocessing == 0 && pool->queue.count == 0)
+            pthread_cond_signal(&pool->work_halted_cond);
+        pthread_mutex_unlock(&pool->lock_mutex);
+    }
+    
+    /* No need to lock here as lock was already obtained */
+    pool->nthreads--;
+    pthread_cond_signal(&pool->work_halted_cond);
+    pthread_mutex_unlock(&pool->lock_mutex);
+    
+    return NULL;
+}
+
+/* Interface */
+
+/** Initialize a threadpool with n worker threads. */
+bool threadpool_init(threadpool *pool, int nworkers) {
+    if (nworkers<1) return false;
+    
+    varray_taskinit(&pool->queue);
+    
+    pthread_mutex_init(&pool->lock_mutex, NULL);
+    pthread_cond_init(&pool->work_available_cond, NULL);
+    pthread_cond_init(&pool->work_halted_cond, NULL);
+    
+    pool->nthreads=nworkers;
+    for (int i=0; i<pool->nthreads; i++) {
+        pthread_t thread;
+        pthread_create(&thread, NULL, threadpool_worker, pool);
+        pthread_detach(thread);
+    }
+    
+    return true;
+}
+
+/** Clears a threadpool. */
+void threadpool_clear(threadpool *pool) {
+    pthread_mutex_lock(&pool->lock_mutex);
+    varray_taskclear(&pool->queue); /* Erase any remaining tasks */
+    pool->stop = true; /* Tell workers to stop */
+    pthread_cond_broadcast(&pool->work_available_cond); /* Signal to workers */
+    pthread_mutex_unlock(&pool->lock_mutex);
+    
+    threadpool_fence(pool); /* Await workers to terminate */
+    
+    pthread_mutex_destroy(&pool->lock_mutex);
+    pthread_cond_destroy(&pool->work_available_cond);
+    pthread_cond_destroy(&pool->work_halted_cond);
+}
+
+/** Adds a task to the threadpool */
+bool threadpool_add_task(threadpool *pool, workfn func, void *arg) {
+    pthread_mutex_lock(&pool->lock_mutex);
+    
+    task t = { .func = func, .arg=arg };
+    if (!varray_taskadd(&pool->queue, &t, 1)) return false; /* Add the task to the queue */
+
+    pthread_cond_broadcast(&pool->work_available_cond); /* Signal there is work to be done */
+    pthread_mutex_unlock(&pool->lock_mutex);
+    return true;
+}
+
+/** Blocks until all tasks in the thread pool are complete */
+void threadpool_fence(threadpool *pool) {
+    pthread_mutex_lock(&pool->lock_mutex);
+    
+    while(true) {
+        if ((!pool->stop && pool->nprocessing > 0) || // If we are simply waiting for tasks to finish
+            (pool->stop && pool->nthreads > 0)) { // Or if we have been told to stop
+            pthread_cond_wait(&pool->work_halted_cond, &pool->lock_mutex); // Block until working_cond is set
+        } else break;
+    }
+    
+    pthread_mutex_unlock(&pool->lock_mutex);
+}
+
+
+bool worker(void *arg) {
+    int *val = arg;
+    int  old = *val;
+    
+    *val += 1000;
+    printf("tid=%p, old=%d, val=%d\n", pthread_self(), old, *val);
+    
+    if (*val%2)
+        usleep(100000);
+    
+    return false;
+}
+
+void threadpool_test(void) {
+    threadpool pool;
+    int num_items = 100;
+    int vals[num_items];
+    
+    threadpool_init(&pool, 4);
+    
+    for (int i=0; i<num_items; i++) {
+        vals[i] = i;
+        threadpool_add_task(&pool, worker, vals+i);
+    }
+    
+    threadpool_fence(&pool);
+    
+    for (int i=0; i<num_items; i++) {
+        printf("%d\n", vals[i]);
+    }
+    
+    threadpool_clear(&pool);
+}

--- a/morpho5/utils/common.h
+++ b/morpho5/utils/common.h
@@ -155,6 +155,4 @@ bool threadpool_add_task(threadpool *pool, workfn func, void *arg);
 void threadpool_fence(threadpool *pool);
 void threadpool_wait(threadpool *pool);
 
-void threadpool_test(void);
-
 #endif /* common_h */

--- a/morpho5/utils/common.h
+++ b/morpho5/utils/common.h
@@ -12,6 +12,7 @@
 #include <math.h>
 #include <float.h>
 #include <string.h>
+#include <pthread.h>
 #include "value.h"
 #include "object.h"
 #include "builtin.h"
@@ -121,5 +122,38 @@ typedef enum {
 
 void morpho_tuplesinit(unsigned int nval, unsigned int n, unsigned int *c, tuplemode mode);
 bool morpho_tuples(unsigned int nval, value *list, unsigned int n, unsigned int *c, tuplemode mode, value *tuple);
+
+/* -----------------------------------------
+ * Thread pools
+ * ----------------------------------------- */
+
+/** A work function will be called by the threadpool once a thread is available.
+    You must supply all relevant information for both input and output in a single structure passed as an opaque reference. */
+typedef bool (* workfn) (void *arg);
+
+typedef struct {
+    workfn func;
+    void *arg;
+} task;
+
+DECLARE_VARRAY(task, task);
+
+typedef struct {
+    varray_task queue; /* Queue of tasks lined up */
+    
+    pthread_mutex_t lock_mutex; /* Lock for access to threadpool structure. */
+    pthread_cond_t work_available_cond; /* Signals that work is available. */
+    pthread_cond_t work_halted_cond; /* Signals when no threads are processing. */
+    int nprocessing; /* Number of threads actively processing work */
+    int nthreads; /* Number of active threads. */
+    bool stop; /* Indicates threads should terminate */
+} threadpool;
+
+bool threadpool_init(threadpool *pool, int nworkers);
+void threadpool_clear(threadpool *pool);
+bool threadpool_add_task(threadpool *pool, workfn func, void *arg);
+void threadpool_fence(threadpool *pool);
+
+void threadpool_test(void);
 
 #endif /* common_h */

--- a/morpho5/utils/common.h
+++ b/morpho5/utils/common.h
@@ -139,20 +139,21 @@ typedef struct {
 DECLARE_VARRAY(task, task);
 
 typedef struct {
-    varray_task queue; /* Queue of tasks lined up */
-    
     pthread_mutex_t lock_mutex; /* Lock for access to threadpool structure. */
     pthread_cond_t work_available_cond; /* Signals that work is available. */
     pthread_cond_t work_halted_cond; /* Signals when no threads are processing. */
     int nprocessing; /* Number of threads actively processing work */
     int nthreads; /* Number of active threads. */
     bool stop; /* Indicates threads should terminate */
+    
+    varray_task queue; /* Queue of tasks lined up */
 } threadpool;
 
 bool threadpool_init(threadpool *pool, int nworkers);
 void threadpool_clear(threadpool *pool);
 bool threadpool_add_task(threadpool *pool, workfn func, void *arg);
 void threadpool_fence(threadpool *pool);
+void threadpool_wait(threadpool *pool);
 
 void threadpool_test(void);
 

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -250,6 +250,7 @@ struct svm {
     program *current; /** The current program being executed */
 
     varray_value globals; /** Global variables */
+    varray_value tlvars; /** Thread-local variables */
     varray_value stack; /** The stack */
     callframe frame[MORPHO_CALLFRAMESTACKSIZE]; /** The call frame stack */
     errorhandler errorhandlers[MORPHO_ERRORHANDLERSTACKSIZE]; /** Error handler stack */

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -241,6 +241,10 @@ typedef struct {
 /** @brief Highest register addressable in a window. */
 #define VM_MAXIMUMREGISTERNUMBER 255
 
+/** Varrays of vms */
+struct svm;
+DECLARE_VARRAY(vm, struct svm)
+
 /** @brief A Morpho virtual machine and its current state */
 struct svm {
     program *current; /** The current program being executed */
@@ -272,6 +276,11 @@ struct svm {
 #endif
     
     objectupvalue *openupvalues; /** Linked list of open upvalues */
+    
+    struct svm *parent; /** Parent vm */
+    varray_vm subkernels; /** Subkernels */
+    
+    _MORPHO_PADDING; /** Ensure subkernels do not cause false sharing */
 };
 
 /* **********************************************************************

--- a/morpho5/vm/core.h
+++ b/morpho5/vm/core.h
@@ -243,7 +243,7 @@ typedef struct {
 
 /** Varrays of vms */
 struct svm;
-DECLARE_VARRAY(vm, struct svm)
+DECLARE_VARRAY(vm, struct svm*)
 
 /** @brief A Morpho virtual machine and its current state */
 struct svm {

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2070,6 +2070,7 @@ bool vm_subkernels(vm *v, int nkernels, vm **subkernels) {
         vm *kernel=v->subkernels.data[i];
         if (!kernel->parent) { // Check whether subkernel is unused
             subkernels[nk]=kernel;
+            kernel->parent=v;
             nk++;
         }
     }

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2124,6 +2124,17 @@ void vm_releasesubkernel(vm *subkernel) {
     subkernel->parent=NULL;
 }
 
+/** Clean out attached objects from a subkernel */
+void vm_cleansubkernel(vm *subkernel) {
+    object *next=NULL;
+    for (object *obj=subkernel->objects; obj!=NULL; obj=next) {
+        next=obj->next;
+        object_free(obj);
+    }
+    subkernel->objects=NULL;
+    subkernel->bound=0;
+}
+
 /* **********************************************************************
 * Initialization
 * ********************************************************************** */

--- a/morpho5/vm/vm.c
+++ b/morpho5/vm/vm.c
@@ -2080,6 +2080,8 @@ bool vm_subkernels(vm *v, int nkernels, vm **subkernels) {
         if (!new) return false;
         if (!varray_vmadd(&v->subkernels, &new, 1)) return false;
         vm_start(new, v->current);
+        new->globals.count=v->globals.count;
+        new->globals.data=v->globals.data;
         new->parent=v;
         subkernels[i]=new;
     }

--- a/test/functionals/area/area2.morpho
+++ b/test/functionals/area/area2.morpho
@@ -8,8 +8,8 @@ print m
 print (a.total(m) - 1) < 1e-5
 // expect: true
 
-//print (a.integrand(m) - Matrix([[ 0.5, 0.5 ]]) ).norm() < 1e-5
+print (a.integrand(m) - Matrix([[ 0.5, 0.5 ]]) ).norm() < 1e-5
 // expect: true
 
-//print (a.gradient(m)-numericalgradient(a, m)).norm() < 1e-5
+print (a.gradient(m)-numericalgradient(a, m)).norm() < 1e-5
 // expect: true

--- a/test/functionals/area/area2.morpho
+++ b/test/functionals/area/area2.morpho
@@ -5,9 +5,11 @@ var a = Area()
 
 print m
 // expect: <Mesh: 4 vertices>
-
-print (a.integrand(m) - Matrix([[ 0.5, 0.5 ]]) ).norm() < 1e-5
+print (a.total(m) - 1) < 1e-5
 // expect: true
 
-print (a.gradient(m)-numericalgradient(a, m)).norm() < 1e-5
+//print (a.integrand(m) - Matrix([[ 0.5, 0.5 ]]) ).norm() < 1e-5
+// expect: true
+
+//print (a.gradient(m)-numericalgradient(a, m)).norm() < 1e-5
 // expect: true

--- a/test/functionals/lineintegral/lineintegral_fieldgradient.morpho
+++ b/test/functionals/lineintegral/lineintegral_fieldgradient.morpho
@@ -1,0 +1,25 @@
+import meshtools 
+
+var m = LineMesh(fn (u) [u,0,0], 0..1:0.1)
+
+var f = Field(m, fn (x,y,z) x)
+
+var ll = LineIntegral(fn (x, f) f^2, f)
+
+var grad = ll.fieldgradient(f)
+
+var ngrad = f.clone() 
+
+var eps = 1e-8
+var fl, fr 
+for (i in 0...f.count()) {
+    var f0 = f[i]
+    f[i]=f0+eps 
+    fr=ll.total(m)
+    f[i]=f0-eps
+    fl=ll.total(m)
+    f[i]=f0 
+    ngrad[i]=(fr-fl)/(2*eps)
+}
+
+print (grad-ngrad).linearize().norm() < 1e-8

--- a/test/functionals/lineintegral/lineintegral_fieldgradient.morpho
+++ b/test/functionals/lineintegral/lineintegral_fieldgradient.morpho
@@ -22,4 +22,4 @@ for (i in 0...f.count()) {
     ngrad[i]=(fr-fl)/(2*eps)
 }
 
-print (grad-ngrad).linearize().norm() < 1e-8
+print (grad-ngrad).linearize().norm() < 1e-8 // expect: true

--- a/test/functionals/lineintegral/selection.morpho
+++ b/test/functionals/lineintegral/selection.morpho
@@ -12,22 +12,19 @@ var f = Field(m, fn (x,y,z) x)
 // A line integral with only spatial dependence
 var lc = LineIntegral(fn (x, f) (f*(1-f))^2, f)
 
-print lc.integrand(f, s)
-// expect: [ 0.000285333 0.00164533 0.00350533 0.00514533 0.00608533 0 0 0 0 0 ]
+var int = lc.integrand(f, s)
 
-print lc.total(f, s)
-// expect: 0.0166667
+var exp = Matrix([[ 0.000285333, 0.00164533, 0.00350533, 0.00514533, 0.00608533, 0, 0, 0, 0, 0 ]])
 
-var grad=lc.fieldgradient(f, s)
-for (x in grad) print x
-// expect: 0.00285333
-// expect: 0.0136
-// expect: 0.0186
-// expect: 0.0164
-// expect: 0.0094
-// expect: 0.00164666
-// expect: 0
-// expect: 0
-// expect: 0
-// expect: 0
-// expect: 0
+print (int-exp).norm() < 1e-8
+// expect: true
+
+print abs(lc.total(f, s) - 0.0166667) < 1e-6
+// expect: true
+
+var grad=lc.fieldgradient(f, s).linearize()
+
+var ngrad = Matrix([ 0.00285333, 0.0136, 0.0186, 0.0164, 0.0094, 0.00164666, 0, 0, 0, 0, 0 ])
+
+print (grad-ngrad).norm() < 1e-8
+// expect: true

--- a/test/functionals/nematicelectric/nematicelectric.morpho
+++ b/test/functionals/nematicelectric/nematicelectric.morpho
@@ -2,6 +2,7 @@
 
 import meshtools
 import plot
+import "../numericalderivatives.morpho"
 
 var L = 1
 var np = 10
@@ -27,13 +28,11 @@ var lne = NematicElectric(nn, phi)
 print lne.integrand(m)
 // expect: [ 0.25 ]
 
-print lne.total(m)
-// expect: 0.25
+print abs(lne.total(m) - 0.25) < 1e-8
+// expect: true
 
-print lne.gradient(m)
-// expect: [ 0.75 -0.25 -0.5 ]
-// expect: [ -0.25 0 0.25 ]
-// expect: [ 0 0 0 ]
+print (lne.gradient(m)-numericalgradient(lne, m)).norm() < 1e-8
+// expect: true
 
 print lne.fieldgradient(nn)
 // expect: <Field>


### PR DESCRIPTION
This PR uses a thread pool to parallelize force and energy calculations, giving a considerable speedup for programs where these are the limiting factor. 

To use, simply run morpho with -wX where X is the number of worker threads to use. 

Note that there is an outstanding (and tricky) issue to resolve with clock(): it reports the CPU time *not* the wall time. For now, use an external timing utility. There seems to be a lack of platform independent solutions to report wall time at the right level of granularity. 