### PR TITLE
Visitor pattern for Graphics simplified with Multiple Dispatch

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -14,7 +14,7 @@ from colored import stylize
 
 sys.path.append('../test')
 ext = "morpho"
-command = 'morpho5'
+command = 'morpho6'
 stk = '@stacktrace'
 err = '@error'
 

--- a/modules/graphics.morpho
+++ b/modules/graphics.morpho
@@ -628,8 +628,18 @@ class Show {
     out.write("W \"${graphic.title}\"")
   }
 
+  /* The visit method for a generic `item`. 
+
+  Here, we define this separate `visitgeneric` method that performs the intended generic task, and have the actual generic `visit` method call `visitgeneric`. This enables calls to the generic fallback from *within a specific implementation*. 
+  For example, the `visit` method for a `Sphere` object can call `self.visitgeneric(item, out)` to visit the `TriangleComplex` representation of the sphere, but calling `self.visit(item, out)` would result in an infinite loop.
+  */
   visitgeneric(item, out) {
     self.visit(item.totrianglecomplex(), out) 
+  }
+
+  // Will be used by Cylinder, Arrow and Tube
+  visit(item, out) {
+    self.visitgeneric(item, out)
   }
 
   visit(Sphere item, out) {
@@ -651,10 +661,6 @@ class Show {
     out.write("t ${item.center[0]} ${item.center[1]} ${item.center[2]}")
     out.write("d ${self.spheres[n].id}")
   }
-
-  visit(Cylinder item, out) { self.visitgeneric(item, out) }
-  visit(Arrow item, out) { self.visitgeneric(item, out) }
-  visit(Tube item, out) { self.visitgeneric(item, out) }
 
   trianglecomplexobjectdata(item, out) {
     var x = item.position

--- a/modules/graphics.morpho
+++ b/modules/graphics.morpho
@@ -76,9 +76,6 @@ class TriangleComplex {
     self.transmit = transmit
   }
 
-  accept(visitor, out) {
-    visitor.visittrianglecomplex(self, out)
-  }
 }
 
 /** Draws a cylinder
@@ -178,9 +175,6 @@ class Cylinder {
       return TriangleComplex(vertices, normals, col, conn)
   }
 
-  accept(visitor, out) {
-    visitor.visitcylinder(self, out)
-  }
 }
 
 var _sphere = [ PolyhedronMesh(
@@ -257,9 +251,6 @@ class Sphere {
     return TriangleComplex(v, normals, col, conn)
   }
 
-  accept(visitor, out) {
-    visitor.visitsphere(self, out)
-  }
 }
 
 /** Draws an arrow
@@ -371,9 +362,6 @@ class Arrow {
     return TriangleComplex(vertices, normals, col, conn)
   }
 
-  accept(visitor, out) {
-    visitor.visitarrow(self, out)
-  }
 }
 
 /** Draws a tube
@@ -517,9 +505,6 @@ class Tube {
       return TriangleComplex(vertices, normals, col, conn, filter=self.filter, transmit=self.transmit)
   }
 
-  accept(visitor, out) {
-    visitor.visittube(self, out)
-  }
 }
 
 /* **************************************
@@ -564,9 +549,6 @@ class Text {
     return m.transpose() 
   }
 
-  accept(visitor, out) {
-    visitor.visittext(self, out)
-  }
 }
 
 class Font {
@@ -647,10 +629,10 @@ class Show {
   }
 
   visitgeneric(item, out) {
-    self.visittrianglecomplex(item.totrianglecomplex(), out) 
+    self.visit(item.totrianglecomplex(), out) 
   }
 
-  visitsphere(item, out) {
+  visit(Sphere item, out) {
     var n = item.refinementlevel()
     
     if (item.color) {
@@ -670,9 +652,9 @@ class Show {
     out.write("d ${self.spheres[n].id}")
   }
 
-  visitcylinder(item, out) { self.visitgeneric(item, out) }
-  visitarrow(item, out) { self.visitgeneric(item, out) }
-  visittube(item, out) { self.visitgeneric(item, out) }
+  visit(Cylinder item, out) { self.visitgeneric(item, out) }
+  visit(Arrow item, out) { self.visitgeneric(item, out) }
+  visit(Tube item, out) { self.visitgeneric(item, out) }  
 
   trianglecomplexobjectdata(item, out) {
     var x = item.position
@@ -718,7 +700,7 @@ class Show {
     }
   }
 
-  visittrianglecomplex(item, out) {
+  visit(TriangleComplex item, out) {
     var id = self.uid() 
     out.write("o ${id}")
     self.trianglecomplexobjectdata(item, out)
@@ -795,7 +777,7 @@ class Show {
     return self.addfont(font, size, out) 
   }
 
-  visittext(item, out) {
+  visit(Text item, out) {
     var font = item.font
     if (!font) font = self.defaultfontname()
     var id = self.findfontid(font, item.size, out)
@@ -819,6 +801,6 @@ class Show {
   write(graphic, out) {
     self.preamble(graphic, out)
 
-    for (item in graphic.displaylist) item.accept(self, out)
+    for (item in graphic.displaylist) self.visit(item, out)
   }
 }

--- a/modules/graphics.morpho
+++ b/modules/graphics.morpho
@@ -654,7 +654,7 @@ class Show {
 
   visit(Cylinder item, out) { self.visitgeneric(item, out) }
   visit(Arrow item, out) { self.visitgeneric(item, out) }
-  visit(Tube item, out) { self.visitgeneric(item, out) }  
+  visit(Tube item, out) { self.visitgeneric(item, out) }
 
   trianglecomplexobjectdata(item, out) {
     var x = item.position

--- a/modules/povray.morpho
+++ b/modules/povray.morpho
@@ -59,7 +59,7 @@ class POVRaytracer {
     return arg
   }
 
-  visittext(item, out) {
+  visit(Text item, out) {
     var arg = self.optionalarg(item)
     out.write("text {" +
               "  ttf \"cyrvetic.ttf\" \"${item.string}\" 0.1, 0 \n" + 
@@ -85,7 +85,7 @@ class POVRaytracer {
     out.write(str)
   }
 
-  visitsphere(item, out) {
+  visit(Sphere item, out) {
     var arg = self.optionalarg(item)
     out.write("sphere {"+
               " ${self.vector(item.center)}, ${item.r}"+
@@ -94,7 +94,7 @@ class POVRaytracer {
               "} } }")
   }
 
-  visitcylinder(item, out) {
+  visit(Cylinder item, out) {
     var radius = 0.5*(item.end - item.start).norm()*item.aspectratio
     var arg = self.optionalarg(item)
     out.write("cylinder {"+
@@ -104,7 +104,7 @@ class POVRaytracer {
               "} } }")
   }
 
-  visitarrow(item, out) {
+  visit(Arrow item, out) {
     var dx = (item.end - item.start).norm()
     var radius = 0.5*dx*item.aspectratio
     var cylend = item.start + (item.end - item.start)*(1-item.aspectratio)
@@ -121,11 +121,11 @@ class POVRaytracer {
               "} } }")
   }
 
-  visittube(item, out) {
-    self.visittrianglecomplex(item.totrianglecomplex(), out)
+  visit(Tube item, out) {
+    self.visit(item.totrianglecomplex(), out)
   }
 
-  visittrianglecomplex(item, out) {
+  visit(TriangleComplex item, out) {
 
     var arg = self.optionalarg(item)
 
@@ -197,7 +197,7 @@ class POVRaytracer {
               "up <0,1,0> right <-1.33,0,0> angle ${self.viewangle}"+
               "look_at ${self.vector(self.look_at)} sky ${self.vector(self.sky)} }")
 
-    for (item in self.graphic.displaylist) item.accept(self, out)
+    for (item in self.graphic.displaylist) self.visit(item, out)
 
     var shadowless = ""
     if (self.shadowless) shadowless = " shadowless"


### PR DESCRIPTION
This small PR uses the new multiple dispatch functionality to simplify the visitor pattern used in the graphics module, where the graphics primitives are visited by `Show` and `POVRaytracer`. 

All examples tests are passing. 

It also updates the run command in the `examples.py` file, providing a temporary band-aid for #263 .