### PR TITLE
Class multiple dispatch

### DIFF
--- a/src/classes/function.h
+++ b/src/classes/function.h
@@ -35,7 +35,7 @@ typedef struct sobjectfunction {
     int creg; // Closure register
     struct sobjectfunction *parent;
     int nregs;
-    objectclass *klass;
+    objectclass *klass; // Parent class for methods
     varray_value konst;
     varray_varray_upvalue prototype;
     varray_optionalparam opt;

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -782,7 +782,7 @@ bool metafunction_compile(objectmetafunction *fn, error *err) {
     mfcompiler_init(&compiler, fn);
     
     mfcompile_set(&compiler, &set);
-    mfcompiler_disassemble(&compiler);
+    //mfcompiler_disassemble(&compiler);
     
     bool success=!morpho_checkerror(&compiler.err);
     if (!success && err) *err=compiler.err;

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -79,10 +79,22 @@ objectmetafunction *object_newmetafunction(value name) {
     if (new) {
         new->name=MORPHO_NIL;
         if (MORPHO_ISSTRING(name)) new->name=object_clonestring(name);
+        new->klass=NULL; 
         varray_valueinit(&new->fns);
         varray_mfinstructioninit(&new->resolver);
     }
 
+    return new;
+}
+
+/** Clone a metafunction */
+objectmetafunction *metafunction_clone(objectmetafunction *f) {
+    objectmetafunction *new = object_newmetafunction(f->name);
+    
+    if (new) {
+        varray_valueadd(&new->fns, f->fns.data, f->fns.count);
+    }
+    
     return new;
 }
 
@@ -128,6 +140,16 @@ bool metafunction_matchtype(value type, value val) {
         MORPHO_ISEQUAL(type, match)) return true; // Or if the types are the same
     
     return false;
+}
+
+/** Sets the parent class of a metafunction */
+void metafunction_setclass(objectmetafunction *f, objectclass *klass) {
+    f->klass=klass;
+}
+
+/** Returns a metafunction's class if any */
+objectclass *metafunction_class(objectmetafunction *f) {
+    return f->klass;
 }
 
 /** Finds whether an implementation f occurs in a metafunction */
@@ -760,7 +782,7 @@ bool metafunction_compile(objectmetafunction *fn, error *err) {
     mfcompiler_init(&compiler, fn);
     
     mfcompile_set(&compiler, &set);
-    //mfcompiler_disassemble(&compiler);
+    mfcompiler_disassemble(&compiler);
     
     bool success=!morpho_checkerror(&compiler.err);
     if (!success && err) *err=compiler.err;

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -775,7 +775,6 @@ bool metafunction_compile(objectmetafunction *fn, error *err) {
     set.rlist=rlist;
     for (int i=0; i<set.count; i++) {
         rlist[i].sig=metafunction_getsignature(fn->fns.data[i]);
-        signature_print(rlist[i].sig);
         rlist[i].fn=fn->fns.data[i];
     }
     
@@ -783,7 +782,7 @@ bool metafunction_compile(objectmetafunction *fn, error *err) {
     mfcompiler_init(&compiler, fn);
     
     mfcompile_set(&compiler, &set);
-    mfcompiler_disassemble(&compiler);
+    //mfcompiler_disassemble(&compiler);
     
     bool success=!morpho_checkerror(&compiler.err);
     if (!success && err) *err=compiler.err;

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -305,7 +305,7 @@ void mfcompiler_disassemble(mfcompiler *c) {
                 break;
             }
             case MF_BRANCHNARGS: {
-                printf("branchargs (%i) -> (%i)\n", instr->narg, i+instr->branch+1);
+                printf("branchnargs (%i) -> (%i)\n", instr->narg, i+instr->branch+1);
                 _mfcompiler_disassemblebranchtable(instr, i);
                 break;
             }
@@ -802,9 +802,14 @@ bool _finduidinlinearization(objectclass *klass, int uid) {
     return false;
 }
 
-/** Execute the metafunction's resolver */
+/** Execute the metafunction's resolver 
+ @param[in] fn - the metafunction to resolve
+ @param[in] nargs - number of positional arguments
+ @param[in] args - positional arguments @warning: the first user-visible argument should be in the zero position
+ @param[out] out - resolved function
+ @returns true if the metafunction was successfully resolved */
 bool metafunction_resolve(objectmetafunction *fn, int nargs, value *args, value *out) {
-    int n=vm_countpositionalargs(nargs, args);;
+    int n=vm_countpositionalargs(nargs, args);
     if (!fn->resolver.data &&
         !metafunction_compile(fn, NULL)) return false;
     mfinstruction *pc = fn->resolver.data;

--- a/src/classes/metafunction.h
+++ b/src/classes/metafunction.h
@@ -37,7 +37,8 @@ DECLARE_VARRAY(mfinstruction, mfinstruction);
 typedef struct sobjectmetafunction {
     object obj;
     value name;
-    varray_value fns; 
+    objectclass *klass; // Parent class for metafunction methods
+    varray_value fns;
     varray_mfinstruction resolver;
 } objectmetafunction;
 
@@ -65,9 +66,14 @@ typedef struct sobjectmetafunction {
  * ------------------------------------------------------- */
 
 objectmetafunction *object_newmetafunction(value name);
+objectmetafunction *metafunction_clone(objectmetafunction *f);
+
 bool metafunction_wrap(value name, value fn, value *out);
 bool metafunction_add(objectmetafunction *f, value fn);
 bool metafunction_typefromvalue(value v, value *out);
+
+void metafunction_setclass(objectmetafunction *f, objectclass *klass);
+objectclass *metafunction_class(objectmetafunction *f);
 
 bool metafunction_matchfn(objectmetafunction *fn, value f);
 bool metafunction_matchset(objectmetafunction *fn, int n, value *fns);

--- a/src/classes/metafunction.h
+++ b/src/classes/metafunction.h
@@ -77,11 +77,12 @@ objectclass *metafunction_class(objectmetafunction *f);
 
 bool metafunction_matchfn(objectmetafunction *fn, value f);
 bool metafunction_matchset(objectmetafunction *fn, int n, value *fns);
+signature *metafunction_getsignature(value fn);
 
 bool metafunction_compile(objectmetafunction *fn, error *err);
 void metafunction_clearinstructions(objectmetafunction *fn);
 
-bool metafunction_resolve(objectmetafunction *f, int nargs, value *args, value *fn);
+bool metafunction_resolve(objectmetafunction *f, int nargs, value *args, error *err, value *fn);
 
 void metafunction_initialize(void);
 

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -3314,12 +3314,28 @@ void compiler_overridemethod(compiler *c, syntaxtreenode *node, objectfunction *
     value symbol = method->name;
     objectclass *klass=compiler_getcurrentclass(c);
     
+    char *str = "ScaleConstraint";
+    objectstring sc = MORPHO_STATICSTRING(str);
+    if (MORPHO_ISEQUAL(MORPHO_OBJECT(&sc), klass->name)) {
+        
+    }   
+    
     if (MORPHO_ISMETAFUNCTION(prev)) {
         objectmetafunction *f = MORPHO_GETMETAFUNCTION(prev);
         if (f->klass!=klass) f=metafunction_clone(f);
         
         if (f) {
             metafunction_setclass(f, klass);
+            dictionary_insert(&klass->methods, symbol, MORPHO_OBJECT(f));
+            
+            for (int i=0; i<f->fns.count; i++) { // Check if this overrides
+                signature *sig = metafunction_getsignature(f->fns.data[i]);
+                if (sig && signature_isequal(sig, &method->sig)) {
+                    // TODO: Should check for duplicate implementation here
+                    f->fns.data[i] = MORPHO_OBJECT(method);
+                }
+            }
+            
             metafunction_add(f, MORPHO_OBJECT(method));
         }
         

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -3480,29 +3480,11 @@ static codeinfo compiler_class(compiler *c, syntaxtreenode *node, registerindx r
         compiler_error(c, node, COMPILE_CLSSLNRZ, MORPHO_GETCSTRING(klass->name));
     }
 
-    objectstring str = MORPHO_STATICSTRING("XProblemAdapter");
-    if (MORPHO_ISEQUAL(klass->name, MORPHO_OBJECT(&str))) {
-        
-    }
-    
     /* Compile method declarations */
     if (node->right!=SYNTAXTREE_UNCONNECTED) {
         syntaxtreenode *child = compiler_getnode(c, node->right);
         mout=compiler_method(c, child, reqout);
         ninstructions+=mout.ninstructions;
-    }
-    
-    /* Compile any metafunctions */
-    for (unsigned int i=0; i<klass->methods.capacity; i++) {
-        dictionaryentry *e = &klass->methods.contents[i];
-        if (MORPHO_ISNIL(e->key)) continue;
-        if (MORPHO_ISMETAFUNCTION(e->val)) {
-            morpho_printvalue(NULL, klass->name);
-            printf(".");
-            morpho_printvalue(NULL, e->key);
-            printf("=>\n");
-            metafunction_compile(MORPHO_GETMETAFUNCTION(e->val), &c->err);
-        }
     }
 
     /* End class definition */

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -3314,12 +3314,6 @@ void compiler_overridemethod(compiler *c, syntaxtreenode *node, objectfunction *
     value symbol = method->name;
     objectclass *klass=compiler_getcurrentclass(c);
     
-    char *str = "ScaleConstraint";
-    objectstring sc = MORPHO_STATICSTRING(str);
-    if (MORPHO_ISEQUAL(MORPHO_OBJECT(&sc), klass->name)) {
-        
-    }   
-    
     if (MORPHO_ISMETAFUNCTION(prev)) {
         objectmetafunction *f = MORPHO_GETMETAFUNCTION(prev);
         if (f->klass!=klass) f=metafunction_clone(f);
@@ -3333,6 +3327,7 @@ void compiler_overridemethod(compiler *c, syntaxtreenode *node, objectfunction *
                 if (sig && signature_isequal(sig, &method->sig)) {
                     // TODO: Should check for duplicate implementation here
                     f->fns.data[i] = MORPHO_OBJECT(method);
+                    return;
                 }
             }
             

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -3309,6 +3309,44 @@ static codeinfo compiler_return(compiler *c, syntaxtreenode *node, registerindx 
     return CODEINFO(REGISTER, REGISTER_UNALLOCATED, ninstructions);
 }
 
+/** Overrides or adds to an existing method implementation */
+void compiler_overridemethod(compiler *c, syntaxtreenode *node, objectfunction *method, value prev) {
+    value symbol = method->name;
+    objectclass *klass=compiler_getcurrentclass(c);
+    
+    if (MORPHO_ISMETAFUNCTION(prev)) {
+        objectmetafunction *f = MORPHO_GETMETAFUNCTION(prev);
+        if (f->klass!=klass) f=metafunction_clone(f);
+        
+        if (f) {
+            metafunction_setclass(f, klass);
+            metafunction_add(f, MORPHO_OBJECT(method));
+        }
+        
+    } else if (MORPHO_ISFUNCTION(prev)) {
+        objectfunction *prevmethod = MORPHO_GETFUNCTION(prev);
+        
+        if (signature_isequal(&prevmethod->sig, &method->sig)) { // Does the method overshadow an old one?
+            if (prevmethod->klass!=klass) { // If so, is the old one in the parent or ancestor class?
+                dictionary_insert(&klass->methods, symbol, MORPHO_OBJECT(method));
+            } else { // It's a redefinition
+                compiler_error(c, node, COMPILE_CLSSDPLCTIMPL, MORPHO_GETCSTRING(symbol), MORPHO_GETCSTRING(klass->name));
+            }
+        } else { // It doesn't override the old definition so wrap in a metafunction
+            objectmetafunction *f = object_newmetafunction(symbol);
+            
+            if (f) {
+                metafunction_add(f, prev);
+                metafunction_add(f, MORPHO_OBJECT(method));
+                metafunction_setclass(f, klass);
+                dictionary_insert(&klass->methods, symbol, MORPHO_OBJECT(f));
+            }
+        }
+    } else if (MORPHO_ISBUILTINFUNCTION(prev)) { // A builtin function can only come from a parent class, so overwrite it
+        dictionary_insert(&klass->methods, symbol, MORPHO_OBJECT(method));
+    }
+}
+
 /** Compiles a list of method declarations. */
 static codeinfo compiler_method(compiler *c, syntaxtreenode *node, registerindx reqout) {
     codeinfo out;
@@ -3334,19 +3372,7 @@ static codeinfo compiler_method(compiler *c, syntaxtreenode *node, registerindx 
                           prev=MORPHO_NIL;
                     
                     if (dictionary_get(&klass->methods, symbol, &prev)) {
-                        if (MORPHO_ISMETAFUNCTION(prev)) { // Add the method to the mf.
-                            metafunction_add(MORPHO_GETMETAFUNCTION(prev), omethod);
-                        } else { // Check if we're replacing an inherited method
-                            if ((MORPHO_ISFUNCTION(prev) &&
-                                MORPHO_GETFUNCTION(prev)->klass!=klass) ||
-                                (MORPHO_ISBUILTINFUNCTION(prev))) { // Just overwrite it
-                                    dictionary_insert(&klass->methods, symbol, omethod);
-                            } else { // We're not, so wrap in a mf.
-                                metafunction_wrap(symbol, prev, &prev);
-                                metafunction_add(MORPHO_GETMETAFUNCTION(prev), omethod);
-                                dictionary_insert(&klass->methods, symbol, prev);
-                            }
-                        }
+                        compiler_overridemethod(c, node, method, prev); // Override or create a metafunction
                     } else dictionary_insert(&klass->methods, symbol, omethod); // Just insert
                 }
             }
@@ -3454,11 +3480,29 @@ static codeinfo compiler_class(compiler *c, syntaxtreenode *node, registerindx r
         compiler_error(c, node, COMPILE_CLSSLNRZ, MORPHO_GETCSTRING(klass->name));
     }
 
+    objectstring str = MORPHO_STATICSTRING("XProblemAdapter");
+    if (MORPHO_ISEQUAL(klass->name, MORPHO_OBJECT(&str))) {
+        
+    }
+    
     /* Compile method declarations */
     if (node->right!=SYNTAXTREE_UNCONNECTED) {
         syntaxtreenode *child = compiler_getnode(c, node->right);
         mout=compiler_method(c, child, reqout);
         ninstructions+=mout.ninstructions;
+    }
+    
+    /* Compile any metafunctions */
+    for (unsigned int i=0; i<klass->methods.capacity; i++) {
+        dictionaryentry *e = &klass->methods.contents[i];
+        if (MORPHO_ISNIL(e->key)) continue;
+        if (MORPHO_ISMETAFUNCTION(e->val)) {
+            morpho_printvalue(NULL, klass->name);
+            printf(".");
+            morpho_printvalue(NULL, e->key);
+            printf("=>\n");
+            metafunction_compile(MORPHO_GETMETAFUNCTION(e->val), &c->err);
+        }
     }
 
     /* End class definition */
@@ -4281,8 +4325,8 @@ void compile_initialize(void) {
     morpho_defineerror(COMPILE_UNKNWNTYPE, ERROR_COMPILE, COMPILE_UNKNWNTYPE_MSG);
     morpho_defineerror(COMPILE_UNKNWNNMSPC, ERROR_COMPILE, COMPILE_UNKNWNNMSPC_MSG);
     morpho_defineerror(COMPILE_UNKNWNTYPENMSPC, ERROR_COMPILE, COMPILE_UNKNWNTYPENMSPC_MSG);
-    
     morpho_defineerror(COMPILE_CLSSLNRZ, ERROR_COMPILE, COMPILE_CLSSLNRZ_MSG);
+    morpho_defineerror(COMPILE_CLSSDPLCTIMPL, ERROR_COMPILE, COMPILE_CLSSDPLCTIMPL_MSG);
     
     morpho_addfinalizefn(compile_finalize);
 }

--- a/src/core/compile.h
+++ b/src/core/compile.h
@@ -120,6 +120,9 @@
 #define COMPILE_CLSSLNRZ                  "ClssLnrz"
 #define COMPILE_CLSSLNRZ_MSG              "Can't linearize class %s: Check parent and ancestor classes for conflicting inheritance order."
 
+#define COMPILE_CLSSDPLCTIMPL             "ClssDplctImpl"
+#define COMPILE_CLSSDPLCTIMPL_MSG         "Duplicate implementation of method %s with same signature in class %s"
+
 /* **********************************************************************
  * Compiler typedefs
  * ********************************************************************** */

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1001,6 +1001,9 @@ callfunction: // Jump here if an instruction becomes a call
                             v->fp->inbuiltinfunction=NULL;
 #endif
                             ERRORCHK();
+                        } else if (MORPHO_ISMETAFUNCTION(ifunc) &&
+                                   !metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a, &ifunc)) {
+                            ERROR(VM_MLTPLDSPTCHFLD);
                         }
                     } else {
                         if (c>0) {

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -989,6 +989,11 @@ callfunction: // Jump here if an instruction becomes a call
                     /* Call the initializer if class provides one */
                     value ifunc;
                     if (dictionary_getintern(&klass->methods, initselector, &ifunc)) {
+                        if (MORPHO_ISMETAFUNCTION(ifunc) &&
+                            !metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &ifunc)) {
+                            ERROR(VM_MLTPLDSPTCHFLD);
+                        }
+                        
                         /* If so, call it */
                         if (MORPHO_ISFUNCTION(ifunc)) {
                             if (!vm_call(v, ifunc, a, c, NULL, &pc, &reg)) goto vm_error;
@@ -1001,9 +1006,6 @@ callfunction: // Jump here if an instruction becomes a call
                             v->fp->inbuiltinfunction=NULL;
 #endif
                             ERRORCHK();
-                        } else if (MORPHO_ISMETAFUNCTION(ifunc) &&
-                                   !metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a, &ifunc)) {
-                            ERROR(VM_MLTPLDSPTCHFLD);
                         }
                     } else {
                         if (c>0) {

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -1116,7 +1116,7 @@ callfunction: // Jump here if an instruction becomes a call
                     value ifunc;
                     if (dictionary_getintern(&klass->methods, right, &ifunc)) {
                         if (MORPHO_ISMETAFUNCTION(ifunc)) {
-                            if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, &v->err, reg+a+1, &ifunc)) {
+                            if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c,  reg+a+1, &v->err, &ifunc)) {
                                 ERRORCHK();
                                 ERROR(VM_MLTPLDSPTCHFLD);
                             }

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -946,7 +946,8 @@ bool morpho_interpret(vm *v, value *rstart, instructionindx istart) {
             c=DECODE_B(bc); // We use c for consistency between call and invoke...
 
             if (MORPHO_ISMETAFUNCTION(left) &&
-                !metafunction_resolve(MORPHO_GETMETAFUNCTION(left), c, reg+a+1, &left)) {
+                !metafunction_resolve(MORPHO_GETMETAFUNCTION(left), c, reg+a+1,                 &v->err, &left)) {
+                ERRORCHK();
                 ERROR(VM_MLTPLDSPTCHFLD);
             }
         
@@ -990,7 +991,8 @@ callfunction: // Jump here if an instruction becomes a call
                     value ifunc;
                     if (dictionary_getintern(&klass->methods, initselector, &ifunc)) {
                         if (MORPHO_ISMETAFUNCTION(ifunc) &&
-                            !metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &ifunc)) {
+                            !metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &v->err, &ifunc)) {
+                            ERRORCHK();
                             ERROR(VM_MLTPLDSPTCHFLD);
                         }
                         
@@ -1035,7 +1037,10 @@ callfunction: // Jump here if an instruction becomes a call
                 if (dictionary_getintern(&instance->klass->methods, right, &ifunc)) {
 
                     if (MORPHO_ISMETAFUNCTION(ifunc)) {
-                        if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &ifunc)) ERROR(VM_MLTPLDSPTCHFLD);
+                        if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &v->err, &ifunc)) {
+                            ERRORCHK();
+                            ERROR(VM_MLTPLDSPTCHFLD);
+                        }
                     }
                     
                     /* If so, call it */
@@ -1076,7 +1081,10 @@ callfunction: // Jump here if an instruction becomes a call
                     if (v->fp>v->frame) reg[a]=reg[0]; /* Copy self into r[a] and call */
 
                     if (MORPHO_ISMETAFUNCTION(ifunc)) {
-                        if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &ifunc)) ERROR(VM_MLTPLDSPTCHFLD);
+                        if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &v->err, &ifunc)) {
+                            ERRORCHK();
+                            ERROR(VM_MLTPLDSPTCHFLD);
+                        }
                     }
                     
                     if (MORPHO_ISFUNCTION(ifunc)) {
@@ -1108,7 +1116,10 @@ callfunction: // Jump here if an instruction becomes a call
                     value ifunc;
                     if (dictionary_getintern(&klass->methods, right, &ifunc)) {
                         if (MORPHO_ISMETAFUNCTION(ifunc)) {
-                            if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, reg+a+1, &ifunc)) ERROR(VM_MLTPLDSPTCHFLD);
+                            if (!metafunction_resolve(MORPHO_GETMETAFUNCTION(ifunc), c, &v->err, reg+a+1, &ifunc)) {
+                                ERRORCHK();
+                                ERROR(VM_MLTPLDSPTCHFLD);
+                            }
                         }
                         
                         if (MORPHO_ISBUILTINFUNCTION(ifunc)) {
@@ -1720,8 +1731,8 @@ bool morpho_call(vm *v, value f, int nargs, value *args, value *ret) {
     value r0=f;
 
     if (MORPHO_ISMETAFUNCTION(fn) &&
-        !metafunction_resolve(MORPHO_GETMETAFUNCTION(fn), nargs, args, &fn)) {
-        morpho_runtimeerror(v, VM_MLTPLDSPTCHFLD);
+        !metafunction_resolve(MORPHO_GETMETAFUNCTION(fn), nargs, args, &v->err, &fn)) {
+        if (!morpho_checkerror(&v->err)) morpho_runtimeerror(v, VM_MLTPLDSPTCHFLD);
         return false;
     }
     

--- a/src/datastructures/error.h
+++ b/src/datastructures/error.h
@@ -189,7 +189,7 @@ void morpho_unreachable(const char *explanation);
 #define VM_GETINDEXARGS_MSG               "Noninteger array index."
 
 #define VM_MLTPLDSPTCHFLD                 "MltplDsptchFld"
-#define VM_MLTPLDSPTCHFLD_MSG             "Mutiple dispatch could not find an implementation that matches these arguments."
+#define VM_MLTPLDSPTCHFLD_MSG             "Multiple dispatch could not find an implementation that matches these arguments."
 
 /* -------------------------------------------------------
  * Error interface

--- a/src/geometry/functional.c
+++ b/src/geometry/functional.c
@@ -3839,7 +3839,7 @@ FUNCTIONAL_METHOD(NormSq, integrand, MESH_GRADE_VERTEX, fieldref, gradsq_prepare
 
 FUNCTIONAL_METHOD(NormSq, total, MESH_GRADE_VERTEX, fieldref, gradsq_prepareref, functional_sumintegrand, normsq_integrand, NULL, GRADSQ_ARGS, SYMMETRY_NONE);
 
-FUNCTIONAL_METHOD(NormSq, gradient, MESH_GRADE_AREA, fieldref, gradsq_prepareref, functional_mapnumericalgradient, normsq_integrand, NULL, GRADSQ_ARGS, SYMMETRY_NONE);
+FUNCTIONAL_METHOD(NormSq, gradient, MESH_GRADE_VERTEX, fieldref, gradsq_prepareref, functional_mapnumericalgradient, normsq_integrand, NULL, GRADSQ_ARGS, SYMMETRY_NONE);
 
 value NormSq_fieldgradient(vm *v, int nargs, value *args) {
     functional_mapinfo info;

--- a/test/types/multiple_dispatch/class_multiple_dispatch_post.morpho
+++ b/test/types/multiple_dispatch/class_multiple_dispatch_post.morpho
@@ -1,0 +1,28 @@
+// Dipatch methods on multiple types with a type defined after the class
+
+class A {
+    f(String x) {
+        print x
+    }
+
+    f(Float x) {
+        print x+1
+    }
+
+    f(List x) {
+        print x[-1]
+    }
+
+    f(x) {
+        print "Backup"
+    }
+}
+
+class B {
+
+}
+
+var a = A()
+
+a.f(B())
+// expect: Backup

--- a/test/types/multiple_dispatch/class_multiple_initializer.morpho
+++ b/test/types/multiple_dispatch/class_multiple_initializer.morpho
@@ -1,0 +1,22 @@
+// Multiple dispatch in ititializer
+
+class A {
+    init(problem) {
+        self.problem = problem
+    }
+}
+
+class B is A {
+    init(problem, List target) {
+        super.init(problem)
+        self.target = target 
+    }
+
+    init(x, String s) { self.init(x, [s]) }
+    init(x, Dictionary d) { self.init(x, [d]) }
+}
+
+var b = B("", "Hello")
+
+print b.target
+// expect: [ Hello ]

--- a/test/types/multiple_dispatch/duplicate_no_type_two.morpho
+++ b/test/types/multiple_dispatch/duplicate_no_type_two.morpho
@@ -1,0 +1,13 @@
+// Duplicate implementations with one argument no Type annotations.
+
+fn f(x, y) {
+    return 0
+}
+
+fn f(x, y) {
+    return 1 
+}
+
+print f(1)
+// expect error 'MltplDisptchAmbg'
+


### PR DESCRIPTION
Improves multiple dispatch on classes. Methods are not inherited correctly, and overwrite older methods with equivalent signatures. 

Multiple initializer methods can now be provided in class definitions, and they are selected correctly by the virtual machine.