### PR TITLE
Allow keywords as property and method labels

### DIFF
--- a/src/classes/list.c
+++ b/src/classes/list.c
@@ -708,16 +708,16 @@ void list_initialize(void) {
     // Define list objecttype
     objectlisttype=object_addtype(&objectlistdefn);
     
-    // Locate the Object class to use as the parent class of Range
+    // Locate the Object class to use as the parent class of List
     objectstring objname = MORPHO_STATICSTRING(OBJECT_CLASSNAME);
     value objclass = builtin_findclass(MORPHO_OBJECT(&objname));
-    
-    // List constructor function
-    builtin_addfunction(LIST_CLASSNAME, list_constructor, MORPHO_FN_CONSTRUCTOR);
     
     // Define List class
     value listclass=builtin_addclass(LIST_CLASSNAME, MORPHO_GETCLASSDEFINITION(List), objclass);
     object_setveneerclass(OBJECT_LIST, listclass);
+    
+    // List constructor function
+    morpho_addfunction(LIST_CLASSNAME, "List (...)", list_constructor, MORPHO_FN_CONSTRUCTOR, NULL);
     
     // List error messages
     morpho_defineerror(LIST_ENTRYNTFND, ERROR_HALT, LIST_ENTRYNTFND_MSG);

--- a/src/classes/range.c
+++ b/src/classes/range.c
@@ -191,9 +191,11 @@ void range_initialize(void) {
     value objclass = builtin_findclass(MORPHO_OBJECT(&objname));
     
     // Create range veneer class
-    builtin_addfunction(RANGE_CLASSNAME, range_constructor, MORPHO_FN_CONSTRUCTOR);
     value rangeclass=builtin_addclass(RANGE_CLASSNAME, MORPHO_GETCLASSDEFINITION(Range), objclass);
     object_setveneerclass(OBJECT_RANGE, rangeclass);
+    
+    // Range constructor function
+    morpho_addfunction(RANGE_CLASSNAME, "Range (...)", range_constructor, MORPHO_FN_CONSTRUCTOR, NULL);
     
     // Range error messages
     morpho_defineerror(RANGE_ARGS, ERROR_HALT, RANGE_ARGS_MSG);

--- a/src/classes/strng.c
+++ b/src/classes/strng.c
@@ -314,9 +314,10 @@ void string_initialize(void) {
     objectstring objname = MORPHO_STATICSTRING(OBJECT_CLASSNAME);
     value objclass = builtin_findclass(MORPHO_OBJECT(&objname));
     
-    // Create string veneer class
-    builtin_addfunction(STRING_CLASSNAME, string_constructor, MORPHO_FN_CONSTRUCTOR);
-    
+    // Create String veneer class
     value stringclass=builtin_addclass(STRING_CLASSNAME, MORPHO_GETCLASSDEFINITION(String), objclass);
     object_setveneerclass(OBJECT_STRING, stringclass);
+    
+    // String constructor function
+    morpho_addfunction(STRING_CLASSNAME, "String (...)", string_constructor, MORPHO_FN_CONSTRUCTOR, NULL);
 }

--- a/src/morpho.h
+++ b/src/morpho.h
@@ -113,7 +113,7 @@ program *morpho_newprogram(void);
 void morpho_freeprogram(program *p);
 
 /* Optimizers */
-typedef bool (*optimizerfn) (program *in);
+typedef bool (optimizerfn) (program *in);
 void morpho_setoptimizer(optimizerfn *optimizer);
 
 /* Virtual machine */

--- a/src/support/lex.c
+++ b/src/support/lex.c
@@ -142,7 +142,6 @@ void lex_newline(lexer *l) {
     l->line++; l->posn=0;
 }
 
-
 /** @brief Attempts to find a matching token for the current token.
  *  @param[in] l The lexer in use
  *  @param[out] defn Type of token, if found
@@ -637,6 +636,12 @@ void lex_setprefn(lexer *l, processtokenfn prefn) {
 /* **********************************************************************
  * Lexer public interface
  * ********************************************************************** */
+
+/** @brief Checks if a token contains a keyword */
+bool lex_tokeniskeyword(lexer *l, token *tok) {
+    if (tok->type==TOKEN_SYMBOL) return false;
+    return lex_isalpha(tok->start[0]);
+}
 
 /** @brief Identifies the next token
  *  @param[in]  l     The lexer in use

--- a/src/support/lex.h
+++ b/src/support/lex.h
@@ -179,7 +179,6 @@ char lex_peek(lexer *l);
 char lex_peekahead(lexer *l, int n);
 char lex_peekprevious(lexer *l);
 void lex_newline(lexer *l);
-
 bool lex_skipshebang(lexer *l);
 
 /* -------------------------------------------------------
@@ -202,6 +201,9 @@ void lex_setmatchkeywords(lexer *l, bool match);
 bool lex_matchkeywords(lexer *l);
 void lex_setwhitespacefn(lexer *l, processtokenfn whitespacefn);
 void lex_setprefn(lexer *l, processtokenfn prefn);
+
+// Get information about a token
+bool lex_tokeniskeyword(lexer *l, token *tok);
 
 // Obtain the next token
 bool lex(lexer *l, token *tok, error *err);

--- a/src/support/parse.c
+++ b/src/support/parse.c
@@ -136,6 +136,13 @@ bool parse_checktokenadvance(parser *p, tokentype type) {
     return true;
 }
 
+/** Checks whether the current token is a keyword */
+bool parse_checktokeniskeywordadvance(parser *p) {
+    PARSE_CHECK(lex_tokeniskeyword(p->lex, &p->current));
+    PARSE_CHECK(parse_advance(p));
+    return true;
+}
+
 /** @brief Checks if the next token has the required type and advance if it does, otherwise generates an error.
  *  @param   p    the parser in use
  *  @param   type type to check
@@ -807,6 +814,9 @@ bool parse_binary(parser *p, void *out) {
         if (nodetype==NODE_ASSIGN &&
             parse_checktokenadvance(p, TOKEN_FUNCTION)) {
             PARSE_CHECK(parse_anonymousfunction(p, &right));
+        } else if (nodetype==NODE_DOT &&
+                   parse_checktokeniskeywordadvance(p)) {
+            PARSE_CHECK(parse_symbol(p, &right));
         } else {
             PARSE_CHECK(parse_precedence(p, rule->precedence + (assoc == LEFT ? 1 : 0), &right));
         }
@@ -1053,7 +1063,8 @@ bool parse_functiondeclaration(parser *p, void *out) {
                    body=SYNTAXTREE_UNCONNECTED;
     
     /* Function name */
-    if (parse_checktokenadvance(p, TOKEN_SYMBOL)) {
+    if (parse_checktokenadvance(p, TOKEN_SYMBOL) ||
+        parse_checktokeniskeywordadvance(p)) {
         name=parse_tokenasstring(p);
         parse_addobject(p, name);
     } else {

--- a/test/class/keyword_method.morpho
+++ b/test/class/keyword_method.morpho
@@ -12,5 +12,5 @@ class A {
 
 var a = A("foo")
 
-A.print() 
+a.print() 
 // expect: foo

--- a/test/class/keyword_method.morpho
+++ b/test/class/keyword_method.morpho
@@ -1,0 +1,16 @@
+// Ensure a class can use keywords for method labels
+
+class A {
+  init(a) {
+    self.a = a
+  }
+
+  print() {
+    print self.a
+  }
+}
+
+var a = A("foo")
+
+A.print() 
+// expect: foo

--- a/test/class/keyword_property.morpho
+++ b/test/class/keyword_property.morpho
@@ -1,0 +1,15 @@
+// Ensure a class can use keywords for property labels
+
+class A {
+  init(a) {
+    self.while = a
+  }
+}
+
+var a = A("foo")
+
+print a
+// expect: <A>
+
+print a.while 
+// expect: foo


### PR DESCRIPTION
This PR updates the parser to allow use of keywords as property and method labels for objects and classes. This will facilitate changing 'prnt' methods to `print` in future (possibly with a deprecation warning). 

```
class A {
  init(a) {
    self.while = a
  }
}
```