### PR TITLE
More tests for multiple dispatch

### DIFF
--- a/test/types/multiple_dispatch/duplicate_no_type.morpho
+++ b/test/types/multiple_dispatch/duplicate_no_type.morpho
@@ -1,4 +1,4 @@
-// Duplicate implementations with no Type annotations.
+// Duplicate implementations with one argument no Type annotations.
 // This one currently segfaults due to an infinite loop.
 
 /* Backtrace from LLDB: (the loop goes mfcompile_set -> mfcompile_dispatchany -> mfcompile_dispatchonparam -> mfcompile_set)

--- a/test/types/multiple_dispatch/duplicate_no_type.morpho
+++ b/test/types/multiple_dispatch/duplicate_no_type.morpho
@@ -1,0 +1,30 @@
+// Duplicate implementations with no Type annotations.
+// This one currently segfaults due to an infinite loop.
+
+/* Backtrace from LLDB: (the loop goes mfcompile_set -> mfcompile_dispatchany -> mfcompile_dispatchonparam -> mfcompile_set)
+    frame #62738: 0x00000001005335f8 libmorpho.dylib`mfcompile_set + 252
+    frame #62739: 0x0000000100533f20 libmorpho.dylib`mfcompile_dispatchany + 332
+    frame #62740: 0x00000001005341c4 libmorpho.dylib`mfcompile_dispatchonparam + 520
+    frame #62741: 0x00000001005335f8 libmorpho.dylib`mfcompile_set + 252
+    frame #62742: 0x0000000100534878 libmorpho.dylib`metafunction_compile + 344
+    frame #62743: 0x000000010053aa9c libmorpho.dylib`compiler_resolvefunctionref + 848
+    frame #62744: 0x000000010053b134 libmorpho.dylib`compiler_symbol + 228
+    frame #62745: 0x0000000100543198 libmorpho.dylib`compiler_call + 2156
+    frame #62746: 0x000000010053d820 libmorpho.dylib`compiler_print + 88
+    frame #62747: 0x0000000100541664 libmorpho.dylib`compiler_sequence + 412
+    frame #62748: 0x00000001005450f0 libmorpho.dylib`morpho_compile + 220
+    frame #62749: 0x0000000100001dc4 morpho6`cli_run + 224
+    frame #62750: 0x000000010000bb3c morpho6`main + 424
+    frame #62751: 0x000000018385a0e0 dyld`start + 2360
+*/
+fn f(x) {
+    return 0
+}
+
+fn f(x) {
+    return 1 
+}
+
+print f(1)
+// expect error 'MltplDisptchAmbg'
+

--- a/test/types/multiple_dispatch/duplicate_no_type_two_arguments.morpho
+++ b/test/types/multiple_dispatch/duplicate_no_type_two_arguments.morpho
@@ -1,0 +1,13 @@
+// Duplicate implementations with two arguments and no type annotations
+
+fn f(x, y) {
+    return 0
+}
+
+fn f(x, y) {
+    return 1 
+}
+
+print f(1,1)
+// expect error 'MltplDisptchAmbg'
+

