### PR TITLE
Allow absolute paths for povray render

### DIFF
--- a/morpho5/modules/povray.morpho
+++ b/morpho5/modules/povray.morpho
@@ -209,9 +209,9 @@ class POVRaytracer {
     if (quiet) silent = "&> /dev/null"
     var disp = ""
     if (!display) disp = "-D"
-    system("povray ./\"${path}\" ${disp} +A +W${self.width} +H${self.height} ${silent}")
+    system("povray \"${path}\" ${disp} +A +W${self.width} +H${self.height} ${silent}")
     var out = self._slice(path, 0, path.count()-4)
-    if (!quiet && display) system("open ./${out}.png")
+    if (!quiet && display) system("open ${out}.png")
   }
   /*
   private method: slice a string given a start and an end


### PR DESCRIPTION
Removes the ./ from the filenames, thus allowing for absolute paths as inputs.