### PR TITLE
CI workflow to perform automated testing with multithreading

### DIFF
--- a/.github/workflows/buildandtestmultithreaded.yml
+++ b/.github/workflows/buildandtestmultithreaded.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: TestMultiThreaded
 
 on:
   push:

--- a/.github/workflows/buildandtestmultithreaded.yml
+++ b/.github/workflows/buildandtestmultithreaded.yml
@@ -1,0 +1,42 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: configure
+      run:  |
+        sudo apt update
+        sudo apt install libsuitesparse-dev
+        sudo apt install liblapacke-dev
+        sudo apt install libunistring-dev
+        python -m pip install --upgrade pip
+        python -m pip install regex colored
+    - name: make
+      run: |
+        mkdir build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Release ..
+        sudo make install
+        sudo mkdir /usr/local/lib/morpho
+    - name: getcli
+      run: |
+        git clone https://github.com/Morpho-lang/morpho-cli.git
+        cd morpho-cli 
+        mkdir build
+        cd build
+        cmake ..
+        sudo make install
+    - name: test 
+      run: |
+        cd test
+        python3 test.py -c -m

--- a/.github/workflows/buildandtestmultithreaded.yml
+++ b/.github/workflows/buildandtestmultithreaded.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ dkms.conf
 .entitlements
 .vscode/settings.json
 
-test/FailedTests.txt
+test/FailedTests*.txt
 *.png
 *.out
 manual/src/manual.lyx~

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The simplest way to install morpho is through the [homebrew package manager](htt
 ```
 brew update
 brew tap morpho-lang/morpho
-brew install morpho
+brew install morpho morpho-cli morpho-morphoview
 ```
 
-If you need to uninstall morpho, simply open a terminal and type `brew uninstall morpho`. It's very important to uninstall the homebrew morpho in this way before attempting to install from source as below.
+If you need to uninstall morpho, simply open a terminal and type `brew uninstall morpho-cli morpho-morphoview morpho`. It's very important to uninstall the homebrew morpho in this way before attempting to install from source as below.
 
 ### Install from source
 

--- a/test/test.py
+++ b/test/test.py
@@ -184,15 +184,15 @@ total=0   # total number of tests
 # this is being run for continous integration
 CI = False
 # Also look for a command line argument that says this is being run with multiple threads
-MP = False
+MT = False
 for arg in sys.argv:
     if arg == '-c': # if the argument is -c, then we are running in CI mode
         CI = True
     if arg == '-m': # if the argument is -m, then we are running in multi-thread mode
-        MP = True
+        MT = True
 
 failedTestsFileName = "FailedTests.txt"
-if MP:
+if MT:
     failedTestsFileName = "FailedTestsMultiThreaded.txt"
     command += " -w4" 
     print("Running tests with 4 threads")

--- a/test/test.py
+++ b/test/test.py
@@ -183,11 +183,23 @@ total=0   # total number of tests
 # look for a command line arguement that says
 # this is being run for continous integration
 CI = False
-if (len(sys.argv) > 1):
-    CI = sys.argv[1] == '-c'
+# Also look for a command line argument that says this is being run with multiple threads
+MP = False
+if (len(sys.argv) == 2):
+    CI = sys.argv[1] == '-c' # if the argument is -c, then we are running in CI mode
+    MP = sys.argv[1] == '-m' # if the argument is -m, then we are running in multi-thread mode
+elif (len(sys.argv) == 3):
+    CI = sys.argv[1] == '-c' or sys.argv[2] == '-c'
+    MP = sys.argv[1] == '-m' or sys.argv[2] == '-m'
+
+failedTestsFileName = "FailedTests.txt"
+if MP:
+    failedTestsFileName = "FailedTestsMultiThreaded.txt"
+    command = "morpho6 -w2"
+    print("Running tests with 2 threads")
 
 files=glob.glob('**/**.'+ext, recursive=True)
-with open("FailedTests.txt",'w') as testLog:
+with open(failedTestsFileName,'w') as testLog:
 
     for f in files:
         # print(f)

--- a/test/test.py
+++ b/test/test.py
@@ -185,18 +185,17 @@ total=0   # total number of tests
 CI = False
 # Also look for a command line argument that says this is being run with multiple threads
 MP = False
-if (len(sys.argv) == 2):
-    CI = sys.argv[1] == '-c' # if the argument is -c, then we are running in CI mode
-    MP = sys.argv[1] == '-m' # if the argument is -m, then we are running in multi-thread mode
-elif (len(sys.argv) == 3):
-    CI = sys.argv[1] == '-c' or sys.argv[2] == '-c'
-    MP = sys.argv[1] == '-m' or sys.argv[2] == '-m'
+for arg in sys.argv:
+    if arg == '-c': # if the argument is -c, then we are running in CI mode
+        CI = True
+    if arg == '-m': # if the argument is -m, then we are running in multi-thread mode
+        MP = True
 
 failedTestsFileName = "FailedTests.txt"
 if MP:
     failedTestsFileName = "FailedTestsMultiThreaded.txt"
-    command = "morpho6 -w2"
-    print("Running tests with 2 threads")
+    command += " -w4" 
+    print("Running tests with 4 threads")
 
 files=glob.glob('**/**.'+ext, recursive=True)
 with open(failedTestsFileName,'w') as testLog:


### PR DESCRIPTION
This PR attempts to add a CI workflow to run the test-suite with `morpho6 -w2`, thus checking for bugs with multithreading.

Given the increase in parallelization in Morpho (yay!), this could be quite useful to spot bugs like #259 

It essentially adds one more argument flag to test.py and invokes it in the new workflow.


