### PR TITLE
Fixresource

### DIFF
--- a/morpho5/Makefile
+++ b/morpho5/Makefile
@@ -6,11 +6,13 @@ RESOURCEPREFIX = $(MORPHORESOURCESDIR)
 HELPDIR = $(RESOURCEPREFIX)/share/help
 MODULESDIR = $(RESOURCEPREFIX)/share/modules
 HEADERSDIR = $(RESOURCEPREFIX)/include
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib
 else 
 RESOURCEPREFIX = /usr/local
 HELPDIR = $(RESOURCEPREFIX)/share/morpho/help
 MODULESDIR = $(RESOURCEPREFIX)/share/morpho/modules
 HEADERSDIR = $(RESOURCEPREFIX)/include/morpho
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib/morpho
 endif 
 
 ifdef DESTDIR 
@@ -47,6 +49,10 @@ headers:
 	mkdir -p $(HEADERSDIR)
 	find . -type f -name '*.h' -exec cp {} $(HEADERSDIR) \;
 
+.PHONY: extensions
+headers: 
+	mkdir -p $(EXTENSIONSDIR)
+
 .PHONY: install
 install: morpho5
 	mkdir -p $(INSTALLDIR)
@@ -54,5 +60,6 @@ install: morpho5
 	make modules
 	make help
 	make headers 
+	make extensions
 	make clean
 	

--- a/morpho5/Makefile.linux
+++ b/morpho5/Makefile.linux
@@ -5,10 +5,14 @@ ifdef MORPHORESOURCESDIR
 RESOURCEPREFIX = $(MORPHORESOURCESDIR)
 HELPDIR = $(RESOURCEPREFIX)/share/help
 MODULESDIR = $(RESOURCEPREFIX)/share/modules
+HEADERSDIR = $(RESOURCEPREFIX)/include
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib
 else 
 RESOURCEPREFIX = /usr/local
 HELPDIR = $(RESOURCEPREFIX)/share/morpho/help
 MODULESDIR = $(RESOURCEPREFIX)/share/morpho/modules
+HEADERSDIR = $(RESOURCEPREFIX)/include/morpho
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib/morpho
 endif 
 
 ifdef DESTDIR 
@@ -45,6 +49,10 @@ headers:
 	mkdir -p $(HEADERSDIR)
 	find . -type f -name '*.h' -exec cp {} $(HEADERSDIR) \;
 
+.PHONY: extensions
+headers: 
+	mkdir -p $(EXTENSIONSDIR)
+
 .PHONY: install
 install: morpho5
 	mkdir -p $(INSTALLDIR)
@@ -52,6 +60,7 @@ install: morpho5
 	make modules
 	make help
 	make headers
+	make extensions
 	make clean
 
 nonanboxing: CFLAGS += -D_NO_NAN_BOXING

--- a/morpho5/Makefile.m1
+++ b/morpho5/Makefile.m1
@@ -5,10 +5,14 @@ ifdef MORPHORESOURCESDIR
 RESOURCEPREFIX = $(MORPHORESOURCESDIR)
 HELPDIR = $(RESOURCEPREFIX)/share/help
 MODULESDIR = $(RESOURCEPREFIX)/share/modules
+HEADERSDIR = $(RESOURCEPREFIX)/include
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib
 else 
 RESOURCEPREFIX = /usr/local
 HELPDIR = $(RESOURCEPREFIX)/share/morpho/help
 MODULESDIR = $(RESOURCEPREFIX)/share/morpho/modules
+HEADERSDIR = $(RESOURCEPREFIX)/include/morpho
+EXTENSIONSDIR = $(RESOURCEPREFIX)/lib/morpho
 endif 
 
 ifdef DESTDIR 
@@ -45,6 +49,10 @@ headers:
 	mkdir -p $(HEADERSDIR)
 	find . -type f -name '*.h' -exec cp {} $(HEADERSDIR) \;
 
+.PHONY: extensions
+headers: 
+	mkdir -p $(EXTENSIONSDIR)
+
 .PHONY: install
 install: morpho5
 	mkdir -p $(INSTALLDIR)
@@ -52,4 +60,5 @@ install: morpho5
 	make modules
 	make help
 	make headers
+	make extensions
 	make clean

--- a/morpho5/utils/common.c
+++ b/morpho5/utils/common.c
@@ -527,15 +527,25 @@ void resources_basefolders(resourceenumerator *en) {
     }
 }
 
+/** Finds the character at which the extension separator occurs in a filename. Returns NULL if no extension is present */
+char *resources_findextension(char *f) {
+    for (char *c = f+strlen(f); c>=f; c--) {
+        if (*c=='.') return c;
+    }
+    
+    return NULL;
+}
+
 /** Checks if a filename matches all criteria in a resourceenumerator
  @param[in] en - initialized enumerator */
 bool resources_matchfile(resourceenumerator *en, char *file) {
-    char *c = file+strlen(file);
-
-    while (c>=file && *c!='.') c--; // Skip past extension
+    
+    // Skip extension
+    char *ext = resources_findextension(file);
+    if (!ext) ext = file+strlen(file); // If no extension found, just go to the end of the filename
 
     if (en->fname) { // Match filename if requested
-        char *f = c;
+        char *f = ext;
         while (f>=file && *f!=MORPHO_SEPARATOR) f--; // Find last separator
         if (*f==MORPHO_SEPARATOR) f++; // If we stopped at a separator, skip it
         
@@ -544,9 +554,9 @@ bool resources_matchfile(resourceenumerator *en, char *file) {
 
     if (!en->ext) return true; // Match extension only if requested
 
-    if (*c!='.') return false;
+    if (*ext!='.') return false;
     for (int k=0; *en->ext[k]!='\0'; k++) { // Check extension against possible extensions
-        if (strcmp(c+1, en->ext[k])==0) return true; // We have a match
+        if (strcmp(ext+1, en->ext[k])==0) return true; // We have a match
     }
 
     return false;

--- a/morpho5/utils/common.c
+++ b/morpho5/utils/common.c
@@ -549,7 +549,9 @@ bool resources_matchfile(resourceenumerator *en, char *file) {
         while (f>=file && *f!=MORPHO_SEPARATOR) f--; // Find last separator
         if (*f==MORPHO_SEPARATOR) f++; // If we stopped at a separator, skip it
         
-        if (strncmp(en->fname, f, strlen(en->fname))!=0) return false; // Now compare
+        size_t len = strlen(en->fname);
+        if (strncmp(en->fname, f, len)!=0) return false; // Compare string
+        if (!(f[len]=='.' || f[len]=='\0')) return false; // Ensure filename is terminated by null byte or file extension separator.
     }
 
     if (!en->ext) return true; // Match extension only if requested


### PR DESCRIPTION
This PR fixes a number of bugs in the resource finder. 

* File extensions are now handled correctly.
* Resource finder now checks that a morpho extension links AND initializes correctly before returning success. 
* File names now match exactly rather than partially. 

Additionally the make files have been updated to ensure a library folder always exists for morpho extensions. 