### PR TITLE
New System functionality

### DIFF
--- a/morpho5/Makefile.linux
+++ b/morpho5/Makefile.linux
@@ -21,7 +21,7 @@ help = $(wildcard docs/*.md)
 modules = $(wildcard modules/*)
 
 LDFLAGS  = -ldl -lm -lblas -llapacke -lcxsparse -lpthread
-CFLAGS   = $(EXTCFLAGS) -DMORPHO_RESOURCESDIR=\"$(RESOURCEPREFIX)\" -std=c99 -O3 -I. -I/usr/include/suitesparse -I./datastructures -I./geometry -I./interface -I./utils -I./vm -I./builtin
+CFLAGS   = $(EXTCFLAGS) -Wl,-export-dynamic -DMORPHO_RESOURCESDIR=\"$(RESOURCEPREFIX)\" -std=c99 -O3 -I. -I/usr/include/suitesparse -I./datastructures -I./geometry -I./interface -I./utils -I./vm -I./builtin
 
 morpho5: $(obj)
 	$(CC) -o $@ $^ $(LDFLAGS) $(CFLAGS)

--- a/morpho5/Makefile.linux
+++ b/morpho5/Makefile.linux
@@ -20,7 +20,7 @@ endif
 help = $(wildcard docs/*.md)
 modules = $(wildcard modules/*)
 
-LDFLAGS  = -lm -lblas -llapacke -lcxsparse -lpthread -ldl
+LDFLAGS  = -ldl -lm -lblas -llapacke -lcxsparse -lpthread
 CFLAGS   = $(EXTCFLAGS) -DMORPHO_RESOURCESDIR=\"$(RESOURCEPREFIX)\" -std=c99 -O3 -I. -I/usr/include/suitesparse -I./datastructures -I./geometry -I./interface -I./utils -I./vm -I./builtin
 
 morpho5: $(obj)

--- a/morpho5/build.h
+++ b/morpho5/build.h
@@ -77,7 +77,7 @@
 #define MORPHO_ERRORSTRINGSIZE 255
 
 /** @brief Default size of input buffer. */
-#define MORPHO_INPUTBUFFERDEFAULTSIZE 255
+#define MORPHO_INPUTBUFFERDEFAULTSIZE 1024
 
 /** @brief Maximum file name length. */
 #define MORPHO_MAXIMUMFILENAMELENGTH 255

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -54,6 +54,30 @@ value System_print(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
+/** Sleep for a specified number of milliseconds */
+void system_sleep(int msecs) {
+#ifdef WIN32
+    Sleep (msecs);
+#else
+    struct timespec t;
+    t.tv_sec  =  msecs / 1000;
+    t.tv_nsec = (msecs % 1000) * 1000000;
+    nanosleep (&t, NULL);
+#endif
+}
+
+/** Sleep for a specified number of seconds */
+value System_sleep(vm *v, int nargs, value *args) {
+    if (nargs==1 && MORPHO_ISNUMBER(MORPHO_GETARG(args, 0))) {
+        double t;
+        if (morpho_valuetofloat(MORPHO_GETARG(args, 0), &t)) {
+            system_sleep((int) (1000*t));
+        }
+    } else morpho_runtimeerror(v, SLEEP_ARGS);
+    
+    return MORPHO_NIL;
+}
+
 /** Readline */
 value System_readline(vm *v, int nargs, value *args) {
     char buffer[MORPHO_INPUTBUFFERDEFAULTSIZE];
@@ -80,8 +104,9 @@ MORPHO_BEGINCLASS(System)
 MORPHO_METHOD(SYSTEM_PLATFORM_METHOD, System_platform, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_VERSION_METHOD, System_version, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_CLOCK_METHOD, System_clock, BUILTIN_FLAGSEMPTY),
-MORPHO_METHOD(SYSTEM_READLINE_METHOD, System_readline, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_PRINT_METHOD, System_print, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(SYSTEM_SLEEP_METHOD, System_sleep, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(SYSTEM_READLINE_METHOD, System_readline, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_EXIT_METHOD, System_exit, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS
 
@@ -95,6 +120,7 @@ void system_initialize(void) {
     
     builtin_addclass(SYSTEM_CLASSNAME, MORPHO_GETCLASSDEFINITION(System), objclass);
     
+    morpho_defineerror(SLEEP_ARGS, ERROR_HALT, SLEEP_ARGS_MSG);
     morpho_defineerror(VM_EXIT, ERROR_EXIT, VM_EXIT_MSG);
 }
 

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -48,6 +48,28 @@ value System_clock(vm *v, int nargs, value *args) {
     return MORPHO_FLOAT( ((double) time)/((double) CLOCKS_PER_SEC) );
 }
 
+/** Print */
+value System_print(vm *v, int nargs, value *args) {
+    for (int i=0; i<nargs; i++) morpho_printvalue(MORPHO_GETARG(args, i));
+    return MORPHO_NIL;
+}
+
+/** Readline */
+value System_readline(vm *v, int nargs, value *args) {
+    char buffer[MORPHO_INPUTBUFFERDEFAULTSIZE];
+    value out = MORPHO_NIL;
+     
+    if (fgets(buffer, sizeof(buffer), stdin)) {
+        char *p = strchr(buffer, '\n');
+        if (p) *p = '\0';
+        
+        out = object_stringfromcstring(buffer, strlen(buffer));
+        if (MORPHO_ISSTRING(out)) morpho_bindobjects(v, 1, &out);
+    }
+    
+    return out;
+}
+
 /** Exit */
 value System_exit(vm *v, int nargs, value *args) {
     morpho_runtimeerror(v, VM_EXIT);
@@ -58,6 +80,8 @@ MORPHO_BEGINCLASS(System)
 MORPHO_METHOD(SYSTEM_PLATFORM_METHOD, System_platform, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_VERSION_METHOD, System_version, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_CLOCK_METHOD, System_clock, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(SYSTEM_READLINE_METHOD, System_readline, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(MORPHO_PRINT_METHOD, System_print, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_EXIT_METHOD, System_exit, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS
 

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -11,6 +11,10 @@
 #include "builtin.h"
 #include "veneer.h"
 
+#ifndef WIN32
+#include <sys/time.h>
+#endif
+
 /** Set arguments passed to morpho program */
 
 static value arglist;

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -42,11 +42,21 @@ value System_version(vm *v, int nargs, value *args) {
     return ret;
 }
 
+double system_clock(void) {
+#ifdef WIN32
+    SYSTEMTIME st;
+    GetSystemTime (&st);
+    return ((double) st.wSecond) + st.wMilliseconds * 1e-6;
+#else
+    struct timeval tv;
+    gettimeofday (&tv, NULL);
+    return ((double) tv.tv_sec) + tv.tv_usec * 1e-6;
+#endif
+}
+
 /** Clock */
 value System_clock(vm *v, int nargs, value *args) {
-    clock_t time;
-    time = clock();
-    return MORPHO_FLOAT( ((double) time)/((double) CLOCKS_PER_SEC) );
+    return MORPHO_FLOAT(system_clock());
 }
 
 /** Print */

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -4,6 +4,7 @@
  *  @brief Built in class to provide access to the runtime
  */
 
+#include <stdio.h>
 #include <time.h>
 #include "build.h"
 #include "system.h"
@@ -51,6 +52,7 @@ value System_clock(vm *v, int nargs, value *args) {
 /** Print */
 value System_print(vm *v, int nargs, value *args) {
     for (int i=0; i<nargs; i++) morpho_printvalue(MORPHO_GETARG(args, i));
+    fflush(stdout);
     return MORPHO_NIL;
 }
 

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -139,7 +139,7 @@ value System_readline(vm *v, int nargs, value *args) {
 
 /** Arguments passed to the process */
 value System_arguments(vm *v, int nargs, value *args) {
-    return MORPHO_OBJECT(arglist);
+    return arglist;
 }
 
 /** Exit */

--- a/morpho5/builtin/system.c
+++ b/morpho5/builtin/system.c
@@ -4,6 +4,8 @@
  *  @brief Built in class to provide access to the runtime
  */
 
+#define _POSIX_C_SOURCE 199309L
+
 #include <stdio.h>
 #include <time.h>
 #include "build.h"

--- a/morpho5/builtin/system.h
+++ b/morpho5/builtin/system.h
@@ -21,12 +21,16 @@
 #define SYSTEM_VERSION_METHOD         "version"
 #define SYSTEM_CLOCK_METHOD           "clock"
 #define SYSTEM_READLINE_METHOD        "readline"
+#define SYSTEM_SLEEP_METHOD           "sleep"
 #define SYSTEM_EXIT_METHOD            "exit"
 
 #define SYSTEM_MACOS   "macos"
 #define SYSTEM_LINUX   "linux"
 #define SYSTEM_UNIX    "unix"
 #define SYSTEM_WINDOWS "windows"
+
+#define SLEEP_ARGS                        "SystmSlpArgs"
+#define SLEEP_ARGS_MSG                    "Sleep method expects a time in seconds."
 
 void system_initialize(void);
 void system_finalize(void);

--- a/morpho5/builtin/system.h
+++ b/morpho5/builtin/system.h
@@ -22,6 +22,7 @@
 #define SYSTEM_CLOCK_METHOD           "clock"
 #define SYSTEM_READLINE_METHOD        "readline"
 #define SYSTEM_SLEEP_METHOD           "sleep"
+#define SYSTEM_ARGUMENTS_METHOD       "arguments"
 #define SYSTEM_EXIT_METHOD            "exit"
 
 #define SYSTEM_MACOS   "macos"

--- a/morpho5/builtin/system.h
+++ b/morpho5/builtin/system.h
@@ -20,6 +20,7 @@
 #define SYSTEM_PLATFORM_METHOD        "platform"
 #define SYSTEM_VERSION_METHOD         "version"
 #define SYSTEM_CLOCK_METHOD           "clock"
+#define SYSTEM_READLINE_METHOD        "readline"
 #define SYSTEM_EXIT_METHOD            "exit"
 
 #define SYSTEM_MACOS   "macos"

--- a/morpho5/docs/system.md
+++ b/morpho5/docs/system.md
@@ -6,16 +6,28 @@
 
 The `System` class provides information and access to some features of the runtime environment. 
 
+[showsubtopics]: # (subtopics)
+
+## Platform
+[tagplatform]: # (platform)
+
 Detect which platform morpho was compiled for: 
 
     print System.platform() 
 
-which could return `macos`, `linux`, `unix` or `windows`. 
+which returns `"macos"`, `"linux"`, `"unix"` or `"windows"`. 
+
+## Version
+[tagversion]: # (version)
 
 Find the current version of morpho: 
 
     print System.version() 
 
+## Exit
+[tagexit]: # (exit)
+
 Stop execution of a program:
 
     System.exit() 
+

--- a/morpho5/docs/system.md
+++ b/morpho5/docs/system.md
@@ -24,10 +24,48 @@ Find the current version of morpho:
 
     print System.version() 
 
+## Clock
+[tagclock]: # (clock)
+
+Returns the system time in seconds, with at least millisecond granularity. Primarily intended for timing:
+
+    var start=System.clock() 
+    // Do something 
+    print System.clock()-start 
+
+Note that `System.clock` measures the actual physical time elapsed, not the time spent in a process. 
+
+## Sleep
+[tagsleep]: # (sleep)
+
+Pauses the program for a specified number of seconds:
+
+    System.sleep(0.5) // Sleep for half a second
+
+## Readline
+[tagreadline]: # (readline)
+
+Reads a line of input from the console:
+
+    var in = System.readline() 
+
+## Arguments
+[tagargunents]: # (arguments)
+
+Returns a `List` of arguments passed to the current morpho on the command line. 
+
+    var args = System.arguments() 
+    for (e in args) print e 
+
+Run a morpho program with arguments: 
+
+    morpho5 program.morpho hello world
+
+Note that, in line with UNIX conventions, command line arguments before the program file name are passed to the `morpho5` runtime; those after are passed to the morpho program via `System.arguments`. 
+
 ## Exit
 [tagexit]: # (exit)
 
 Stop execution of a program:
 
     System.exit() 
-

--- a/morpho5/main.c
+++ b/morpho5/main.c
@@ -16,9 +16,10 @@
 int main(int argc, const char * argv[]) {
     clioptions opt = CLI_RUN;
     const char *file = NULL;
+    int i=0;
 
     /* Process command line arguments */
-    for (unsigned int i=1; i<argc; i++) {
+    for (i=1; i<argc; i++) {
         const char *option = argv[i];
         if (argv[i] && option[0]=='-') {
             switch (option[1]) {
@@ -60,10 +61,13 @@ int main(int argc, const char * argv[]) {
             }
         } else {
             file = option;
+            break;
         }
     }
 
     morpho_initialize();
+    
+    if (i<argc) morpho_setargs(argc-i-1, argv+i+1); // Pass unprocessed args to the morpho runtime.
 
     if (file) cli_run(file, opt);
     else cli(opt);

--- a/morpho5/morpho.h
+++ b/morpho5/morpho.h
@@ -156,6 +156,7 @@ int morpho_threadnumber(void);
 void morpho_setbaseclass(value clss);
 void morpho_initialize(void);
 void morpho_finalize(void);
+void morpho_setargs(int argc, const char * argv[]); // Pass arguments to morpho
 
 /* Obtain and use subkernels [for internal use only] */
 bool vm_subkernels(vm *v, int nkernels, vm **subkernels);

--- a/morpho5/utils/memory.c
+++ b/morpho5/utils/memory.c
@@ -6,7 +6,6 @@
 
 #include <stdio.h>
 #include "memory.h"
-#include "dictionary.h"
 
 #ifdef MORPHO_DEBUG_STRESSGARBAGECOLLECTOR
 #include "morpho.h"

--- a/morpho5/utils/memory.h
+++ b/morpho5/utils/memory.h
@@ -8,7 +8,6 @@
 #define memory_h
 
 #include <stdlib.h>
-#include "build.h"
 
 /** Macro to redirect malloc through our memory management */
 #define MORPHO_MALLOC(size) morpho_allocate(NULL, 0, size)

--- a/test/system/args.morpho
+++ b/test/system/args.morpho
@@ -1,0 +1,7 @@
+// Gets the arguments and prints them 
+
+system("morpho5 system/args.xmorpho")
+// expect: [  ]
+
+system("morpho5 system/args.xmorpho hello world")
+// expect: [ hello, world ]

--- a/test/system/args.xmorpho
+++ b/test/system/args.xmorpho
@@ -1,0 +1,5 @@
+// Gets the arguments and prints them 
+
+var args = System.arguments() 
+
+print args 


### PR DESCRIPTION
This PR includes a number of new methods on the System class, designed to help morpho scripts interact with the environment: 

- clock() now returns wall time rather than process time, which helps with benchmarking.
- sleep() now pauses morpho for a specified amount of time.
- readline() reads a single line of text from stdin. 
- arguments() returns command line arguments passed to morpho *after* the filename. 