### PR TITLE
Fix parenthesis

### DIFF
--- a/help/complex.md
+++ b/help/complex.md
@@ -25,7 +25,7 @@ or alternatively:
     print a.real()
     print a.imag() 
 
-[showsubtopics]: # subtopics
+[showsubtopics]: # (subtopics)
 
 ## Angle
 [tagangle]: # (angle)


### PR DESCRIPTION
The complex.md contains a `subtopics` command without parenthesis, causing incorrect behavior in the RTD. This fixes that.