--- a/test/types/multiple_dispatch/duplicate_one_arg.morpho
+++ b/test/types/multiple_dispatch/duplicate_one_arg.morpho
@@ -1,4 +1,5 @@
-// Duplicate implementations
+// Duplicate implementations with a single Typed argument. 
+// This also segfaults similar to `duplicate_no_type.morpho`
 
 fn f(Int x) {
     return 0

--- a/test/types/multiple_dispatch/duplicate_one_arg.morpho
+++ b/test/types/multiple_dispatch/duplicate_one_arg.morpho
@@ -1,0 +1,13 @@
+// Duplicate implementations
+
+fn f(Int x) {
+    return 0
+}
+
+fn f(Int x) {
+    return 1 
+}
+
+print f(1)
+// expect error 'MltplDisptchAmbg'
+

--- a/test/types/multiple_dispatch/namespace_for_new.morpho
+++ b/test/types/multiple_dispatch/namespace_for_new.morpho
@@ -9,5 +9,6 @@ fn f(Matrix a) {
 
 }
 
+// Do we want this to be a new implementation for the namespace function, or this is not intended / allowed?
 f(Matrix(2,2))
 // expect: [ 2, 2 ]

--- a/test/types/multiple_dispatch/namespace_for_new.morpho
+++ b/test/types/multiple_dispatch/namespace_for_new.morpho
@@ -1,0 +1,13 @@
+// Namespace with 'for' keyword, with new implementation in local file
+
+import "namespace.xmorpho" for f 
+
+// Here, we add a new implementation for a Matrix input
+
+fn f(Matrix a) {
+    print a.dimensions()
+
+}
+
+f(Matrix(2,2))
+// expect: [ 2, 2 ]

--- a/test/types/multiple_dispatch/namespace_for_overwrite.morpho
+++ b/test/types/multiple_dispatch/namespace_for_overwrite.morpho
@@ -1,0 +1,33 @@
+// Namespace with 'for' keyword, and try to overwrite an existing signature
+
+import "namespace.xmorpho" for f 
+
+// Here, we define an implementation for a String input, which already exists in the namespace, so it should raise an error.
+
+// This segfaults, with a slightly different compiler loop than in `duplicate_no_type.morpho`.
+
+/* Backttace from LLDB: (the loop goes mfcompile_set -> mfcompile_dispatchtable -> mfcompile_dispatchonparam -> mfcompile_set, so slightly differnt than in `duplicate_no_type.morpho`)
+
+    frame #62739: 0x00000001005335f8 libmorpho.dylib`mfcompile_set + 252
+    frame #62740: 0x0000000100533bb4 libmorpho.dylib`mfcompile_dispatchtable + 904
+    frame #62741: 0x0000000100534170 libmorpho.dylib`mfcompile_dispatchonparam + 436
+    frame #62742: 0x00000001005335f8 libmorpho.dylib`mfcompile_set + 252
+    frame #62743: 0x0000000100534878 libmorpho.dylib`metafunction_compile + 344
+    frame #62744: 0x000000010053aa9c libmorpho.dylib`compiler_resolvefunctionref + 848
+    frame #62745: 0x000000010053b134 libmorpho.dylib`compiler_symbol + 228
+    frame #62746: 0x0000000100543198 libmorpho.dylib`compiler_call + 2156
+    frame #62747: 0x0000000100541664 libmorpho.dylib`compiler_sequence + 412
+    frame #62748: 0x00000001005450f0 libmorpho.dylib`morpho_compile + 220
+    frame #62749: 0x0000000100001dc4 morpho6`cli_run + 224
+    frame #62750: 0x000000010000bb3c morpho6`main + 424
+    frame #62751: 0x000000018385a0e0 dyld`start + 2360
+
+*/
+
+fn f(String a) {
+    print a.count()
+
+}
+
+f("Hi")
+// expect error 'MltplDisptchAmbg'


### PR DESCRIPTION
A few more tests for multiple dispatch. The `namespace_for_new` test implements a new signature for a function in the namespace, and Morpho does run that implementation. Not sure what the intended behavior is here. I feel like this should be allowed as it will allow users to re-use code nicely.

Not sure about the `namespace_for_overwrite`, which tries to redefine an already existing implementation from the namespace. I think this should just result in a standard multiple dispatch error of matching signatures. 

`duplicate_no_types_two_arguments` is same as the `duplicate` test, but the signature doesn’t contain types. This works correctly. The `duplicate_no_types` however has duplicate functions with a _single_ untyped argument, and this fails due to a segfault. So does the `namespace_for_overwrite` test.

The segfault is due to a compiler infinite loop (see block comments in the files for a backtrace). 

Edit: Upon adding another duplicate test with a _single_ **typed** argument that _also_ fails, the problem seems to be for functions with one argument, and less to do with Type annotations.
