### PR TITLE
Add CMake option to build with profiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(MORPHO_GCSTRESSTEST "Stress tests the garbage collector" OFF)
 option(MORPHO_BUILD_LINALG "Builds with linear algebra" ON)
 option(MORPHO_BUILD_SPARSE "Builds with sparse matrix support" ON)
 option(MORPHO_BUILD_GEOMETRY "Builds with geometry library" ON)
+option(MORPHO_BUILD_PROFILER "Builds with profiler" OFF)
 
 #-------------------------------------------------------------------------------
 # Process options
@@ -51,6 +52,10 @@ endif()
 # Include geometry as part of the build
 if(MORPHO_BUILD_GEOMETRY)
 target_compile_definitions(morpho PUBLIC MORPHO_INCLUDE_GEOMETRY)
+endif()
+
+if(MORPHO_BUILD_PROFILER)
+target_compile_definitions(morpho PUBLIC _DEBUG_PROFILER)
 endif()
 
 #-------------------------------------------------------------------------------

--- a/src/build.h
+++ b/src/build.h
@@ -185,4 +185,6 @@
 //#define MORPHO_OPCODE_USAGE
 
 /** @brief Buiild with profile support */
-#define MORPHO_PROFILER
+#ifdef _DEBUG_PROFILER
+    #define MORPHO_PROFILER
+#endif


### PR DESCRIPTION
Add option to CMakeLists.txt to build with/without Morpho profiler without manually chaging build.h