### PR TITLE
Fix povray quiet mode

### DIFF
--- a/modules/povray.morpho
+++ b/modules/povray.morpho
@@ -216,7 +216,7 @@ class POVRaytracer {
     self.transparent = transparent // Sets the attribute to be used in the write method and in the command line argument for povray
     var path = self.write(file)
     var silent = ""
-    if (quiet) silent = "&> /dev/null"
+    if (quiet) silent = "> /dev/null 2>&1"
     var disp = ""
     if (!display) disp = "-D"
     var ua = "+A"


### PR DESCRIPTION
Fixes bug #96 whereby setting quiet=true in POVRaytracer.render did not work correctly on some platforms. The code was redirecting to /dev/null but not setting stderr to also redirect to /dev/null. This now works on linux/ubuntu and macOS. 