### PR TITLE
Error class improvements

### DIFF
--- a/help/errors.md
+++ b/help/errors.md
@@ -4,6 +4,8 @@
 # Errors
 [tagerror]: # (error)
 [tagerrors]: # (errors)
+[tagerrors]: # (throw)
+[tagerrors]: # (warning)
 
 When an error occurs in running a morpho program, an error message is displayed together with an explanation of where in the program that the error happened.
 

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -2040,6 +2040,7 @@ void morpho_initialize(void) {
     
     morpho_defineerror(ERROR_ALLOCATIONFAILED, ERROR_EXIT, ERROR_ALLOCATIONFAILED_MSG);
     morpho_defineerror(ERROR_INTERNALERROR, ERROR_EXIT, ERROR_INTERNALERROR_MSG);
+    morpho_defineerror(ERROR_ERROR, ERROR_HALT, ERROR_ERROR_MSG);
     
     morpho_defineerror(VM_STCKOVFLW, ERROR_HALT, VM_STCKOVFLW_MSG);
     morpho_defineerror(VM_ERRSTCKOVFLW, ERROR_HALT, VM_ERRSTCKOVFLW_MSG);

--- a/src/datastructures/error.h
+++ b/src/datastructures/error.h
@@ -115,6 +115,9 @@ void morpho_unreachable(const char *explanation);
 #define ERROR_INTERNALERROR               "Intrnl"
 #define ERROR_INTERNALERROR_MSG           "Internal error (contact developer)."
 
+#define ERROR_ERROR                       "Err"
+#define ERROR_ERROR_MSG                   "Error."
+
 /* -------------------------------------------------------
  * VM error messages
  * ------------------------------------------------------- */

--- a/test/error/throw_on_class.morpho
+++ b/test/error/throw_on_class.morpho
@@ -1,0 +1,4 @@
+// Calling throw on the class
+
+Error.throw("FooFoo", "Can't foo foos.")
+// expect: Error 'FooFoo': Can't foo foos.

--- a/test/error/throw_on_class_notag.morpho
+++ b/test/error/throw_on_class_notag.morpho
@@ -1,0 +1,4 @@
+// Calling throw on the class without a tag
+
+Error.throw("Can't foo foos.")
+// expect: Error 'Err': Can't foo foos.


### PR DESCRIPTION
This PR makes adjustments to the Error class to support calling throw and warning on the class without instantiation, e.g. 

`Error.warning("Foo")`

Includes two tests of the fixed functionality. Fixes #252.
