### PR TITLE
Safe linearize

### DIFF
--- a/morpho5/geometry/field.c
+++ b/morpho5/geometry/field.c
@@ -812,6 +812,21 @@ value Field_mesh(vm *v, int nargs, value *args) {
 /** Get the matrix that stores the Field */
 value Field_linearize(vm *v, int nargs, value *args) {
     objectfield *f=MORPHO_GETFIELD(MORPHO_SELF(args));
+    value out = MORPHO_NIL;
+    
+    objectmatrix *m=object_clonematrix(&f->data);
+    if (m) {
+        out = MORPHO_OBJECT(m);
+        morpho_bindobjects(v, 1, &out);
+    }
+    
+    return out;
+}
+
+/** Directly the matrix that stores the Field
+ @warning only use when you know what you're doing.  */
+value Field_unsafelinearize(vm *v, int nargs, value *args) {
+    objectfield *f=MORPHO_GETFIELD(MORPHO_SELF(args));
     
     return MORPHO_OBJECT(&f->data);
 }
@@ -836,7 +851,8 @@ MORPHO_METHOD(MORPHO_PRINT_METHOD, Field_print, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(MORPHO_CLONE_METHOD, Field_clone, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(FIELD_SHAPE_METHOD, Field_shape, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(FIELD_MESH_METHOD, Field_mesh, BUILTIN_FLAGSEMPTY),
-MORPHO_METHOD(FIELD_LINEARIZE_METHOD, Field_linearize, BUILTIN_FLAGSEMPTY)
+MORPHO_METHOD(FIELD_LINEARIZE_METHOD, Field_linearize, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(FIELD__LINEARIZE_METHOD, Field_unsafelinearize, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS
 
 /* **********************************************************************

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -55,7 +55,7 @@ objectfield *object_newfield(objectmesh *mesh, value prototype, unsigned int *do
 #define FIELD_SHAPE_METHOD   "shape"
 #define FIELD_MESH_METHOD    "mesh"
 #define FIELD_LINEARIZE_METHOD    "linearize"
-#define FIELD__LINEARIZE_METHOD    "_linearize"
+#define FIELD__LINEARIZE_METHOD    "__linearize"
 
 #define FIELD_INDICESOUTSIDEBOUNDS       "FldBnds"
 #define FIELD_INDICESOUTSIDEBOUNDS_MSG   "Field index out of bounds."

--- a/morpho5/geometry/field.h
+++ b/morpho5/geometry/field.h
@@ -55,6 +55,7 @@ objectfield *object_newfield(objectmesh *mesh, value prototype, unsigned int *do
 #define FIELD_SHAPE_METHOD   "shape"
 #define FIELD_MESH_METHOD    "mesh"
 #define FIELD_LINEARIZE_METHOD    "linearize"
+#define FIELD__LINEARIZE_METHOD    "_linearize"
 
 #define FIELD_INDICESOUTSIDEBOUNDS       "FldBnds"
 #define FIELD_INDICESOUTSIDEBOUNDS_MSG   "Field index out of bounds."

--- a/test/field/linearize.morpho
+++ b/test/field/linearize.morpho
@@ -6,7 +6,7 @@ print m
 
 var f = Field(m)
 var a = f.linearize() 
-var b = f._linearize() 
+var b = f.__linearize() 
 
 print a
 // expect: [ 0 ]

--- a/test/field/linearize.morpho
+++ b/test/field/linearize.morpho
@@ -6,6 +6,7 @@ print m
 
 var f = Field(m)
 var a = f.linearize() 
+var b = f._linearize() 
 
 print a
 // expect: [ 0 ]
@@ -14,6 +15,14 @@ print a
 // expect: [ 0 ]
 
 for (i in 0...4) a[i] = i
+print f 
+// expect: <Field>
+// expect: [ 0 ]
+// expect: [ 0 ]
+// expect: [ 0 ]
+// expect: [ 0 ]
+
+for (i in 0...4) b[i] = i
 print f 
 // expect: <Field>
 // expect: [ 0 ]


### PR DESCRIPTION
This PR changes the behavior of Field.linearize(). 

Previously, Field.linearize() gave direct access to the underlying Matrix object. While not widely used outside of optimizer prototypes, this has proven to be a major design flaw. We therefore change the behavior of Field.linearize() to return a CLONE of the underlying matrix store as a column vector. 

A second method, Field.__linearize() continues to implement the old functionality. We have created a new convention that functions or methods beginning with __ indicate to the programmer that they are intended to be used by the optimizer and may have significant usage restrictions. 