### PR TITLE
Fix setworkingfolder and add test

### DIFF
--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -122,7 +122,7 @@ value System_setworkingfolder(vm *v, int nargs, value *args) {
         MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
         char *path = MORPHO_GETCSTRING(MORPHO_GETARG(args, 0));
         
-        if (platform_setcurrentdirectory(path)) morpho_runtimeerror(v, SYS_STWRKDR);
+        if (!platform_setcurrentdirectory(path)) morpho_runtimeerror(v, SYS_STWRKDR);
     } else morpho_runtimeerror(v, STWRKDR_ARGS);
     
     return MORPHO_NIL;

--- a/test/system/setworkingfolder.morpho
+++ b/test/system/setworkingfolder.morpho
@@ -1,0 +1,8 @@
+// Test setworkingfolder 
+
+var a = System.workingfolder()
+System.setworkingfolder(a)
+var b = System.workingfolder()
+
+print (a==b)
+// expect: true

--- a/test/system/workingfolder.morpho
+++ b/test/system/workingfolder.morpho
@@ -1,0 +1,4 @@
+// Test workingfolder 
+
+print isstring(System.workingfolder())
+// expect: true


### PR DESCRIPTION
Corrects an error in System.setworkingfolder that incorrectly reported an error. Two tests have been added to ensure this isn't broken as it also breaks morphopm. 

Fixes #306 