### PR TITLE
New help system

### DIFF
--- a/help/functionals.md
+++ b/help/functionals.md
@@ -282,7 +282,7 @@ See the `Functionals` entry for general information about functionals.
 
 The `AreaIntegral` functional computes the area integral of a function. You supply an integrand function that takes a position matrix as an argument.
 
-To compute integral(x*y) over an area element:
+To compute `integral(x*y)` over an area element:
 
     var la=AreaIntegral(fn (x) x[0]*x[1])
 

--- a/help/matrix.md
+++ b/help/matrix.md
@@ -46,7 +46,7 @@ The division operator is used to solve a linear system, e.g.
 
     print b/a
 
-yields the solution to the system a*x = b.
+yields the solution to the system `a*x = b`.
 
 [showsubtopics]: # (subtopics)
 
@@ -116,7 +116,7 @@ Returns the inverse of a matrix if it is invertible. Raises a
     var m = Matrix([[1,2],[3,4]])
     var mi = m.inverse()
 
-yields the inverse of the matrix `m`, such that mi*m is the identity
+yields the inverse of the matrix `m`, such that `mi*m` is the identity
 matrix.
 
 ## Norm

--- a/help/syntax.md
+++ b/help/syntax.md
@@ -38,7 +38,7 @@ enabling the programmer to quickly comment out a section of code.
 [tagsymbols]: # (symbols)
 [tagnames]: # (names)
 
-Symbols are used to refer to named entities, including variables, classes, functions etc. Symbols must begin with a letter or underscore _ as the first character and may include letters or numbers as the remainder. Symbols are case sensitive.
+Symbols are used to refer to named entities, including variables, classes, functions etc. Symbols must begin with a letter or underscore `_` as the first character and may include letters or numbers as the remainder. Symbols are case sensitive.
 
     asymbol
     _alsoasymbol

--- a/src/build.h
+++ b/src/build.h
@@ -92,7 +92,7 @@
 
 /** @brief Build Morpho VM with small but hacky value type [NaN boxing] */
 #ifndef _NO_NAN_BOXING
-#define MORPHO_NAN_BOXING
+//#define MORPHO_NAN_BOXING
 #endif
 /** @brief Number of bytes to bind before GC first runs */
 #define MORPHO_GCINITIAL 1024

--- a/src/build.h
+++ b/src/build.h
@@ -92,7 +92,7 @@
 
 /** @brief Build Morpho VM with small but hacky value type [NaN boxing] */
 #ifndef _NO_NAN_BOXING
-//#define MORPHO_NAN_BOXING
+#define MORPHO_NAN_BOXING
 #endif
 /** @brief Number of bytes to bind before GC first runs */
 #define MORPHO_GCINITIAL 1024

--- a/src/build.h
+++ b/src/build.h
@@ -90,7 +90,6 @@
 /** @brief Build Morpho VM with computed gotos */
 #define MORPHO_COMPUTED_GOTO
 
-
 /** @brief Build Morpho VM with small but hacky value type [NaN boxing] */
 #ifndef _NO_NAN_BOXING
 #define MORPHO_NAN_BOXING

--- a/src/build.h
+++ b/src/build.h
@@ -90,6 +90,7 @@
 /** @brief Build Morpho VM with computed gotos */
 #define MORPHO_COMPUTED_GOTO
 
+
 /** @brief Build Morpho VM with small but hacky value type [NaN boxing] */
 #ifndef _NO_NAN_BOXING
 #define MORPHO_NAN_BOXING

--- a/src/build.h
+++ b/src/build.h
@@ -123,14 +123,17 @@
  * Core library [options set in CMake]
  * ********************************************************************** */
 
-/** Build with Matrix class using BLAS/LAPACK */
+/** @brief Build with Matrix class using BLAS/LAPACK */
 //#define MORPHO_INCLUDE_LINALG
 
-/** Build with Sparse class */
+/** @brief Build with Sparse class */
 //#define MORPHO_INCLUDE_SPARSE
 
-/** Build with geometry classes */
+/** @brief Build with geometry classes */
 //#define MORPHO_INCLUDE_GEOMETRY
+
+/** @brief Build with new help system */
+#define MORPHO_INCLUDE_HELP
 
 /* **********************************************************************
  * Libraries

--- a/src/classes/file.c
+++ b/src/classes/file.c
@@ -165,6 +165,7 @@ bool file_readintovarray(FILE *f, varray_char *string) {
     if (varray_charresize(string, (int) size+1)) {
         size_t nread=fread(string->data, sizeof(char), size, f);
         string->data[nread]='\0';
+        string->count=(unsigned int) nread+1;
     }
     
     return true;

--- a/src/classes/list.h
+++ b/src/classes/list.h
@@ -75,6 +75,7 @@ value List_getindex(vm *v, int nargs, value *args);
 
 bool list_resize(objectlist *list, int size);
 void list_append(objectlist *list, value v);
+bool list_remove(objectlist *list, value val);
 unsigned int list_length(objectlist *list);
 bool list_getelement(objectlist *list, int i, value *out);
 void list_sort(objectlist *list);

--- a/src/classes/strng.h
+++ b/src/classes/strng.h
@@ -37,11 +37,11 @@ typedef struct {
 /** Extracts the string length from a value */
 #define MORPHO_GETSTRINGLENGTH(val)       (((objectstring *) MORPHO_GETOBJECT(val))->length)
 
-/** Use to create static strings on the C stack */
-#define MORPHO_STATICSTRING(cstring)      { .obj.type=OBJECT_STRING, .obj.status=OBJECT_ISUNMANAGED, .obj.next=NULL, .string=cstring, .length=strlen(cstring) }
+/** Use to create static strings on the C stack (cstring may be const char *). */
+#define MORPHO_STATICSTRING(cstring)      { .obj.type=OBJECT_STRING, .obj.status=OBJECT_ISUNMANAGED, .obj.next=NULL, .string=(char *)(cstring), .length=strlen(cstring) }
 
-/** Use to create static strings on the C stack */
-#define MORPHO_STATICSTRINGWITHLENGTH(cstring, len)      { .obj.type=OBJECT_STRING, .obj.status=OBJECT_ISUNMANAGED, .obj.next=NULL, .string=cstring, .length=len }
+/** Use to create static strings on the C stack (cstring may be const char *). */
+#define MORPHO_STATICSTRINGWITHLENGTH(cstring, len)      { .obj.type=OBJECT_STRING, .obj.status=OBJECT_ISUNMANAGED, .obj.next=NULL, .string=(char *)(cstring), .length=len }
 
 
 #define OBJECT_STRINGLABEL "string" // These are only used by the parser... Should be moved?

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -10,6 +10,7 @@
 #include "classes.h"
 #include "system.h"
 #include "platform.h"
+#include "help.h"
 
 /* **********************************************************************
  * System utility functions
@@ -128,6 +129,30 @@ value System_setworkingfolder(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
+/** Help query */
+value System_help(vm *v, int nargs, value *args) {
+    value out = MORPHO_NIL;
+    
+    if (nargs==1 && MORPHO_ISSTRING(MORPHO_GETARG(args, 0))) {
+        char *query = MORPHO_GETCSTRING(MORPHO_GETARG(args, 0));
+        
+        varray_char result;
+        varray_charinit(&result);
+        
+        if (morpho_help(query, &result)) {
+            objectstring *new=object_stringfromvarraychar(&result);
+            if (new) {
+                out = MORPHO_OBJECT(new);
+                morpho_bindobjects(v, 1, &out);
+            }
+        }
+        
+        varray_charclear(&result);
+    }
+    
+    return out;
+}
+
 /** Get working folder */
 value System_workingfolder(vm *v, int nargs, value *args) {
     value out = MORPHO_NIL;
@@ -172,6 +197,7 @@ MORPHO_METHOD(SYSTEM_READLINE_METHOD, System_readline, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_ARGUMENTS_METHOD, System_arguments, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_EXIT_METHOD, System_exit, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_SETWORKINGFOLDER_METHOD, System_setworkingfolder, BUILTIN_FLAGSEMPTY),
+MORPHO_METHOD(SYSTEM_HELP_METHOD, System_help, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_WORKINGFOLDER_METHOD, System_workingfolder, BUILTIN_FLAGSEMPTY),
 MORPHO_METHOD(SYSTEM_HOMEFOLDER_METHOD, System_homefolder, BUILTIN_FLAGSEMPTY)
 MORPHO_ENDCLASS

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -139,7 +139,7 @@ value System_help(vm *v, int nargs, value *args) {
         varray_char result;
         varray_charinit(&result);
         
-        if (morpho_help(query, &result)) {
+        if (morpho_helpastext(query, &result)) {
             out=object_stringfromvarraychar(&result);
             if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
         }

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -140,11 +140,8 @@ value System_help(vm *v, int nargs, value *args) {
         varray_charinit(&result);
         
         if (morpho_help(query, &result)) {
-            objectstring *new=object_stringfromvarraychar(&result);
-            if (new) {
-                out = MORPHO_OBJECT(new);
-                morpho_bindobjects(v, 1, &out);
-            }
+            out=object_stringfromvarraychar(&result);
+            if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
         }
         
         varray_charclear(&result);

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -139,11 +139,9 @@ value System_help(vm *v, int nargs, value *args) {
         varray_char result;
         varray_charinit(&result);
         
-        if (morpho_helpastext(query, &result)) {
-            out=object_stringfromvarraychar(&result);
-            if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
-        }
-        
+        morpho_helpastext(query, &result); /* fills result with help text or a "not found" hint */
+        out = object_stringfromvarraychar(&result);
+        if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
         varray_charclear(&result);
     }
     

--- a/src/classes/system.h
+++ b/src/classes/system.h
@@ -22,6 +22,7 @@
 #define SYSTEM_READLINE_METHOD        "readline"
 #define SYSTEM_SLEEP_METHOD           "sleep"
 #define SYSTEM_ARGUMENTS_METHOD       "arguments"
+#define SYSTEM_HELP_METHOD            "help"
 #define SYSTEM_EXIT_METHOD            "exit"
 
 #define SYSTEM_HOMEFOLDER_METHOD      "homefolder"

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -15,6 +15,7 @@
 #include "profile.h"
 #include "resources.h"
 #include "extensions.h"
+#include "help.h"
 
 value initselector = MORPHO_NIL;
 value indexselector = MORPHO_NIL;
@@ -2137,6 +2138,7 @@ void morpho_initialize(void) {
     compile_initialize();
     debugger_initialize();
     extensions_initialize();
+    help_initialize();
     
 #ifdef MORPHO_DEBUG_GCSIZETRACKING
     dictionary_init(&sizecheck);

--- a/src/datastructures/dictionary.c
+++ b/src/datastructures/dictionary.c
@@ -385,6 +385,16 @@ static inline bool _dictionary_get(dictionary *dict, value key, bool intern, val
     return false;
 }
 
+/** @brief If a key equal to key is present, returns that stored key and (if val) its value; otherwise returns MORPHO_NIL. */
+value dictionary_getkey(dictionary *dict, value key, value *val) {
+    dictionaryentry *entry = NULL;
+    if (dictionary_find(dict, key, false, &entry)) {
+        if (val) *val = entry->val;
+        return entry->key;
+    }
+    return MORPHO_NIL;
+}
+
 /** @brief Retrieves a value from a dictionary given a key
  * @param[in]  dict the dictionary to get
  * @param[in]  key  key to locate

--- a/src/datastructures/dictionary.h
+++ b/src/datastructures/dictionary.h
@@ -58,6 +58,7 @@ void dictionary_freecontents(dictionary *dict, bool freekeys, bool freevals);
 bool dictionary_insert(dictionary *dict, value key, value val);
 bool dictionary_insertintern(dictionary *dict, value key, value val);
 value dictionary_intern(dictionary *dict, value key);
+value dictionary_getkey(dictionary *dict, value key, value *val);
 bool dictionary_get(dictionary *dict, value key, value *val);
 bool dictionary_getintern(dictionary *dict, value key, value *val);
 bool dictionary_remove(dictionary *dict, value key);

--- a/src/datastructures/varray.h
+++ b/src/datastructures/varray.h
@@ -41,7 +41,7 @@
     } varray_##name; \
     \
     void varray_##name##init(varray_##name *v); \
-    bool varray_##name##add(varray_##name *v, type *data, int count); \
+    bool varray_##name##add(varray_##name *v, const type *data, int count); \
     bool varray_##name##resize(varray_##name *v, int count); \
     int varray_##name##write(varray_##name *v, type data); \
     void varray_##name##clear(varray_##name *v);
@@ -53,7 +53,7 @@ void varray_##name##init(varray_##name *v) { \
     v->data=NULL; \
 } \
 \
-bool varray_##name##add(varray_##name *v, type *data, int count) { \
+bool varray_##name##add(varray_##name *v, const type *data, int count) { \
     if (v->capacity<v->count + count) { \
         unsigned int capacity = varray_powerof2ceiling(v->count + count); \
         v->data = (type *) morpho_allocate(v->data, v->capacity * sizeof(type), \

--- a/src/datastructures/varray.h
+++ b/src/datastructures/varray.h
@@ -41,7 +41,7 @@
     } varray_##name; \
     \
     void varray_##name##init(varray_##name *v); \
-    bool varray_##name##add(varray_##name *v, const type *data, int count); \
+    bool varray_##name##add(varray_##name *v, type *data, int count); \
     bool varray_##name##resize(varray_##name *v, int count); \
     int varray_##name##write(varray_##name *v, type data); \
     void varray_##name##clear(varray_##name *v);
@@ -53,7 +53,7 @@ void varray_##name##init(varray_##name *v) { \
     v->data=NULL; \
 } \
 \
-bool varray_##name##add(varray_##name *v, const type *data, int count) { \
+bool varray_##name##add(varray_##name *v, type *data, int count) { \
     if (v->capacity<v->count + count) { \
         unsigned int capacity = varray_powerof2ceiling(v->count + count); \
         v->data = (type *) morpho_allocate(v->data, v->capacity * sizeof(type), \

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(morpho
         common.c      common.h
         extensions.c  extensions.h
         format.c      format.h
+        help.c        help.h 
         lex.c         lex.h
         memory.c      memory.h
         parse.c       parse.h
@@ -20,6 +21,7 @@ target_sources(morpho
         common.h
         extensions.h
         format.h
+        help.h
         lex.h
         memory.h
         parse.h

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -142,10 +142,19 @@ bool md_parsebold(parser *p, void *out) {
     return true;
 }
 
+/** Parses italic: called after consuming opening * or _; consumes TEXT then closing delimiter (same as bold). */
+bool md_parseitalic(parser *p, void *out) {
+    tokentype delim = p->previous.type; /* MD_ASTERISK or MD_UNDERSCORE */
+    while (parse_checktokenadvance(p, MD_TEXT));
+    return parse_checktokenadvance(p, delim);
+}
+
 parserule md_rules[] = {
-    PARSERULE_PREFIX(MD_ASTERISK2,       md_parsebold        ),
-    PARSERULE_PREFIX(MD_UNDERSCORE2,     md_parsebold        ),
-    PARSERULE_PREFIX(MD_BACKTICK,        md_parseinlinecode  ),
+    PARSERULE_PREFIX(MD_ASTERISK,        md_parseitalic       ),
+    PARSERULE_PREFIX(MD_UNDERSCORE,      md_parseitalic       ),
+    PARSERULE_PREFIX(MD_ASTERISK2,       md_parsebold         ),
+    PARSERULE_PREFIX(MD_UNDERSCORE2,     md_parsebold         ),
+    PARSERULE_PREFIX(MD_BACKTICK,        md_parseinlinecode   ),
     PARSERULE_UNUSED(TOKEN_NONE)
 };
 
@@ -153,15 +162,18 @@ parserule md_rules[] = {
  * Markdown parse rules
  * ------------------------------------------------------- */
 
-/** Check if a token type is a 'textual' token */
-tokentype _inlinetokens[] = { MD_TEXT, MD_COLON, MD_BACKTICK, MD_LEFTPAREN, MD_RIGHTPAREN };
+/** Check if a token type is a 'textual' token (incl. * _ for italic, ** __ for bold, ` for code) */
+tokentype _inlinetokens[] = {
+    MD_TEXT, MD_COLON, MD_BACKTICK, MD_LEFTPAREN, MD_RIGHTPAREN,
+    MD_ASTERISK, MD_UNDERSCORE, MD_ASTERISK2, MD_UNDERSCORE2
+};
 int _ninlinetokens = sizeof(_inlinetokens)/sizeof(tokentype);
 
 bool md_checktexttoken(parser *p) {
     return parse_checktokenmulti(p, _ninlinetokens, _inlinetokens);
 }
 
-/** Parses text writen in markdown; stops at a non-textual token  */
+/** Parses text written in markdown; stops at a non-textual token. Line ends with NEWLINE or EOF. */
 bool md_parsetext(parser *p, void *out) {
     while (md_checktexttoken(p)) {
         parse_advance(p);
@@ -170,29 +182,29 @@ bool md_parsetext(parser *p, void *out) {
             if (!rule->prefix(p, out)) return false;
         }
     }
-    
-    parse_checktokenadvance(p, MD_NEWLINE);
-    
-    return true;
+    /* Line terminator: newline or end of file */
+    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
+    if (parse_checktoken(p, MD_EOF)) return true;
+    return false;
 }
 
-/** Parses a markdown header  */
+/** Parses a markdown header (title then newline or EOF). */
 bool md_parseheader(parser *p, void *out) {
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-    parse_checktokenadvance(p, MD_NEWLINE);
-    return true;
+    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
+    if (parse_checktoken(p, MD_EOF)) return true;
+    return false;
 }
 
-/** Parses markdown code. */
+/** Parses markdown code block (indented lines until newline or EOF). */
 bool md_parsecode(parser *p, void *out) {
     while (!parse_checktoken(p, MD_NEWLINE) &&
            !parse_checktoken(p, MD_EOF)) {
         parse_advance(p);
     }
-    
-    parse_checktokenadvance(p, MD_NEWLINE);
-    
-    return true;
+    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
+    if (parse_checktoken(p, MD_EOF)) return true;
+    return false;
 }
 
 /** Parses a markdown list. */
@@ -200,25 +212,21 @@ bool md_parselist(parser *p, void *out) {
     return md_parsetext(p, out);
 }
 
-bool md_parseurl(parser *p, void *out) { // TODO: This is a placeholder
-    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-    PARSE_CHECK(parse_checktokenadvance(p, MD_HASH));
-    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-    return true;
+/** Parses the rest of a link definition after ]:  (e.g. " # (target)" or " # (subtopics)"). Consumes until newline or EOF. */
+bool md_parseurl(parser *p, void *out) {
+    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) {
+        parse_advance(p);
+    }
+    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
+    return true; /* EOF is valid end of link line */
 }
 
-/** Parses a markdown link  */
+/** Parses a markdown link definition [label]: # (optional) ... */
 bool md_parselink(parser *p, void *out) {
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
     PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
     PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
     PARSE_CHECK(md_parseurl(p, out));
-    if (parse_checktokenadvance(p, MD_LEFTPAREN)) {
-        PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-        PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTPAREN));
-    }
-    parse_checktokenadvance(p, MD_NEWLINE);
-    
     return true;
 }
 
@@ -239,12 +247,13 @@ bool md_parseblock(parser *p, void *out) {
         return md_parselist(p, out);
     } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
         return md_parselink(p, out);
-    } else if (parse_checktokenadvance(p, MD_NEWLINE)) { // A blank line
+    } else if (parse_checktokenadvance(p, MD_NEWLINE)) { /* blank line */
         return true;
+    } else if (parse_checktoken(p, MD_EOF)) {
+        return true; /* let outer loop exit */
     } else {
         UNREACHABLE("Unrecognized token.");
     }
-    
     return false;
 }
 
@@ -261,7 +270,7 @@ bool md_parse(parser *p, void *out) {
  * Initialize a Markdown parser
  * ------------------------------------------------------- */
 
-/** Initializes a parser to parse JSON */
+/** Initializes a parser to parse Markdown (help format). */
 void help_initializemdparser(parser *p, lexer *l, error *err, void *out) {
     parse_init(p, l, err, out);
     parse_setbaseparsefn(p, md_parse);
@@ -283,9 +292,12 @@ bool help_parse(char *src) {
     parser p;
     help_initializemdparser(&p, &l, &err, NULL);
     
-    parse(&p);
+    bool success = parse(&p);
     
-    return true;
+    parse_clear(&p);
+    lex_clear(&l);
+    
+    return success;
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -13,6 +13,9 @@
 #include "help.h"
 #include "resources.h"
 
+#include "lex.h"
+#include "file.h"
+
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
  *  valid Markdown, although only a subset is used, and the help system interprets
@@ -27,6 +30,59 @@
  *
  *  The help system also recognizes code blocks etc. */
 
+/* **********************************************************************
+ * Markdown lexer
+ * ********************************************************************** */
+
+enum {
+    MD_LEFTBRACE,
+    MD_RIGHTBRACE,
+    MD_LEFTSQUAREBRACE,
+    MD_RIGHTSQUAREBRACE,
+    MD_BOLD,
+    MD_ITALIC,
+    MD_BOLDITALIC,
+    MD_EOF
+};
+
+tokendefn mdtokens[] = {
+    { "(",          MD_LEFTBRACE                , NULL },
+    { ")",          MD_RIGHTBRACE               , NULL },
+    { "[",          MD_LEFTSQUAREBRACE          , NULL },
+    { "]",          MD_RIGHTSQUAREBRACE         , NULL },
+    { "*",          MD_ITALIC                   , NULL },
+    { "_",          MD_ITALIC                   , NULL },
+    { "**",         MD_BOLD                     , NULL },
+    { "__",         MD_BOLD                     , NULL },
+    { "***",        MD_BOLDITALIC               , NULL },
+    { "___",        MD_BOLDITALIC               , NULL },
+    { "",           TOKEN_NONE                  , NULL }
+};
+
+
+/* -------------------------------------------------------
+ * Initialize a JSON lexer
+ * ------------------------------------------------------- */
+
+void help_initializemdlexer(lexer *l, char *src) {
+    lex_init(l, src, 0);
+    lex_settokendefns(l, mdtokens);
+    //lex_setprefn(l, json_lexpreprocess);
+    //lex_setwhitespacefn(l, json_lexwhitespace);
+    lex_seteof(l, MD_EOF);
+}
+
+/* **********************************************************************
+ * Parse help files
+ * ********************************************************************** */
+
+bool help_parse(char *src) {
+    lexer l;
+    help_initializemdlexer(&l, src);
+    
+    
+    return false;
+}
 
 /* **********************************************************************
  * Morpho help files
@@ -35,8 +91,24 @@
 /** Loads a help file
  *  @param file     file to load
  *  @returns true if any help entries were successfully loaded */
-bool help_load(char *file) {
+bool help_load(char *filename) {
+    bool success=false;
     
+    FILE *f = fopen(filename, "r");
+    if (f) {
+        varray_char contents;
+        varray_charinit(&contents);
+        
+        if (file_readintovarray(f, &contents)) {
+            success=help_parse(contents.data);
+        }
+        
+        varray_charclear(&contents);
+        
+        fclose(f);
+    }
+    
+    return success;
 }
 
 /** Searches for help files

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -531,6 +531,55 @@ static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
     return nsegs;
 }
 
+/** Find parent topic index (same file, level < current, block_index < current, largest block_index). */
+static int help_findparent(int idx) {
+    if (idx < 0 || (unsigned int) idx >= s_topics.count) return -1;
+    const md_topic *t = &s_topics.data[idx];
+    int level = t->level;
+    if (level <= 1) return -1;
+    int parent = -1;
+    unsigned int best_block = 0;
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (s_topics.data[i].file_index != t->file_index) continue;
+        if (s_topics.data[i].level >= level) continue;
+        if (s_topics.data[i].block_index >= t->block_index) continue;
+        if (parent < 0 || s_topics.data[i].block_index > best_block) {
+            parent = (int) i;
+            best_block = s_topics.data[i].block_index;
+        }
+    }
+    return parent;
+}
+
+/** Write full display path for topic (e.g. "System.clock") into buf. */
+static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
+    if (!bufsize || idx < 0 || (unsigned int) idx >= s_topics.count) { if (bufsize) buf[0] = '\0'; return; }
+    const md_topic *t = &s_topics.data[idx];
+    if (!t->name) { buf[0] = '\0'; return; }
+    int p = (t->level > 1) ? help_findparent(idx) : -1;
+    if (p >= 0) {
+        help_topic_displaypath(p, buf, bufsize);
+        size_t len = strlen(buf);
+        if (len + 1 < bufsize) snprintf(buf + len, bufsize - len, ".%s", t->name);
+    } else {
+        size_t n = strlen(t->name);
+        if (n >= bufsize) n = bufsize - 1;
+        memcpy(buf, t->name, n);
+        buf[n] = '\0';
+    }
+}
+
+/** Find all topic indices with given name. Fills indices[] up to max, returns count. */
+#define MORPHO_HELP_MAX_MULTIMATCH 8
+static int help_findallbyname(const char *name, int indices[], int max) {
+    int n = 0;
+    for (unsigned int i = 0; i < s_topics.count && n < max; i++) {
+        if (s_topics.data[i].name && strcmp(s_topics.data[i].name, name) == 0)
+            indices[n++] = (int) i;
+    }
+    return n;
+}
+
 /** Find topic index by file and block index. Returns -1 if not found. */
 static int help_findtopicbyblock(int file_index, unsigned int block_index) {
     for (unsigned int i = 0; i < s_topics.count; i++) {
@@ -784,8 +833,17 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs <= 0) return false;
 
-    int idx = help_findtopic(&s_topics, segs[0]);
-    if (idx < 0) return false;
+    int idx;
+    if (nsegs == 1) {
+        int multi[MORPHO_HELP_MAX_MULTIMATCH];
+        int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
+        if (n == 0) return false;
+        if (n >= 2) return false; /* multiple matches: caller will show hint */
+        idx = multi[0];
+    } else {
+        idx = help_findtopic(&s_topics, segs[0]);
+        if (idx < 0) return false;
+    }
 
     /* Resolve remaining segments as subtopics. */
     for (int i = 1; i < nsegs; i++) {
@@ -811,6 +869,23 @@ static void help_hintappend(varray_char *result, const char *query, const char *
     if (n > 0 && (size_t) n < sizeof(buf)) varray_charadd(result, buf, n);
 }
 
+/** Append "Topic 'query' had multiple matches: did you mean 'A' or 'B'?" (or "..., 'A', 'B', or 'C'?"). */
+static void help_hintappend_multi(varray_char *result, const char *query, int indices[], int count) {
+    char buf[MORPHO_HELP_HINTBUFSIZE];
+    char path[MORPHO_MAX_HELPQUERY_LENGTH];
+    int n = snprintf(buf, sizeof(buf), "Topic '%s' had multiple matches: did you mean ", query);
+    for (int i = 0; i < count && n < (int) sizeof(buf) - 4; i++) {
+        help_topic_displaypath(indices[i], path, sizeof(path));
+        if (i == 0)
+            n += snprintf(buf + n, sizeof(buf) - (size_t) n, "'%s'", path);
+        else if (i == count - 1)
+            n += snprintf(buf + n, sizeof(buf) - (size_t) n, " or '%s'?", path);
+        else
+            n += snprintf(buf + n, sizeof(buf) - (size_t) n, ", '%s'", path);
+    }
+    if (n > 0 && (size_t) n < sizeof(buf)) varray_charadd(result, buf, n);
+}
+
 /** Build a hint for a failed query and append to result (caller may clear result first). */
 static void help_queryhint(const char *query, varray_char *result) {
     if (!result) return;
@@ -818,6 +893,20 @@ static void help_queryhint(const char *query, varray_char *result) {
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs == 0) {
+        varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+        return;
+    }
+    if (nsegs == 1) {
+        int multi[MORPHO_HELP_MAX_MULTIMATCH];
+        int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
+        if (n >= 2) {
+            help_hintappend_multi(result, query, multi, n);
+            return;
+        }
+        if (n == 0) {
+            help_hintappend(result, query, help_findclosesttopic(segs[0]));
+            return;
+        }
         varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
         return;
     }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -501,11 +501,61 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
 }
 
 /* **********************************************************************
- * Parse help files
+ * Help topic lookup and content range
  * ********************************************************************** */
 
 static varray_md_file s_files;
 static varray_md_topic s_topics;
+
+/** Number of blocks that form this topic's content (header + following until next same-level or higher header). */
+static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_file *file) {
+    unsigned int i = topic->block_index;
+    unsigned int n = file->blocks.count;
+    int level = topic->level;
+    while (i < n) {
+        const md_block *b = &file->blocks.data[i];
+        if (b->type == MD_BLOCK_HEADER && b->as.header.level <= level && i > topic->block_index)
+            break;
+        i++;
+    }
+    return i - topic->block_index;
+}
+
+bool help_topictotext(const help_topic *t, varray_char *result) {
+    if (!t || !t->file || !t->file->source || !result) return false;
+    const char *src = t->file->source;
+    size_t src_len = t->file->sourcelen;
+
+    for (unsigned int i = 0; i < t->nblocks; i++) {
+        const md_block *b = &t->content_blocks[i];
+        if (b->span.start >= src_len) continue;
+        size_t len = b->span.length;
+        if (b->span.start + len > src_len) len = src_len - b->span.start;
+
+        switch (b->type) {
+            case MD_BLOCK_HEADER: {
+                /* Skip leading # and space for plain text */
+                const char *p = src + b->as.header.title.start;
+                size_t tlen = b->as.header.title.length;
+                if (b->as.header.title.start + tlen > src_len) tlen = src_len - b->as.header.title.start;
+                while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; }
+                if (tlen > 0) varray_charadd(result, p, (int) tlen);
+                varray_charadd(result, "\n\n", 2);
+                break;
+            }
+            case MD_BLOCK_PARAGRAPH:
+            case MD_BLOCK_LIST:
+            case MD_BLOCK_CODE:
+                varray_charadd(result, src + b->span.start, (int) len);
+                if (len > 0 && src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
+                break;
+            case MD_BLOCK_LINK_DEF:
+            case MD_BLOCK_BLANK:
+                break;
+        }
+    }
+    return true;
+}
 
 bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     error err;
@@ -585,8 +635,34 @@ void help_findfiles(void) {
  * ********************************************************************** */
 
 /** Interface to the morpho help system */
+bool morpho_helptopic(const char *query, help_topic *out) {
+    /* Topic names are stored lowercase; search key must match. */
+    char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
+    size_t qlen = 0;
+    while (query[qlen] && qlen < MORPHO_MAX_HELPQUERY_LENGTH - 1) {
+        qbuf[qlen] = (char) tolower((unsigned char) query[qlen]);
+        qlen++;
+    }
+    qbuf[qlen] = '\0';
+
+    int idx = help_findtopic(&s_topics, qbuf);
+    if (idx < 0) return false;
+    const md_topic *topic = &s_topics.data[idx];
+    if (topic->file_index < 0 || (unsigned int) topic->file_index >= s_files.count) return false;
+    const md_file *file = &s_files.data[topic->file_index];
+    if (topic->block_index >= file->blocks.count) return false;
+
+    out->topic = topic;
+    out->file = file;
+    out->content_blocks = &file->blocks.data[topic->block_index];
+    out->nblocks = help_topiccontentnblocks(topic, file);
+    return true;
+}
+
 bool morpho_help(char *query, varray_char *result) {
-    return false;
+    help_topic t;
+    if (!morpho_helptopic(query, &t)) return false;
+    return help_topictotext(&t, result);
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -254,17 +254,11 @@ bool md_parsetext(parser *p, void *out) {
     size_t block_start = (size_t)(p->current.start - base);
 
     for (;;) {
-        // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers.
-        // A leading * or _ is treated as text (list-marker style); we could parse as list item later.
+        /* Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers. */
         while (md_checktexttoken(p)) {
             parse_advance(p);
-            size_t tok_start = (size_t)(p->previous.start - base);
             parserule *rule = parse_getrule(p, p->previous.type);
-            if (rule && rule->prefix) {
-                bool leading_asterisk_or_underscore = (tok_start == block_start &&
-                    (p->previous.type == MD_ASTERISK || p->previous.type == MD_UNDERSCORE));
-                if (!leading_asterisk_or_underscore && !rule->prefix(p, out)) return false;
-            }
+            if (rule && rule->prefix && !rule->prefix(p, out)) return false;
         }
         if (md_parselineend(p)) break;
         // Allow block-style tokens to appear literally in prose (e.g. "+" in "minimization + retriangulation").

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -802,12 +802,11 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     return true;
 }
 
-/** Append "Topic 'query' not found [. Did you mean 'suggest'?]." to result. suggest2 optional (then suggest is "suggest1.suggest2"). */
-static void help_hintappend(varray_char *result, const char *query, const char *suggest1, const char *suggest2) {
+/** Append "Topic 'query' not found [. Did you mean 'suggest'?]." to result. suggest is full path or NULL. */
+static void help_hintappend(varray_char *result, const char *query, const char *suggest) {
     char buf[MORPHO_HELP_HINTBUFSIZE];
-    int n = suggest1
-        ? (suggest2 ? snprintf(buf, sizeof(buf), "Topic '%s' not found. Did you mean '%s.%s'?", query, suggest1, suggest2)
-                    : snprintf(buf, sizeof(buf), "Topic '%s' not found. Did you mean '%s'?", query, suggest1))
+    int n = suggest
+        ? snprintf(buf, sizeof(buf), "Topic '%s' not found. Did you mean '%s'?", query, suggest)
         : snprintf(buf, sizeof(buf), "Topic '%s' not found.", query);
     if (n > 0 && (size_t) n < sizeof(buf)) varray_charadd(result, buf, n);
 }
@@ -824,18 +823,35 @@ static void help_queryhint(const char *query, varray_char *result) {
     }
     int idx = help_findtopic(&s_topics, segs[0]);
     if (idx < 0) {
-        help_hintappend(result, query, help_findclosesttopic(segs[0]), NULL);
+        help_hintappend(result, query, help_findclosesttopic(segs[0]));
         return;
     }
+    char path[MORPHO_MAX_HELPQUERY_LENGTH];
+    int path_len = (int) strlen(segs[0]);
+    if (path_len >= (int) sizeof(path)) path_len = (int) sizeof(path) - 1;
+    memcpy(path, segs[0], (size_t) path_len);
+    path[path_len] = '\0';
+
     for (int i = 1; i < nsegs; i++) {
         int next = help_findsubtopic(idx, segs[i]);
         if (next < 0) {
-            const md_topic *parent = &s_topics.data[idx];
             const char *closest = help_findclosestsubtopic(idx, segs[i]);
-            help_hintappend(result, query, closest ? parent->name : NULL, closest);
+            char suggest[MORPHO_MAX_HELPQUERY_LENGTH];
+            if (closest && path_len + 1 + (int) strlen(closest) < (int) sizeof(suggest))
+                snprintf(suggest, sizeof(suggest), "%s.%s", path, closest);
+            else
+                suggest[0] = '\0';
+            help_hintappend(result, query, suggest[0] ? suggest : NULL);
             return;
         }
         idx = next;
+        if (path_len > 0 && path_len < (int) sizeof(path) - 1) {
+            path[path_len++] = '.';
+            int seglen = (int) strlen(segs[i]);
+            if (path_len + seglen >= (int) sizeof(path)) seglen = (int) sizeof(path) - 1 - path_len;
+            if (seglen > 0) { memcpy(path + path_len, segs[i], (size_t) seglen); path_len += seglen; }
+            path[path_len] = '\0';
+        }
     }
     varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -232,6 +232,7 @@ typedef struct {
 
 /* Forward declarations */
 static void md_push_simpleblock(parser *p, md_parseout *out, size_t block_start, md_blocktype type);
+static void md_push_blank(parser *p, md_parseout *out);
 
 static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len);
 static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start);
@@ -484,6 +485,7 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
         return md_parselink(p, out);
     } else if (parse_checktokenadvance(p, MD_NEWLINE)) { // blank line
+        md_push_blank(p, ctx);
         return true;
     } else if (parse_checktoken(p, MD_EOF)) {
         return true; // let outer loop exit
@@ -644,6 +646,13 @@ static void md_push_code(parser *p, md_parseout *out, size_t block_start) {
 }
 static void md_push_list(parser *p, md_parseout *out, size_t block_start) {
     md_push_simpleblock(p, out, block_start, MD_BLOCK_LIST);
+}
+
+/** Push a blank line as MD_BLOCK_BLANK. Call after consuming the newline token. */
+static void md_push_blank(parser *p, md_parseout *out) {
+    const char *base = out->file->source;
+    size_t block_start = (size_t)(p->previous.start - base);
+    md_push_simpleblock(p, out, block_start, MD_BLOCK_BLANK);
 }
 
 static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t label_start, size_t label_len, size_t target_start, size_t target_len) {
@@ -898,8 +907,10 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 size_t tlen = md_clamp_span(b->as.header.title.start, b->as.header.title.length, src_len);
                 const char *p = src + b->as.header.title.start;
                 while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; } // strip leading # and space
-                if (tlen > 0) varray_charadd(result, (char *) p, (int) tlen);
-                varray_charadd(result, "\n\n", 2);
+                if (tlen > 0) {
+                    varray_charadd(result, (char *) p, (int) tlen);
+                    varray_charadd(result, "\n", 1);
+                }
                 break;
             }
             case MD_BLOCK_PARAGRAPH:
@@ -909,9 +920,11 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 if (len > 0 && src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
                 break;
             case MD_BLOCK_LINK_DEF:
-            case MD_BLOCK_BLANK:
             case MD_BLOCK_THEMATIC_BREAK:
                 break; // omit from plain text (thematic breaks render as blank lines)
+            case MD_BLOCK_BLANK:
+                varray_charadd(result, "\n", 1);
+                break;
         }
     }
     return true;

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -45,6 +45,7 @@ enum {
     MD_RIGHTPAREN,
     MD_LEFTSQUAREBRACE,
     MD_RIGHTSQUAREBRACE,
+    MD_BACKTICK,
     MD_ASTERISK,
     MD_PLUS,
     MD_DASH,
@@ -73,6 +74,7 @@ tokendefn mdtokens[] = {
     { ")",          MD_RIGHTPAREN               , NULL },
     { "[",          MD_LEFTSQUAREBRACE          , NULL },
     { "]",          MD_RIGHTSQUAREBRACE         , NULL },
+    { "`",          MD_BACKTICK                 , NULL },
     { "*",          MD_ASTERISK                 , NULL },
     { "+",          MD_PLUS                     , NULL },
     { "-",          MD_DASH                     , NULL },
@@ -117,15 +119,46 @@ void help_initializemdlexer(lexer *l, char *src) {
 }
 
 /* -------------------------------------------------------
+ * Markdown parse table (for inline syntax)
+ * ------------------------------------------------------- */
+
+bool md_parseinlinecode(parser *p, void *out) {
+    while (parse_checktokenadvance(p, MD_TEXT));
+    parse_checktokenadvance(p, MD_BACKTICK);
+    return true;
+}
+
+bool md_parsebold(parser *p, void *out) {
+    
+}
+
+parserule md_rules[] = {
+    PARSERULE_PREFIX(MD_ASTERISK2,       md_parsebold        ),
+    PARSERULE_PREFIX(MD_UNDERSCORE2,     md_parsebold        ),
+    PARSERULE_PREFIX(MD_BACKTICK,        md_parseinlinecode  ),
+    PARSERULE_UNUSED(TOKEN_NONE)
+};
+
+/* -------------------------------------------------------
  * Markdown parse rules
  * ------------------------------------------------------- */
 
+/** Check if a token type is a 'textual' token */
+tokentype _inlinetokens[] = { MD_TEXT, MD_COLON, MD_BACKTICK, MD_LEFTPAREN, MD_RIGHTPAREN };
+int _ninlinetokens = sizeof(_inlinetokens)/sizeof(tokentype);
+
+bool md_checktexttoken(parser *p) {
+    return parse_checktokenmulti(p, _ninlinetokens, _inlinetokens);
+}
+
 /** Parses text writen in markdown; stops at a non-textual token  */
 bool md_parsetext(parser *p, void *out) {
-    tokentype intokens[] = { MD_TEXT, MD_COLON, MD_LEFTPAREN, MD_RIGHTPAREN };
-    
-    while (parse_checktokenmulti(p, 4, intokens)) {
+    while (md_checktexttoken(p)) {
         parse_advance(p);
+        parserule *rule = parse_getrule(p, p->previous.type);
+        if (rule && rule->prefix) {
+            if (!rule->prefix(p, out)) return false;
+        }
     }
     
     parse_checktokenadvance(p, MD_NEWLINE);
@@ -181,7 +214,7 @@ bool md_parselink(parser *p, void *out) {
 
 /** Parse a markdown 'block'  */
 bool md_parseblock(parser *p, void *out) {
-    if (parse_checktokenadvance(p, MD_TEXT)) {
+    if (md_checktexttoken(p)) {
         return md_parsetext(p, out);
     } else if (parse_checktokenadvance(p, MD_HASH) ||
                parse_checktokenadvance(p, MD_HASH2) ||
@@ -207,23 +240,12 @@ bool md_parseblock(parser *p, void *out) {
 
 /** Base markdown parse type */
 bool md_parse(parser *p, void *out) {
-    while (parse_checktoken(p, MD_EOF)) {
+    while (!parse_checktoken(p, MD_EOF)) {
         PARSE_CHECK(md_parseblock(p, out));
     }
     
     return true;
 }
-
-/* -------------------------------------------------------
- * Markdown parse table
- * ------------------------------------------------------- */
-
-parserule md_rules[] = {
-    PARSERULE_PREFIX(MD_HASH,            NULL           ),
-    PARSERULE_PREFIX(MD_LEFTSQUAREBRACE, NULL           ),
-    PARSERULE_PREFIX(MD_ASTERISK,        NULL           ),
-    PARSERULE_UNUSED(TOKEN_NONE)
-};
 
 /* -------------------------------------------------------
  * Initialize a Markdown parser

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -913,20 +913,11 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
-    // Own a copy of the source so each file in s_files has independent storage.
+    /* Keep contents.data; mdfile will own it (freed in md_file_clear). Do not clear contents. */
     size_t len = (contents.count > 0) ? contents.count - 1 : 0;
-    char *copy = (char *) MORPHO_MALLOC(len + 1);
-    if (!copy) {
-        varray_charclear(&contents);
-        return false;
-    }
-    memcpy(copy, contents.data, len + 1);
-    varray_charclear(&contents);
-    // Parse appends topics to s_topics with file_index = s_files.count. If parse fails we must
-    // remove those topics so they don't point at the next file we append.
     md_file mdfile;
     md_file_init(&mdfile);
-    mdfile.source = copy;
+    mdfile.source = contents.data;
     mdfile.sourcelen = len;
     unsigned int n_topics_before = s_topics.count;
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -14,6 +14,7 @@
 #include "classes.h"
 #include "help.h"
 #include "resources.h"
+#include "common.h"
 
 #include "error.h"
 #include "lex.h"
@@ -226,6 +227,9 @@ typedef struct {
     int file_index;
     int current_header_level; // 1–3, set before md_parseheader
 } md_parseout;
+
+/* Forward declarations */
+static void md_push_simpleblock(parser *p, md_parseout *out, size_t block_start, md_blocktype type);
 
 static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len);
 static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start);
@@ -525,6 +529,7 @@ void md_block_clear(md_block *b) {
 void md_file_init(md_file *f) {
     f->source = NULL;
     f->sourcelen = 0;
+    f->filename = NULL;
     varray_md_blockinit(&f->blocks);
 }
 
@@ -532,6 +537,8 @@ void md_file_clear(md_file *f) {
     if (f->source) MORPHO_FREE(f->source);
     f->source = NULL;
     f->sourcelen = 0;
+    if (f->filename) MORPHO_FREE(f->filename);
+    f->filename = NULL;
     for (unsigned int i = 0; i < f->blocks.count; i++) md_block_clear(&f->blocks.data[i]);
     varray_md_blockclear(&f->blocks);
 }
@@ -953,6 +960,7 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
             if (has_posn) fprintf(stderr, "%sposition %d", has_line ? ", " : "", err.posn + 1);
             fprintf(stderr, ")");
         }
+        if (file->filename) fprintf(stderr, " in %s", file->filename);
         fprintf(stderr, "\n");
     }
     return ok;
@@ -979,12 +987,12 @@ bool help_load(char *filename) {
     md_file_init(&mdfile);
     mdfile.source = contents.data;
     mdfile.sourcelen = len;
+    mdfile.filename = morpho_strdup(filename);
     unsigned int n_topics_before = s_topics.count;
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
     if (ok) {
         varray_md_filewrite(&s_files, mdfile);
     } else {
-        fprintf(stderr, "Help file failed to parse: %s\n", filename);
         md_file_clear(&mdfile);
         // Remove topics added during the failed parse; they have file_index = s_files.count
         while (s_topics.count > n_topics_before) {

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -15,6 +15,8 @@
 #include "help.h"
 #include "resources.h"
 #include "common.h"
+#include "dictionary.h"
+#include "list.h"
 
 #include "error.h"
 #include "lex.h"
@@ -31,11 +33,10 @@
 DEFINE_VARRAY(md_block, md_block);
 DEFINE_VARRAY(md_file, md_file);
 DEFINE_VARRAY(md_topic, md_topic);
-DEFINE_VARRAY(md_alias, md_alias);
 
 static varray_md_file s_files;
 static varray_md_topic s_topics;
-static varray_md_alias s_aliases;
+static dictionary s_names; // Map names or aliases to topic index or list of indices
 
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
@@ -564,39 +565,88 @@ void md_file_clear(md_file *f) {
 }
 
 /* -------------------------------------------------------
- * Topic and alias comparison and sorting
+ * Name index (single dict: name/alias -> index or List of indices)
  * ------------------------------------------------------- */
 
-int md_topic_compare(const void *a, const void *b) {
-    const md_topic *ta = (const md_topic *) a;
-    const md_topic *tb = (const md_topic *) b;
-    return strcmp(ta->name, tb->name);
+/** Build s_names from topic names (value = index or List). Call once after all files loaded and parent_topic set. Aliases may already be in dict from parse. */
+static void help_buildnameindex(void) {
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (!MORPHO_ISSTRING(s_topics.data[i].name)) continue;
+        value key = s_topics.data[i].name;
+        value v;
+        if (!dictionary_get(&s_names, key, &v)) {
+            dictionary_insert(&s_names, key, MORPHO_INTEGER((int) i));
+            continue;
+        }
+        if (MORPHO_ISINTEGER(v) && MORPHO_GETINTEGERVALUE(v) == (int) i) continue; // already points to this topic
+        objectlist *list;
+        if (MORPHO_ISINTEGER(v)) {
+            list = object_newlist(0, NULL);
+            if (!list) continue;
+            list_append(list, v);
+            dictionary_insert(&s_names, key, MORPHO_OBJECT(list));
+        } else list = MORPHO_GETLIST(v);
+        list_append(list, MORPHO_INTEGER((int) i));
+    }
 }
 
-int md_alias_compare(const void *a, const void *b) {
-    const md_alias *aa = (const md_alias *) a;
-    const md_alias *ab = (const md_alias *) b;
-    return strcmp(aa->name, ab->name);
+/** Get first topic index from dict value (integer or first element of list). Returns -1 if not found or invalid. */
+static int help_indexvalue_first(value v) {
+    if (MORPHO_ISINTEGER(v)) return MORPHO_GETINTEGERVALUE(v);
+    if (MORPHO_ISLIST(v)) {
+        objectlist *list = MORPHO_GETLIST(v);
+        if (list_length(list) == 0) return -1;
+        value first;
+        if (list_getelement(list, 0, &first) && MORPHO_ISINTEGER(first))
+            return MORPHO_GETINTEGERVALUE(first);
+    }
+    return -1;
 }
 
-void help_sorttopics(varray_md_topic *topics) {
-    if (topics->data && topics->count > 0)
-        qsort(topics->data, topics->count, sizeof(md_topic), md_topic_compare);
+/** Fill indices[] from dict value (integer or list). Returns count. */
+static int help_indexvalue_collect(value v, int indices[], int max) {
+    if (MORPHO_ISINTEGER(v)) {
+        if (max > 0) indices[0] = MORPHO_GETINTEGERVALUE(v);
+        return 1;
+    } else if (MORPHO_ISLIST(v)) {
+        objectlist *list = MORPHO_GETLIST(v);
+        unsigned int n = list_length(list);
+        if ((int) n > max) n = (unsigned int) max;
+        for (unsigned int i = 0; i < n; i++) {
+            value el;
+            if (list_getelement(list, (int) i, &el) && MORPHO_ISINTEGER(el))
+                indices[i] = MORPHO_GETINTEGERVALUE(el);
+        }
+        return (int) list_length(list);
+    }
+    return 0;
 }
 
-void help_sortaliases(varray_md_alias *aliases) {
-    if (aliases->data && aliases->count > 0)
-        qsort(aliases->data, aliases->count, sizeof(md_alias), md_alias_compare);
+int help_findtopic(const char *name) {
+    objectstring key_str = MORPHO_STATICSTRING(name);
+    value key = MORPHO_OBJECT(&key_str);
+    value v;
+    if (!dictionary_get(&s_names, key, &v)) return -1;
+    return help_indexvalue_first(v);
 }
 
-static int help_findalias(const char *name);
+int help_findallbyname(const char *name, int indices[], int max) {
+    objectstring key_str = MORPHO_STATICSTRING(name);
+    value key = MORPHO_OBJECT(&key_str);
+    value v;
+    if (!dictionary_get(&s_names, key, &v)) return 0;
+    return help_indexvalue_collect(v, indices, max);
+}
 
-int help_findtopic(varray_md_topic *topics, const char *name) {
-    md_topic key = { .name = (char *) name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
-    md_topic *found = (md_topic *) bsearch(&key, topics->data, topics->count, sizeof(md_topic), md_topic_compare);
-    if (found) return (int) (found - topics->data);
-    
-    return help_findalias(name); // Not found in topics, check aliases
+/** Find child of parent topic with given name. Returns topic index or -1. */
+static int help_findchild(int parent_idx, const char *name) {
+    objectstring key_str = MORPHO_STATICSTRING(name);
+    value key = MORPHO_OBJECT(&key_str);
+    for (unsigned int j = 0; j < s_topics.count; j++) {
+        if (s_topics.data[j].parent_topic != parent_idx) continue;
+        if (MORPHO_ISEQUAL(s_topics.data[j].name, key)) return (int) j;
+    }
+    return -1;
 }
 
 /* -------------------------------------------------------
@@ -618,6 +668,12 @@ static void md_span_set(md_span *s, size_t start, size_t length) {
 static void md_trimspan(const char *base, size_t *start, size_t *len) {
     while (*len && (unsigned char) base[*start] <= ' ') { (*start)++; (*len)--; }
     while (*len && (unsigned char) base[*start + *len - 1] <= ' ') (*len)--;
+}
+
+/** Lowercase len bytes from src into buf and null-terminate. Caller must provide buf of size at least len + 1. */
+static void help_lowercase_into(const char *src, size_t len, char *buf) {
+    for (size_t i = 0; i < len; i++) buf[i] = (char) tolower((unsigned char) src[i]);
+    buf[len] = '\0';
 }
 
 /** Initialize common block fields (type, span, parent, children). */
@@ -657,26 +713,29 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
     md_block_set_header(&b, out->current_header_level, title_start, title_len);
     varray_md_blockwrite(&out->file->blocks, b);
 
-    // Topic: trimmed title span, lowercased, for index lookup
+    // Topic: trimmed title span, lowercased Morpho string (stack buffer)
     size_t ns = title_start, nl = title_len;
     md_trimspan(base, &ns, &nl);
-    char *name = (char *) MORPHO_MALLOC(nl + 1);
-    if (name) {
-        for (size_t i = 0; i < nl; i++)
-            name[i] = (char) tolower((unsigned char) base[ns + i]);
-        name[nl] = '\0';
-        md_topic topic = {
-            .name = name,
-            .file_index = out->file_index,
-            .block_index = out->file->blocks.count - 1,
-            .level = out->current_header_level,
-            .parent_topic = -1
-        };
-        varray_md_topicwrite(out->topics, topic);
-        out->current_topic_index = (int) out->topics->count - 1;
-    } else {
+    if (nl > MORPHO_MAX_HELPQUERY_LENGTH) {
         out->current_topic_index = -1;
+        return;
     }
+    char buf[nl + 1];
+    help_lowercase_into(base + ns, nl, buf);
+    value name_val = object_stringfromcstring(buf, nl);
+    if (!MORPHO_ISSTRING(name_val)) {
+        out->current_topic_index = -1;
+        return;
+    }
+    md_topic topic = {
+        .name = name_val,
+        .file_index = out->file_index,
+        .block_index = out->file->blocks.count - 1,
+        .level = out->current_header_level,
+        .parent_topic = -1
+    };
+    varray_md_topicwrite(out->topics, topic);
+    out->current_topic_index = (int) out->topics->count - 1;
 }
 
 static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start) {
@@ -709,50 +768,25 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
  * Help topic aliases
  * ********************************************************************** */
 
-/** Find topic index by alias name. Returns -1 if not found. Resolves topic by name so index is correct after sorting. */
-static int help_findalias(const char *name) {
-    if (!s_aliases.data || s_aliases.count == 0) return -1;
-    md_alias key = { .name = (char *) name, .topic_name = NULL };
-    md_alias *found = (md_alias *) bsearch(&key, s_aliases.data, s_aliases.count, sizeof(md_alias), md_alias_compare);
-    if (!found || !found->topic_name) return -1;
-    return help_findtopic(&s_topics, found->topic_name);
-}
-
-/** Create an alias from a tag link definition. Returns true if alias was created. Stores a pointer to the topic's name so resolution stays valid after topics are sorted. */
+/** Create an alias from a tag link definition. Inserts alias -> topic index into s_names. */
 static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index) {
     if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return false;
-    
-    // Check if label starts with "tag"
     if (label_len < 3) return false;
     const char *label = base + label_start;
     if (tolower((unsigned char) label[0]) != 't' || tolower((unsigned char) label[1]) != 'a' || tolower((unsigned char) label[2]) != 'g') return false;
-    
-    // Extract alias name from target (find text in parentheses)
     const char *target = base + target_start, *open = NULL, *close = NULL;
     for (const char *p = target; p < target + target_len && !close; p++) {
         if (!open && *p == '(') open = p + 1;
         else if (open && *p == ')') { close = p; break; }
     }
     if (!open || !close || close == open) return false;
-    
-    // Allocate and lowercase alias name
     size_t len = (size_t)(close - open);
-    char *alias_name = (char *) MORPHO_MALLOC(len + 1);
-    if (!alias_name) return false;
-    for (size_t j = 0; j < len; j++) alias_name[j] = (char) tolower((unsigned char) open[j]);
-    alias_name[len] = '\0';
-    
-    // Check for duplicate alias name
-    for (unsigned int j = 0; j < s_aliases.count; j++) {
-        if (s_aliases.data[j].name && strcmp(s_aliases.data[j].name, alias_name) == 0) {
-            MORPHO_FREE(alias_name);
-            return false;
-        }
-    }
-    
-    // Store pointer to topic's name
-    const char *topic_name = s_topics.data[topic_index].name;
-    varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_name = topic_name });
+    if (len > MORPHO_MAX_HELPQUERY_LENGTH) return false;
+    char alias_buf[len + 1];
+    help_lowercase_into(open, len, alias_buf);
+    value alias_val = object_stringfromcstring(alias_buf, len);
+    if (!MORPHO_ISSTRING(alias_val)) return false;
+    dictionary_insert(&s_names, alias_val, MORPHO_INTEGER(topic_index));
     return true;
 }
 
@@ -827,76 +861,19 @@ static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
         return;
     }
     const md_topic *t = &s_topics.data[idx];
-    if (!t->name) {
+    const char *name = MORPHO_ISSTRING(t->name) ? MORPHO_GETCSTRING(t->name) : NULL;
+    if (!name) {
         buf[0] = '\0';
         return;
     }
     int p = (t->level > 1) ? help_findparent(idx) : -1;
     if (p >= 0) {
-        // Recurse for parent path, then append ".name"
         help_topic_displaypath(p, buf, bufsize);
         size_t len = strlen(buf);
-        if (len + 1 < bufsize) snprintf(buf + len, bufsize - len, ".%s", t->name);
+        if (len + 1 < bufsize) snprintf(buf + len, bufsize - len, ".%s", name);
     } else {
-        // Top-level or no parent: just the topic name
-        snprintf(buf, bufsize, "%s", t->name);
+        snprintf(buf, bufsize, "%s", name);
     }
-}
-
-/* -------------------------------------------------------
- * Topic lookup by name or block
- * ------------------------------------------------------- */
-
-/** Find all topic indices with given name. Fills indices[] up to max, returns count. */
-static int help_findallbyname(const char *name, int indices[], int max) {
-    int n = 0;
-    for (unsigned int i = 0; i < s_topics.count && n < max; i++) {
-        if (s_topics.data[i].name && strcmp(s_topics.data[i].name, name) == 0)
-            indices[n++] = (int) i;
-    }
-    return n;
-}
-
-/** Find topic index by file and block index. Returns -1 if not found. */
-static int help_findtopicbyblock(int file_index, unsigned int block_index) {
-    for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (s_topics.data[i].file_index == file_index && s_topics.data[i].block_index == block_index)
-            return (int) i;
-    }
-    return -1;
-}
-
-/** True if header title span (trimmed, lowercased) equals name. */
-static bool help_headertitleeq(const char *base, size_t start, size_t len, const char *name) {
-    md_trimspan(base, &start, &len);
-    while (len && *name && (char) tolower((unsigned char) base[start]) == *name) {
-        start++;
-        len--;
-        name++;
-    }
-    return len == 0 && *name == '\0';
-}
-
-/** Find first subtopic of parent with given name (same file, block after parent, level > parent). Returns topic index or -1. */
-static int help_findsubtopic(int parent_idx, const char *name) {
-    if (parent_idx < 0 || (unsigned int) parent_idx >= s_topics.count) return -1;
-    const md_topic *parent = &s_topics.data[parent_idx];
-    if (parent->file_index < 0 || (unsigned int) parent->file_index >= s_files.count) return -1;
-    const md_file *file = &s_files.data[parent->file_index];
-    const char *base = file->source;
-    size_t base_len = file->sourcelen;
-
-    // Scan blocks after parent; stop when we hit same-or-higher level (left section)
-    for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
-        const md_block *b = &file->blocks.data[i];
-        if (b->type != MD_BLOCK_HEADER) continue;
-        if (b->as.header.level <= parent->level) return -1; // left section
-        size_t start = b->as.header.title.start;
-        size_t len = md_clamp_span(start, b->as.header.title.length, base_len);
-        if (help_headertitleeq(base, start, len, name))
-            return help_findtopicbyblock(parent->file_index, i);
-    }
-    return -1;
 }
 
 /* -------------------------------------------------------
@@ -940,9 +917,10 @@ static const char *help_findclosesttopic(const char *name) {
     const char *best = NULL;
     unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
     for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (s_topics.data[i].level != 1 || !s_topics.data[i].name) continue;
-        unsigned int d = help_editdistance(name, s_topics.data[i].name, best_d - 1);
-        if (d < best_d) { best_d = d; best = s_topics.data[i].name; }
+        if (s_topics.data[i].level != 1 || !MORPHO_ISSTRING(s_topics.data[i].name)) continue;
+        const char *tn = MORPHO_GETCSTRING(s_topics.data[i].name);
+        unsigned int d = help_editdistance(name, tn, best_d - 1);
+        if (d < best_d) { best_d = d; best = tn; }
     }
     return best;
 }
@@ -950,19 +928,14 @@ static const char *help_findclosesttopic(const char *name) {
 /** Find subtopic name under parent closest to name; NULL if none within distance. */
 static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
     if (parent_idx < 0 || (unsigned int) parent_idx >= s_topics.count) return NULL;
-    const md_topic *parent = &s_topics.data[parent_idx];
-    if (parent->file_index < 0 || (unsigned int) parent->file_index >= s_files.count) return NULL;
-    const md_file *file = &s_files.data[parent->file_index];
     const char *best = NULL;
     unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
-    for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
-        const md_block *b = &file->blocks.data[i];
-        if (b->type != MD_BLOCK_HEADER) continue;
-        if (b->as.header.level <= parent->level) break;
-        int ti = help_findtopicbyblock(parent->file_index, i);
-        if (ti < 0 || !s_topics.data[ti].name) continue;
-        unsigned int d = help_editdistance(name, s_topics.data[ti].name, best_d - 1);
-        if (d < best_d) { best_d = d; best = s_topics.data[ti].name; }
+    for (unsigned int j = 0; j < s_topics.count; j++) {
+        if (s_topics.data[j].parent_topic != parent_idx) continue;
+        if (!MORPHO_ISSTRING(s_topics.data[j].name)) continue;
+        const char *tn = MORPHO_GETCSTRING(s_topics.data[j].name);
+        unsigned int d = help_editdistance(name, tn, best_d - 1);
+        if (d < best_d) { best_d = d; best = tn; }
     }
     return best;
 }
@@ -994,17 +967,18 @@ static void help_topicfill(help_topic *out, const md_topic *topic, const md_file
 }
 
 /** Validate topic and get source pointer/length; return false if invalid. */
-static bool help_topicsrc(const help_topic *t, varray_char *result, const char **src, size_t *src_len) {
-    if (!t || !t->file || !t->file->source || !result) return false;
+static bool help_topicsrc(const help_topic *t, const char **src, size_t *src_len) {
+    if (!t || !t->file || !t->file->source) return false;
     *src = t->file->source;
     *src_len = t->file->sourcelen;
     return true;
 }
 
 bool help_topictotext(const help_topic *t, varray_char *result) {
+    if (!result) return false;
     const char *src;
     size_t src_len;
-    if (!help_topicsrc(t, result, &src, &src_len)) return false;
+    if (!help_topicsrc(t, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
         size_t len = md_clamp_span(b->span.start, b->span.length, src_len);
@@ -1041,9 +1015,10 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
 }
 
 bool help_topicrawmd(const help_topic *t, varray_char *result) {
+    if (!result) return false;
     const char *src;
     size_t src_len;
-    if (!help_topicsrc(t, result, &src, &src_len)) return false;
+    if (!help_topicsrc(t, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
         size_t len = md_clamp_span(b->span.start, b->span.length, src_len);
@@ -1058,13 +1033,13 @@ bool help_topicrawmd(const help_topic *t, varray_char *result) {
  * Morpho help files (load and parse)
  * ********************************************************************** */
 
-/** Parse a markdown file and append blocks/topics to the given arrays. */
-bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
+/** Parse a markdown file and append blocks/topics to s_topics. */
+bool help_parse(md_file *file, int file_index) {
     error err;
     error_init(&err);
     md_parseout parseout = {
         .file = file,
-        .topics = topics,
+        .topics = &s_topics,
         .file_index = file_index,
         .current_header_level = 1,
         .current_topic_index = -1
@@ -1111,23 +1086,19 @@ bool help_load(char *filename) {
     mdfile.sourcelen = len;
     mdfile.filename = morpho_strdup(filename);
     unsigned int n_topics_before = s_topics.count;
-    bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
+    bool ok = help_parse(&mdfile, (int) s_files.count);
     if (ok) {
         varray_md_filewrite(&s_files, mdfile);
     } else {
         md_file_clear(&mdfile);
         // Remove topics added during the failed parse; they have file_index = s_files.count
-        while (s_topics.count > n_topics_before) {
-            md_topic *t = &s_topics.data[s_topics.count - 1];
-            if (t->name) MORPHO_FREE(t->name);
-            t->name = NULL;
+        while (s_topics.count > n_topics_before)
             s_topics.count--;
-        }
     }
     return ok;
 }
 
-/** Finds and loads all help files; populates s_files and s_topics, then sorts topics. */
+/** Finds and loads all help files; sets parent_topic for each topic, then builds name index. */
 void help_findfiles(void) {
     varray_value files;
     varray_valueinit(&files);
@@ -1138,8 +1109,9 @@ void help_findfiles(void) {
         for (unsigned int i = 0; i < files.count; i++) morpho_freeobject(files.data[i]);
     }
     varray_valueclear(&files);
-    help_sorttopics(&s_topics);
-    help_sortaliases(&s_aliases);
+    for (unsigned int i = 0; i < s_topics.count; i++)
+        s_topics.data[i].parent_topic = help_findparent(i);
+    help_buildnameindex();
 }
 
 /* **********************************************************************
@@ -1200,7 +1172,7 @@ void help_queryhint(const char *query, varray_char *result) {
         return;
     }
     // Multi-segment: resolve first, then walk subtopics; on first failure suggest path.closest
-    int idx = help_findtopic(&s_topics, segs[0]);
+    int idx = help_findtopic(segs[0]);
     if (idx < 0) {
         help_hintappend(result, query, help_findclosesttopic(segs[0]));
         varray_charwrite(result, '\0');
@@ -1211,7 +1183,7 @@ void help_queryhint(const char *query, varray_char *result) {
     if (path_len < 0 || path_len >= (int) sizeof(path)) path_len = (int) sizeof(path) - 1;
 
     for (int i = 1; i < nsegs; i++) {
-        int next = help_findsubtopic(idx, segs[i]);
+        int next = help_findchild(idx, segs[i]);
         if (next < 0) {
             const char *closest = help_findclosestsubtopic(idx, segs[i]);
             char suggest[MORPHO_MAX_HELPQUERY_LENGTH] = {0};
@@ -1251,7 +1223,7 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs <= 0) return false;
 
-    // Single segment: resolve by name; fail if 0 or multiple matches (caller shows hint)
+    // Single segment: dict gives 0, 1, or many; if many caller shows "did you mean?"
     int idx;
     if (nsegs == 1) {
         int multi[MORPHO_HELP_MAX_MULTIMATCH];
@@ -1259,19 +1231,18 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
         if (n == 1) {
             idx = multi[0];
         } else if (n == 0) {
-            idx = help_findtopic(&s_topics, segs[0]); // fallback: bsearch by name
-            if (idx < 0) return false;
+            return false;
         } else {
-            return false; // multiple matches: caller will show hint
+            return false; // multiple matches: caller shows hint
         }
     } else {
-        idx = help_findtopic(&s_topics, segs[0]);
+        idx = help_findtopic(segs[0]); // first match
         if (idx < 0) return false;
     }
 
-    // Resolve remaining segments as subtopics
+    // Resolve remaining segments by walking children
     for (int i = 1; i < nsegs; i++) {
-        idx = help_findsubtopic(idx, segs[i]);
+        idx = help_findchild(idx, segs[i]);
         if (idx < 0) return false;
     }
 
@@ -1283,14 +1254,14 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     return true;
 }
 
-bool morpho_helpastext(char *query, varray_char *result) {
+bool morpho_helpastext(const char *query, varray_char *result) {
     help_topic t;
     if (morpho_helpastopic(query, &t)) return help_topictotext(&t, result);
     help_queryhint(query, result);
     return false;
 }
 
-bool morpho_helpasmd(char *query, varray_char *result) {
+bool morpho_helpasmd(const char *query, varray_char *result) {
     help_topic t;
     if (morpho_helpastopic(query, &t)) return help_topicrawmd(&t, result);
     help_queryhint(query, result);
@@ -1315,23 +1286,18 @@ void help_initialize(void) {
 
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
-    varray_md_aliasinit(&s_aliases);
+    dictionary_init(&s_names);
     morpho_addfinalizefn(help_finalize);
 }
 
-/** @brief Finalization: free all files and topics. */
+/** @brief Finalization: free all files and topics. Name keys not owned; free List values then clear dict. */
 void help_finalize(void) {
     for (unsigned int i = 0; i < s_files.count; i++)
         md_file_clear(&s_files.data[i]);
     varray_md_fileclear(&s_files);
-    for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (s_topics.data[i].name) MORPHO_FREE(s_topics.data[i].name);
-    }
     varray_md_topicclear(&s_topics);
-    for (unsigned int i = 0; i < s_aliases.count; i++) {
-        if (s_aliases.data[i].name) MORPHO_FREE(s_aliases.data[i].name);
-    }
-    varray_md_aliasclear(&s_aliases);
+    dictionary_freecontents(&s_names, false, true); /* free List values; keys (names) are VM-owned */
+    dictionary_clear(&s_names);
 }
 
 #endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -406,13 +406,39 @@ bool md_parselist(parser *p, void *out) {
     return true;
 }
 
-/** Parses the rest of a link definition after ]:  (e.g. " # (target)" or " # (subtopics)"). Consumes until newline or EOF. */
-bool md_parseurl(parser *p, void *out) {
-    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) {
+/** Parses the rest of a link definition after ]:  (e.g. " # (target)" or " # (subtopics)"). Consumes until newline or EOF.
+ *  Extracts target URL and any parenthesized content. Returns target_start, target_len, paren_start, paren_len via pointers.
+ *  paren_start/len are set to 0 if no parentheses found. */
+static void md_parseurl(parser *p, void *out, size_t *target_start, size_t *target_len, size_t *paren_start, size_t *paren_len) {
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    *target_start = (size_t)(p->current.start - base);
+    *paren_start = 0;
+    *paren_len = 0;
+    
+    // Parse tokens until we hit MD_LEFTPAREN (for parenthesized content) or MD_NEWLINE/EOF
+    size_t target_end = *target_start;
+    while (!parse_checktoken(p, MD_LEFTPAREN) && !parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) {
         parse_advance(p);
+        target_end = md_end_previous(p, base);
     }
-    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
-    return true; // EOF is valid end of link line
+    // target_end is now the end of the last token before MD_LEFTPAREN (or MD_NEWLINE/EOF)
+    *target_len = target_end > *target_start ? (size_t)(target_end - *target_start) : 0;
+    
+    // If we found a left parenthesis, extract parenthesized content
+    if (parse_checktokenadvance(p, MD_LEFTPAREN)) {
+        *paren_start = (size_t)(p->current.start - base);
+        // Parse content until right parenthesis
+        while (!parse_checktoken(p, MD_RIGHTPAREN) && !parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) parse_advance(p);
+        if (parse_checktokenadvance(p, MD_RIGHTPAREN)) { // paren_len is content between ( and ), excluding the closing )
+            *paren_len = (size_t)(p->previous.start - base - *paren_start);
+        } else { // Unmatched parenthesis, ignore
+            *paren_start = 0; *paren_len = 0;
+        }
+    }
+    
+    // Consume newline if present
+    parse_checktokenadvance(p, MD_NEWLINE);
 }
 
 /** Parses inline link [text](url)... after [ and label and ] are consumed. Consumes ( url ) and rest of line, pushes paragraph. */
@@ -468,15 +494,20 @@ bool md_parselink(parser *p, void *out) {
         parse_error(p, false, MD_LINKEXPECTCOLON);
         return false;
     }
-    size_t target_start = (size_t)(p->current.start - base);
-    if (!md_parseurl(p, out)) { // Parse target URL until newline/EOF
-        parse_error(p, true, MD_EXPECTLINEEND);
-        return false;
-    }
-    size_t target_end = md_end_previous(p, base);
-    size_t target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
+    size_t target_start, target_len, paren_start, paren_len;
+    md_parseurl(p, out, &target_start, &target_len, &paren_start, &paren_len);
     
-    if (help_casencmp(base + label_start, label_len, "toplevel", 8)) ctx->file->promote_subtopics = true;
+    // Check for special directives: [show]: # (subtopics) or [toplevel]: #
+    // Accept both [show] and [showsubtopics] (case-insensitive prefix match)
+    if (label_len >= 4 && help_casencmp(base + label_start, 4, "show", 4) && paren_len > 0 && help_casencmp(base + paren_start, paren_len, "subtopics", 9)) {
+        md_push_simpleblock(p, ctx, block_start, MD_SHOW_SUBTOPICS);
+        return true;
+    } else if (help_casencmp(base + label_start, label_len, "toplevel", 8)) {
+        ctx->file->promote_subtopics = true;
+        return true;
+    }
+    
+    // Normal reference link: create alias/link block
     help_createalias(base, label_start, label_len, target_start, target_len, ctx->current_topic_index);
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
@@ -1043,6 +1074,7 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 break;
             case MD_BLOCK_LINK_DEF:
             case MD_BLOCK_THEMATIC_BREAK:
+            case MD_SHOW_SUBTOPICS:
                 break; // omit from plain text (thematic breaks render as blank lines)
             case MD_BLOCK_BLANK:
                 varray_charwrite(result, '\n');
@@ -1326,6 +1358,18 @@ void morpho_helptopics(varray_value *out) {
         unsigned int idx;
         if (varray_valuefindsame(out, name, &idx)) continue;
         varray_valuewrite(out, name);
+    }
+}
+
+/** Fills a varray_value with subtopic names for the given topic. */
+void morpho_helpsubtopics(const help_topic *topic, varray_value *out) {
+    if (!topic || !topic->topic || !out) return;
+    int topic_index = (int)(topic->topic - s_topics.data);
+    if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return;
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        const md_topic *t = &s_topics.data[i];
+        if (t->parent_topic != topic_index || !MORPHO_ISSTRING(t->name)) continue;
+        varray_valuewrite(out, t->name);
     }
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -568,38 +568,62 @@ void md_file_clear(md_file *f) {
  * Name index (single dict: name/alias -> index or List of indices)
  * ------------------------------------------------------- */
 
-/** Build s_names from topic names; intern names into s_names (one string per distinct name). Call once after all files loaded and parent_topic set. Aliases may already be in dict from parse. */
-static void help_buildnameindex(void) {
-    for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (!MORPHO_ISSTRING(s_topics.data[i].name)) continue;
-        value key = s_topics.data[i].name;
-        value interned = dictionary_intern(&s_names, key);
-        if (MORPHO_ISNIL(interned)) {
-            dictionary_insert(&s_names, key, MORPHO_INTEGER((int) i));
-            s_topics.data[i].name = key;
-            continue;
-        }
-        if (!MORPHO_ISSAME(interned, key)) morpho_freeobject(key);
-        s_topics.data[i].name = interned;
-        value v;
-        if (!dictionary_get(&s_names, interned, &v)) continue;
-        if (MORPHO_ISNIL(v)) {
-            dictionary_insert(&s_names, interned, MORPHO_INTEGER((int) i));
-            continue;
-        }
-        if (MORPHO_ISINTEGER(v) && MORPHO_GETINTEGERVALUE(v) == (int) i) continue; /* already this topic */
-        objectlist *list;
-        if (MORPHO_ISINTEGER(v)) {
-            list = object_newlist(0, NULL);
-            if (!list) continue;
-            list_append(list, v);
-            if (!dictionary_insert(&s_names, interned, MORPHO_OBJECT(list))) {
-                morpho_freeobject(MORPHO_OBJECT(list));
-                continue;
-            }
-        } else list = MORPHO_GETLIST(v);
-        list_append(list, MORPHO_INTEGER((int) i));
+static bool help_name_referenced_by(value name, unsigned int keep_count) {
+    for (unsigned int j = 0; j < keep_count; j++)
+        if (MORPHO_ISSAME(s_topics.data[j].name, name)) return true;
+    return false;
+}
+
+/** Remove topic_index from s_names (rollback). Frees the name key only if the entry is removed and no topic in [0, keep_count) has that name. */
+static void help_nameindex_remove(int topic_index, unsigned int keep_count) {
+    if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return;
+    value name = s_topics.data[topic_index].name;
+    if (!MORPHO_ISOBJECT(name)) return;
+    value v;
+    if (!dictionary_get(&s_names, name, &v)) return;
+    bool remove_entry = false;
+    if (MORPHO_ISINTEGER(v)) {
+        if (MORPHO_GETINTEGERVALUE(v) != topic_index) return;
+        remove_entry = true;
+    } else if (MORPHO_ISLIST(v)) {
+        list_remove(MORPHO_GETLIST(v), MORPHO_INTEGER(topic_index));
+        remove_entry = (list_length(MORPHO_GETLIST(v)) == 0);
     }
+    if (remove_entry) {
+        if (MORPHO_ISLIST(v)) morpho_freeobject(v);
+        dictionary_remove(&s_names, name);
+        if (!help_name_referenced_by(name, keep_count)) morpho_freeobject(name);
+    }
+}
+
+/** Add topic_index under name (buf, len). Look up with static key; if present use existing key and update value, else allocate and insert. Returns canonical name value. */
+static value help_nameindex_add(const char *buf, size_t len, int topic_index) {
+    objectstring key_obj = MORPHO_STATICSTRINGWITHLENGTH(buf, len);
+    value key = MORPHO_OBJECT(&key_obj);
+    value v;
+    value existing = dictionary_getkey(&s_names, key, &v);
+    if (!MORPHO_ISNIL(existing)) {
+        if (MORPHO_ISNIL(v)) {
+            dictionary_insert(&s_names, existing, MORPHO_INTEGER(topic_index));
+        } else if (MORPHO_ISINTEGER(v)) {
+            if (MORPHO_GETINTEGERVALUE(v) == topic_index) return existing;
+            objectlist *list = object_newlist(0, NULL);
+            if (list) {
+                list_append(list, v);
+                list_append(list, MORPHO_INTEGER(topic_index));
+                if (dictionary_insert(&s_names, existing, MORPHO_OBJECT(list)))
+                    return existing;
+                morpho_freeobject(MORPHO_OBJECT(list));
+            }
+        } else {
+            list_append(MORPHO_GETLIST(v), MORPHO_INTEGER(topic_index));
+        }
+        return existing;
+    }
+    value name_val = object_stringfromcstring(buf, len);
+    if (!MORPHO_ISSTRING(name_val)) return MORPHO_NIL;
+    dictionary_insert(&s_names, name_val, MORPHO_INTEGER(topic_index));
+    return name_val;
 }
 
 /** Get first topic index from dict value (integer or first element of list). Returns -1 if not found or invalid. */
@@ -735,20 +759,21 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
     }
     char buf[nl + 1];
     help_lowercase_into(base + ns, nl, buf);
-    value name_val = object_stringfromcstring(buf, nl);
-    if (!MORPHO_ISSTRING(name_val)) {
+    int topic_index = (int) out->topics->count;
+    value name = help_nameindex_add(buf, nl, topic_index);
+    if (MORPHO_ISNIL(name)) {
         out->current_topic_index = -1;
         return;
     }
     md_topic topic = {
-        .name = name_val,
+        .name = name,
         .file_index = out->file_index,
         .block_index = out->file->blocks.count - 1,
         .level = out->current_header_level,
         .parent_topic = -1
     };
     varray_md_topicwrite(out->topics, topic);
-    out->current_topic_index = (int) out->topics->count - 1;
+    out->current_topic_index = topic_index;
 }
 
 static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start) {
@@ -797,10 +822,7 @@ static bool help_createalias(const char *base, size_t label_start, size_t label_
     if (len > MORPHO_MAX_HELPQUERY_LENGTH) return false;
     char alias_buf[len + 1];
     help_lowercase_into(open, len, alias_buf);
-    value alias_val = object_stringfromcstring(alias_buf, len);
-    if (!MORPHO_ISSTRING(alias_val)) return false;
-    dictionary_insert(&s_names, alias_val, MORPHO_INTEGER(topic_index));
-    return true;
+    return !MORPHO_ISNIL(help_nameindex_add(alias_buf, len, topic_index));
 }
 
 /* **********************************************************************
@@ -1104,17 +1126,15 @@ bool help_load(char *filename) {
         varray_md_filewrite(&s_files, mdfile);
     } else {
         md_file_clear(&mdfile);
-        // Remove topics added during the failed parse; free their names (never interned).
         while (s_topics.count > n_topics_before) {
-            unsigned int i = s_topics.count - 1;
-            if (MORPHO_ISOBJECT(s_topics.data[i].name)) morpho_freeobject(s_topics.data[i].name);
+            help_nameindex_remove((int) s_topics.count - 1, n_topics_before);
             s_topics.count--;
         }
     }
     return ok;
 }
 
-/** Finds and loads all help files; sets parent_topic for each topic, then builds name index. */
+/** Finds and loads all help files; sets parent_topic for each topic. Name index is built incrementally during parse. */
 void help_findfiles(void) {
     varray_value files;
     varray_valueinit(&files);
@@ -1127,7 +1147,6 @@ void help_findfiles(void) {
     varray_valueclear(&files);
     for (unsigned int i = 0; i < s_topics.count; i++)
         s_topics.data[i].parent_topic = help_findparent(i);
-    help_buildnameindex();
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -117,9 +117,27 @@ tokendefn mdtokens[] = {
     { "",           TOKEN_NONE                  , NULL }
 };
 
+/** Check if a character is ASCII punctuation (CommonMark spec 2.4: escapable with backslash). */
+static bool md_isasciipunct(char c) {
+    return (unsigned char)c <= 0x7F && ispunct((unsigned char)c);
+}
+
 /** Lexer token preprocessor function */
 bool md_lexpreprocess(lexer *l, token *tok, error *err) {
     while (!lex_identifytoken(l, false, NULL) && !lex_isatend(l)) {
+        char c = lex_peek(l);
+        if (c == '\\') {
+            char next = lex_peekahead(l, 1);
+            if (md_isasciipunct(next)) {
+                lex_advance(l); // Skip \ and include punctuation as literal
+                lex_advance(l);
+                continue;
+            } else if (next == '\n' || next == '\r' || next == '\0') {
+                lex_advance(l); // Skip \; newline will be tokenized as MD_NEWLINE in next iteration
+                continue;
+            }
+            // Backslash before non-punctuation: include \ as literal
+        }
         lex_advance(l);
     }
     if (l->current > l->start) {
@@ -165,7 +183,7 @@ bool md_parsebold(parser *p, void *out) {
 
 /** Parses italic: called after consuming opening * or _; consumes TEXT then closing delimiter. */
 bool md_parseitalic(parser *p, void *out) {
-    tokentype delim = p->previous.type; /* MD_ASTERISK or MD_UNDERSCORE */
+    tokentype delim = p->previous.type; // MD_ASTERISK or MD_UNDERSCORE
     while (parse_checktokenadvance(p, MD_TEXT));
     if (!parse_checktokenadvance(p, delim)) {
         parse_error(p, false, MD_UNCLOSEDITALIC);
@@ -192,7 +210,7 @@ typedef struct {
     md_file *file;
     varray_md_topic *topics;
     int file_index;
-    int current_header_level;  /* 1–3, set before md_parseheader */
+    int current_header_level; // 1–3, set before md_parseheader
 } md_parseout;
 
 static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len);
@@ -285,7 +303,7 @@ bool md_parsetext(parser *p, void *out) {
 bool md_parseheader(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
-    size_t block_start = (size_t)(p->previous.start - base);  /* # token already consumed */
+    size_t block_start = (size_t)(p->previous.start - base); // # token already consumed
 
     if (!parse_checktokenadvance(p, MD_TEXT)) {
         parse_error(p, false, MD_EXPECTHEADERTEXT);
@@ -308,7 +326,7 @@ bool md_parseheader(parser *p, void *out) {
 /** Parses markdown code block (indented lines until newline or EOF). */
 bool md_parsecode(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
-    size_t block_start = (size_t)(p->previous.start - ctx->file->source);  /* 4 spaces / tab already consumed */
+    size_t block_start = (size_t)(p->previous.start - ctx->file->source); // 4 spaces / tab already consumed
 
     while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) parse_advance(p);
     if (!md_parselineend(p)) {
@@ -323,7 +341,7 @@ bool md_parsecode(parser *p, void *out) {
 bool md_parselist(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
-    size_t block_start = (size_t)(p->previous.start - base);  /* *, +, or - already consumed */
+    size_t block_start = (size_t)(p->previous.start - base); // *, +, or - already consumed
 
     for (;;) {
         while (md_consumetextcontent(p, true, out));
@@ -341,13 +359,13 @@ bool md_parseurl(parser *p, void *out) {
         parse_advance(p);
     }
     if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
-    return true; /* EOF is valid end of link line */
+    return true; // EOF is valid end of link line
 }
 
 /** Parses inline link [text](url)... after [ and label and ] are consumed. Consumes ( url ) and rest of line, pushes paragraph. */
 static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
     md_parseout *ctx = (md_parseout *) out;
-    parse_advance(p);  /* consume ( */
+    parse_advance(p); // consume (
     while (!parse_checktoken(p, MD_RIGHTPAREN) && !parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF))
         parse_advance(p);
     if (!parse_checktokenadvance(p, MD_RIGHTPAREN)) {
@@ -355,7 +373,7 @@ static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
         return false;
     }
     while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF))
-        parse_advance(p);
+        parse_advance(p); // consume rest of line (e.g. trailing ".")
     if (!md_parselineend(p)) {
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
@@ -401,7 +419,7 @@ bool md_parselink(parser *p, void *out) {
 /** Parse a markdown 'block' */
 bool md_parseblock(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
-    /* Dispatch by first token. Check block-start alternatives first. */
+    // Dispatch by first token. Check block-start alternatives first.
     if (parse_checktokenadvance(p, MD_HASH)) {
         ctx->current_header_level = 1;
         return md_parseheader(p, out);
@@ -417,7 +435,7 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktoken(p, MD_ASTERISK) ||
                parse_checktoken(p, MD_PLUS) ||
                parse_checktoken(p, MD_DASH)) {
-        /* CommonMark: list marker must be followed by space or tab; else treat as paragraph. */
+        // CommonMark: list marker must be followed by space or tab; else treat as paragraph.
         char c = lex_peek(p->lex);
         if (c == ' ' || c == '\t') {
             parse_advance(p);
@@ -426,10 +444,10 @@ bool md_parseblock(parser *p, void *out) {
         return md_parsetext(p, out);
     } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
         return md_parselink(p, out);
-    } else if (parse_checktokenadvance(p, MD_NEWLINE)) { /* blank line */
+    } else if (parse_checktokenadvance(p, MD_NEWLINE)) { // blank line
         return true;
     } else if (parse_checktoken(p, MD_EOF)) {
-        return true; /* let outer loop exit */
+        return true; // let outer loop exit
     } else if (md_checktexttoken(p)) {
         return md_parsetext(p, out);
     } else {
@@ -909,8 +927,7 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
-    /* Keep contents.data; mdfile will own it (freed in md_file_clear). Do not clear contents. */
-    size_t len = (contents.count > 0) ? contents.count - 1 : 0;
+    size_t len = (contents.count > 0) ? contents.count - 1 : 0; // Keep contents.data; mdfile will own it (freed in md_file_clear). Do not clear contents.
     md_file mdfile;
     md_file_init(&mdfile);
     mdfile.source = contents.data;
@@ -922,7 +939,7 @@ bool help_load(char *filename) {
     } else {
         fprintf(stderr, "Help file failed to parse: %s\n", filename);
         md_file_clear(&mdfile);
-        /* Remove topics added during the failed parse; they have file_index = s_files.count */
+        // Remove topics added during the failed parse; they have file_index = s_files.count
         while (s_topics.count > n_topics_before) {
             md_topic *t = &s_topics.data[s_topics.count - 1];
             if (t->name) MORPHO_FREE(t->name);
@@ -1105,7 +1122,7 @@ bool morpho_helpasmd(char *query, varray_char *result) {
 
 /** @brief Initialize help system */
 void help_initialize(void) {
-    /* Markdown parser errors */
+    // Markdown parser errors
     morpho_defineerror(MD_UNCLOSEDITALIC, ERROR_PARSE, MD_UNCLOSEDITALIC_MSG);
     morpho_defineerror(MD_UNCLOSEDINLINECODE, ERROR_PARSE, MD_UNCLOSEDINLINECODE_MSG);
     morpho_defineerror(MD_EXPECTLINEEND, ERROR_PARSE, MD_EXPECTLINEEND_MSG);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1389,20 +1389,20 @@ void help_initialize(void) {
     morpho_defineerror(MD_LINKEXPECTCOLON, ERROR_PARSE, MD_LINKEXPECTCOLON_MSG);
     morpho_defineerror(MD_UNEXPECTEDTOKEN, ERROR_PARSE, MD_UNEXPECTEDTOKEN_MSG);
 
-    /*varray_md_fileinit(&s_files);
+    varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
     dictionary_init(&s_names);
-    morpho_addfinalizefn(help_finalize);*/
+    morpho_addfinalizefn(help_finalize);
 }
 
 /** @brief Finalization: free all files, topics, and name index. */
 void help_finalize(void) {
-    /*for (unsigned int i = 0; i < s_files.count; i++)
+    for (unsigned int i = 0; i < s_files.count; i++)
         md_file_clear(&s_files.data[i]);
     varray_md_fileclear(&s_files);
     dictionary_freecontents(&s_names, true, true);
     dictionary_clear(&s_names);
-    varray_md_topicclear(&s_topics);*/
+    varray_md_topicclear(&s_topics);
 }
 
 #endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -368,25 +368,7 @@ static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
     return true;
 }
 
-/** Link definition: label and target in one TEXT token (e.g. "tag]: # (target)"). Returns true if found and sets *target_* out params. */
-static bool md_link_def_in_one_token(const char *base, const char *txt, size_t txt_len, size_t label_start,
-    size_t *label_len, size_t *target_start, size_t *target_len) {
-    const char *sep = "]: ";
-    const size_t sep_len = 3;
-    if (txt_len < sep_len) return false;
-    for (size_t i = 0; i + sep_len <= txt_len; i++) {
-        if (memcmp(txt + i, sep, sep_len) != 0) continue;
-        *label_len = i;
-        *target_start = label_start + i + sep_len;
-        *target_len = (txt_len > i + sep_len) ? (txt_len - i - sep_len) : 0;
-        while (*target_len > 0 && (base[*target_start + *target_len - 1] == '\n' || base[*target_start + *target_len - 1] == '\r'))
-            (*target_len)--;
-        return true;
-    }
-    return false;
-}
-
-/** Parses [label]: target (link def) or [text](url) (inline link). Caller has already consumed [. */
+/** Parses [label]: target (link def) or [text](url) an inline link. Caller has already consumed [. */
 bool md_parselink(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
@@ -398,32 +380,24 @@ bool md_parselink(parser *p, void *out) {
     }
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
-    size_t target_start, target_len;
-
-    /* Link def in one token: "label]: target" */
-    if (md_link_def_in_one_token(base, p->previous.start, p->previous.length, label_start, &label_len, &target_start, &target_len)) {
-        md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
-        return true;
-    }
 
     if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) {
         parse_error(p, false, MD_LINKEXPECTBRACKET);
         return false;
     }
-    if (parse_checktoken(p, MD_LEFTPAREN))
-        return md_parseinlinelink(p, out, block_start);
+    if (parse_checktoken(p, MD_LEFTPAREN)) return md_parseinlinelink(p, out, block_start);
 
     if (!parse_checktokenadvance(p, MD_COLON)) {
         parse_error(p, false, MD_LINKEXPECTCOLON);
         return false;
     }
-    target_start = (size_t)(p->current.start - base);
+    size_t target_start = (size_t)(p->current.start - base);
     if (!md_parseurl(p, out)) {
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }
     size_t target_end = md_end_previous(p, base);
-    target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
+    size_t target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -100,18 +100,13 @@ tokendefn mdtokens[] = {
 
 /** Lexer token preprocessor function */
 bool md_lexpreprocess(lexer *l, token *tok, error *err) {
-    // Keep going until we match a token or reach the end
-    while (!lex_identifytoken(l, false, NULL) &&
-           !lex_isatend(l)) {
+    while (!lex_identifytoken(l, false, NULL) && !lex_isatend(l)) {
         lex_advance(l);
     }
-    
-    // If we captured anything, record it as text
-    if (l->current>l->start) {
+    if (l->current > l->start) {
         lex_recordtoken(l, MD_TEXT, tok);
         return true;
     }
-    
     return false;
 }
 
@@ -286,23 +281,44 @@ bool md_parseurl(parser *p, void *out) {
     return true; /* EOF is valid end of link line */
 }
 
-/** Parses a markdown link definition [label]: # (optional) ... */
+/** Parses a markdown link definition [label]: # (optional) ...
+ *  The lexer often gives one MD_TEXT for "label]: target" (no separate ] : tokens).
+ *  Accept either: TEXT then ] then : then rest, or one TEXT containing "]: " and split it. */
 bool md_parselink(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* [ already consumed */
 
-    // [ label ] : then rest of line (target)
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
-    PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
-    PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
-    size_t target_start = (size_t)(p->current.start - base);
-    PARSE_CHECK(md_parseurl(p, out));
-    size_t target_end = md_end_previous(p, base);
-    size_t target_len = (target_end > target_start) ? (target_end - target_start) : 0;
+    size_t target_start;
+    size_t target_len;
 
+    const char *txt = p->previous.start;
+    size_t txt_len = p->previous.length;
+    const char *sep = "]: ";
+    size_t sep_len = 3;
+    const char *found = NULL;
+    if (txt_len >= sep_len) {
+        for (size_t i = 0; i + sep_len <= txt_len; i++) {
+            if (memcmp(txt + i, sep, sep_len) == 0) { found = txt + i; break; }
+        }
+    }
+    if (found != NULL) {
+        label_len = (size_t)(found - txt);
+        target_start = label_start + label_len + sep_len;
+        target_len = (txt_len > label_len + sep_len) ? (txt_len - label_len - sep_len) : 0;
+        if (target_len > 0 && base[target_start + target_len - 1] == '\n') target_len--;
+        /* Rest of line (and newline) was in the TEXT token; next token is next line */
+    } else {
+        PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
+        PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
+        target_start = (size_t)(p->current.start - base);
+        PARSE_CHECK(md_parseurl(p, out));
+        size_t target_end = md_end_previous(p, base);
+        target_len = (target_end > target_start) ? (target_end - target_start) : 0;
+    }
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }
@@ -685,15 +701,14 @@ static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
     return best;
 }
 
-/** Number of blocks that form this topic's content (header + following until next same-level or higher header). */
+/** Number of blocks that form this topic's content (header + following until next header of any level). */
 static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_file *file) {
     unsigned int i = topic->block_index;
     unsigned int n = file->blocks.count;
-    int level = topic->level;
-    // Advance until we hit a header at same or higher level (or end of file)
+    // Advance until we hit any next header (so a # topic doesn't swallow all ## sections)
     while (i < n) {
         const md_block *b = &file->blocks.data[i];
-        if (b->type == MD_BLOCK_HEADER && b->as.header.level <= level && i > topic->block_index)
+        if (b->type == MD_BLOCK_HEADER && i > topic->block_index)
             break;
         i++;
     }
@@ -802,14 +817,26 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
-    // Steal buffer into md_file; parse appends topics to s_topics
+    // Parse appends topics to s_topics with file_index = s_files.count. If parse fails we must
+    // remove those topics so they don't point at the next file we append.
     md_file mdfile;
     md_file_init(&mdfile);
     mdfile.source = contents.data;
     mdfile.sourcelen = (contents.count > 0) ? contents.count - 1 : 0;
+    unsigned int n_topics_before = s_topics.count;
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
-    if (ok) varray_md_filewrite(&s_files, mdfile);
-    else md_file_clear(&mdfile);
+    if (ok) {
+        varray_md_filewrite(&s_files, mdfile);
+    } else {
+        md_file_clear(&mdfile);
+        /* Remove topics added during the failed parse; they have file_index = s_files.count */
+        while (s_topics.count > n_topics_before) {
+            md_topic *t = &s_topics.data[s_topics.count - 1];
+            if (t->name) MORPHO_FREE(t->name);
+            t->name = NULL;
+            s_topics.count--;
+        }
+    }
     return ok;
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -24,6 +24,16 @@
 
 #ifdef MORPHO_INCLUDE_HELP
 
+/** Static data structures */
+DEFINE_VARRAY(md_block, md_block);
+DEFINE_VARRAY(md_file, md_file);
+DEFINE_VARRAY(md_topic, md_topic);
+DEFINE_VARRAY(md_alias, md_alias);
+
+static varray_md_file s_files;    // List of help files
+static varray_md_topic s_topics;  // List of topics
+static varray_md_alias s_aliases; // List of aliases
+
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
  *  valid Markdown, although only a subset is used, and the help system interprets
@@ -228,6 +238,7 @@ typedef struct {
     varray_md_topic *topics;
     int file_index;
     int current_header_level; // 1–3, set before md_parseheader
+    int current_topic_index;  // Index of most recently created topic, or -1
 } md_parseout;
 
 /* Forward declarations */
@@ -420,6 +431,8 @@ static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
     return true;
 }
 
+static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index);
+
 /** Parses [label]: target (link def) or [text](url) an inline link. Caller has already consumed [. */
 bool md_parselink(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
@@ -450,6 +463,10 @@ bool md_parselink(parser *p, void *out) {
     }
     size_t target_end = md_end_previous(p, base);
     size_t target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
+    
+    // Check if this is a tag link definition and create alias if so
+    help_createalias(base, label_start, label_len, target_start, target_len, ctx->current_topic_index);
+    
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }
@@ -522,10 +539,6 @@ void help_initializemdparser(parser *p, lexer *l, error *err, void *out) {
  * Markdown AST: definitions and topic list helpers
  * ********************************************************************** */
 
-DEFINE_VARRAY(md_block, md_block);
-DEFINE_VARRAY(md_file, md_file);
-DEFINE_VARRAY(md_topic, md_topic);
-
 void md_block_clear(md_block *b) {
     varray_intclear(&b->children);
 }
@@ -569,6 +582,8 @@ void help_sortaliases(varray_md_alias *aliases) {
         qsort(aliases->data, aliases->count, sizeof(md_alias), md_alias_compare);
 }
 
+static int help_findalias(const char *name);
+
 int help_findtopic(varray_md_topic *topics, const char *name) {
     if (!topics->data || topics->count == 0) {
         // If no topics, check aliases
@@ -578,8 +593,7 @@ int help_findtopic(varray_md_topic *topics, const char *name) {
     md_topic *found = (md_topic *) bsearch(&key, topics->data, topics->count, sizeof(md_topic), md_topic_compare);
     if (found) return (int) (found - topics->data);
     
-    // Not found in topics, check aliases
-    return help_findalias(name);
+    return help_findalias(name); // Not found in topics, check aliases
 }
 
 /** End offset of the block from the last consumed token. */
@@ -652,6 +666,9 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
             .parent_topic = -1
         };
         varray_md_topicwrite(out->topics, topic);
+        out->current_topic_index = (int) out->topics->count - 1;
+    } else {
+        out->current_topic_index = -1;
     }
 }
 
@@ -685,83 +702,61 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
  * Help topic aliases
  * ********************************************************************** */
 
-/** Alias entry: maps an alias name to a topic index. */
-typedef struct {
-    char *name;              /* lowercase, owned */
-    int topic_index;
-} md_alias;
+/** Find topic index by alias name. Returns -1 if not found. */
+static int help_findalias(const char *name) {
+    if (!s_aliases.data || s_aliases.count == 0) return -1;
+    md_alias key = { .name = (char *) name, .topic_index = 0 };
+    md_alias *found = (md_alias *) bsearch(&key, s_aliases.data, s_aliases.count, sizeof(md_alias), md_alias_compare);
+    return found ? found->topic_index : -1;
+}
 
-DECLARE_VARRAY(md_alias, md_alias);
-
-static varray_md_alias s_aliases;
-
-/** Process link definitions in a file to create aliases from [tag...]: # (alias) entries. */
-static void help_processlinkdefs(int file_index) {
-    if (file_index < 0 || (unsigned int) file_index >= s_files.count) return;
-    const md_file *file = &s_files.data[file_index];
-    const char *base = file->source;
+/** Create an alias from a tag link definition. Returns true if alias was created. */
+static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index) {
+    if (topic_index < 0) return false;
     
-    for (unsigned int i = 0; i < file->blocks.count; i++) {
-        const md_block *b = &file->blocks.data[i];
-        if (b->type != MD_BLOCK_LINK_DEF) continue;
-        
-        // Check if label starts with "tag"
-        size_t label_len = md_clamp_span(b->as.link_def.label.start, b->as.link_def.label.length, file->sourcelen);
-        if (label_len < 3) continue;
-        const char *label = base + b->as.link_def.label.start;
-        if (tolower((unsigned char) label[0]) != 't' || tolower((unsigned char) label[1]) != 'a' || tolower((unsigned char) label[2]) != 'g') continue;
-        
-        // Extract alias name from target (find text in parentheses)
-        size_t target_start = b->as.link_def.target.start;
-        size_t target_len = md_clamp_span(target_start, b->as.link_def.target.length, file->sourcelen);
-        const char *target = base + target_start, *open = NULL, *close = NULL;
-        for (const char *p = target; p < target + target_len && !close; p++) {
-            if (!open && *p == '(') open = p + 1;
-            else if (open && *p == ')') { close = p; break; }
-        }
-        if (!open || !close || close == open) continue;
-        
-        // Allocate and lowercase alias name
-        size_t len = (size_t)(close - open);
-        char *alias_name = (char *) MORPHO_MALLOC(len + 1);
-        if (!alias_name) continue;
-        for (size_t j = 0; j < len; j++) alias_name[j] = (char) tolower((unsigned char) open[j]);
-        alias_name[len] = '\0';
-        
-        // Check for duplicates (topics and existing aliases)
-        bool duplicate = false;
-        if (s_topics.data && s_topics.count > 0) {
-            md_topic key = { .name = alias_name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
-            if (bsearch(&key, s_topics.data, s_topics.count, sizeof(md_topic), md_topic_compare)) duplicate = true;
-        }
-        if (!duplicate) {
-            for (unsigned int j = 0; j < s_aliases.count; j++) {
-                if (s_aliases.data[j].name && strcmp(s_aliases.data[j].name, alias_name) == 0) { duplicate = true; break; }
-            }
-        }
-        if (duplicate) { MORPHO_FREE(alias_name); continue; }
-        
-        // Find topic (most recent header before this block)
-        int topic_idx = -1;
-        for (int j = (int) i - 1; j >= 0; j--) {
-            if (file->blocks.data[j].type == MD_BLOCK_HEADER) {
-                topic_idx = help_findtopicbyblock(file_index, (unsigned int) j);
-                break;
-            }
-        }
-        if (topic_idx < 0) { MORPHO_FREE(alias_name); continue; }
-        
-        // Create alias
-        varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_index = topic_idx });
+    // Check if label starts with "tag"
+    if (label_len < 3) return false;
+    const char *label = base + label_start;
+    if (tolower((unsigned char) label[0]) != 't' || tolower((unsigned char) label[1]) != 'a' || tolower((unsigned char) label[2]) != 'g') return false;
+    
+    // Extract alias name from target (find text in parentheses)
+    const char *target = base + target_start, *open = NULL, *close = NULL;
+    for (const char *p = target; p < target + target_len && !close; p++) {
+        if (!open && *p == '(') open = p + 1;
+        else if (open && *p == ')') { close = p; break; }
     }
+    if (!open || !close || close == open) return false;
+    
+    // Allocate and lowercase alias name
+    size_t len = (size_t)(close - open);
+    char *alias_name = (char *) MORPHO_MALLOC(len + 1);
+    if (!alias_name) return false;
+    for (size_t j = 0; j < len; j++) alias_name[j] = (char) tolower((unsigned char) open[j]);
+    alias_name[len] = '\0';
+    
+    // Check for duplicates (topics and existing aliases)
+    if (s_topics.data && s_topics.count > 0) {
+        md_topic key = { .name = alias_name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
+        if (bsearch(&key, s_topics.data, s_topics.count, sizeof(md_topic), md_topic_compare)) {
+            MORPHO_FREE(alias_name);
+            return false;
+        }
+    }
+    for (unsigned int j = 0; j < s_aliases.count; j++) {
+        if (s_aliases.data[j].name && strcmp(s_aliases.data[j].name, alias_name) == 0) {
+            MORPHO_FREE(alias_name);
+            return false;
+        }
+    }
+    
+    // Create alias
+    varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_index = topic_index });
+    return true;
 }
 
 /* **********************************************************************
  * Help topic lookup and content range
  * ********************************************************************** */
-
-static varray_md_file s_files;
-static varray_md_topic s_topics;
 
 /** Maximum number of query segments (e.g. "System respondsto" -> 2). */
 #define MORPHO_HELP_QUERY_MAXSEGMENTS 8
@@ -855,14 +850,6 @@ static int help_findtopicbyblock(int file_index, unsigned int block_index) {
             return (int) i;
     }
     return -1;
-}
-
-/** Find topic index by alias name. Returns -1 if not found. */
-static int help_findalias(const char *name) {
-    if (!s_aliases.data || s_aliases.count == 0) return -1;
-    md_alias key = { .name = (char *) name, .topic_index = 0 };
-    md_alias *found = (md_alias *) bsearch(&key, s_aliases.data, s_aliases.count, sizeof(md_alias), md_alias_compare);
-    return found ? found->topic_index : -1;
 }
 
 /** True if header title span (trimmed, lowercased) equals name. */
@@ -1052,7 +1039,8 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
         .file = file,
         .topics = topics,
         .file_index = file_index,
-        .current_header_level = 1
+        .current_header_level = 1,
+        .current_topic_index = -1
     };
     lexer l;
     help_initializemdlexer(&l, file->source);
@@ -1103,7 +1091,6 @@ bool help_load(char *filename) {
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
     if (ok) {
         varray_md_filewrite(&s_files, mdfile);
-        help_processlinkdefs((int) s_files.count - 1);
     } else {
         md_file_clear(&mdfile);
         // Remove topics added during the failed parse; they have file_index = s_files.count

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -36,6 +36,11 @@
  * ********************************************************************** */
 
 enum {
+    MD_TEXT,
+    MD_HASH,
+    MD_HASH2,
+    MD_HASH3,
+    MD_COLON,
     MD_LEFTBRACE,
     MD_RIGHTBRACE,
     MD_LEFTSQUAREBRACE,
@@ -47,6 +52,10 @@ enum {
 };
 
 tokendefn mdtokens[] = {
+    { "#",          MD_HASH                     , NULL },
+    { "##",         MD_HASH2                    , NULL },
+    { "###",        MD_HASH3                    , NULL },
+    { ":",          MD_COLON                    , NULL },
     { "(",          MD_LEFTBRACE                , NULL },
     { ")",          MD_RIGHTBRACE               , NULL },
     { "[",          MD_LEFTSQUAREBRACE          , NULL },
@@ -60,6 +69,22 @@ tokendefn mdtokens[] = {
     { "",           TOKEN_NONE                  , NULL }
 };
 
+/** Lexer token preprocessor function */
+bool md_lexpreprocess(lexer *l, token *tok, error *err) {
+    // Keep going until we match a token or reach the end
+    while (!lex_identifytoken(l, false, NULL) &&
+           !lex_isatend(l)) {
+        lex_advance(l);
+    }
+    
+    // If we captured anything, record it as text
+    if (l->current>l->start) {
+        lex_recordtoken(l, MD_TEXT, tok);
+        return true;
+    }
+    
+    return false;
+}
 
 /* -------------------------------------------------------
  * Initialize a Markdown lexer
@@ -68,8 +93,8 @@ tokendefn mdtokens[] = {
 void help_initializemdlexer(lexer *l, char *src) {
     lex_init(l, src, 0);
     lex_settokendefns(l, mdtokens);
-    //lex_setprefn(l, json_lexpreprocess);
-    //lex_setwhitespacefn(l, json_lexwhitespace);
+    lex_setprefn(l, md_lexpreprocess);
+    lex_setwhitespacefn(l, NULL);
     lex_seteof(l, MD_EOF);
 }
 
@@ -119,12 +144,18 @@ bool help_parse(char *src) {
     lexer l;
     help_initializemdlexer(&l, src);
     
+    token tok;
+    while (lex(&l, &tok, &err)) {
+        if (tok.type==MD_EOF) break;
+    }
+    
+    /*
     parser p;
     help_initializemdparser(&p, &l, &err, NULL);
     
-    parse(&p);
+    parse(&p);*/
     
-    return false;
+    return true;
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -9,10 +9,71 @@
 #include <stdbool.h>
 #include <varray.h>
 
+#include "classes.h"
 #include "help.h"
+#include "resources.h"
+
+/** The interactive help system uses a collection of Markdown files, located in
+ *  MORPHO_HELPFOLDER, that define available topics. Help files are all
+ *  valid Markdown, although only a subset is used, and the help system interprets
+ *  Markdown syntax in special ways:
+ *
+ *  Headers defined with #, ##, etc are used to identify discrete topics.
+ *  Successive levels of header are used to create subtopics.
+ *
+ *  Link definitions are used to include metadata:
+ *
+ *  [tag]: # (<TAG>)      is used to define additional synonyms for the topic.
+ *
+ *  The help system also recognizes code blocks etc. */
+
+
+/* **********************************************************************
+ * Morpho help files
+ * ********************************************************************** */
+
+/** Loads a help file
+ *  @param file     file to load
+ *  @returns true if any help entries were successfully loaded */
+bool help_load(char *file) {
+    
+}
+
+/** Searches for help files
+ *  @returns true if any help files were successfully processed. */
+void help_findfiles(void) {
+    varray_value files;
+    varray_valueinit(&files);
+    
+    if (morpho_listresources(MORPHO_RESOURCE_HELP, &files)) {
+        for (int i=0; i<files.count; i++) {
+            if (MORPHO_ISSTRING(files.data[i])) help_load(MORPHO_GETCSTRING(files.data[i]));
+        }
+    }
+    
+    varray_valueclear(&files);
+}
+
+/* **********************************************************************
+ * Morpho help files
+ * ********************************************************************** */
 
 /** Interface to the morpho help system */
 bool morpho_help(char *query, varray_char *result) {
     return false;
 }
 
+/* **********************************************************************
+ * Initialization/finalization
+ * ********************************************************************** */
+
+/** @brief Initialization/finalization */
+void help_initialize(void) {
+    help_findfiles();
+    
+    morpho_addfinalizefn(help_finalize);
+}
+
+/** @brief Initialization/finalization */
+void help_finalize(void) {
+}

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -864,9 +864,9 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
         fprintf(stderr, "Help parse error [%s]: %s", err.id ? err.id : "?", err.msg);
         if (err.line != ERROR_POSNUNIDENTIFIABLE || err.posn != ERROR_POSNUNIDENTIFIABLE) {
             fprintf(stderr, " (");
-            if (err.line != ERROR_POSNUNIDENTIFIABLE) fprintf(stderr, "line %d", err.line);
+            if (err.line != ERROR_POSNUNIDENTIFIABLE) fprintf(stderr, "line %d", err.line + 1);
             if (err.posn != ERROR_POSNUNIDENTIFIABLE)
-                fprintf(stderr, "%sposition %d", err.line != ERROR_POSNUNIDENTIFIABLE ? ", " : "", err.posn);
+                fprintf(stderr, "%sposition %d", err.line != ERROR_POSNUNIDENTIFIABLE ? ", " : "", err.posn + 1);
             fprintf(stderr, ")");
         }
         fprintf(stderr, "\n");

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -730,10 +730,7 @@ static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
         if (len + 1 < bufsize) snprintf(buf + len, bufsize - len, ".%s", t->name);
     } else {
         // Top-level or no parent: just the topic name
-        size_t n = strlen(t->name);
-        if (n >= bufsize) n = bufsize - 1;
-        memcpy(buf, t->name, n);
-        buf[n] = '\0';
+        snprintf(buf, bufsize, "%s", t->name);
     }
 }
 
@@ -822,8 +819,6 @@ static unsigned int help_editdistance(const char *a, const char *b, unsigned int
     return prev[nb];
 }
 
-static const char MORPHO_HELP_NOTFOUND[] = "Topic not found.";
-
 /** Find top-level topic name closest to name; NULL if none within distance. */
 static const char *help_findclosesttopic(const char *name) {
     const char *best = NULL;
@@ -901,14 +896,14 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 size_t tlen = md_clamp_span(b->as.header.title.start, b->as.header.title.length, src_len);
                 const char *p = src + b->as.header.title.start;
                 while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; } // strip leading # and space
-                if (tlen > 0) varray_charadd(result, p, (int) tlen);
+                if (tlen > 0) varray_charadd(result, (char *) p, (int) tlen);
                 varray_charadd(result, "\n\n", 2);
                 break;
             }
             case MD_BLOCK_PARAGRAPH:
             case MD_BLOCK_LIST:
             case MD_BLOCK_CODE:
-                varray_charadd(result, src + b->span.start, (int) len);
+                varray_charadd(result, (char *) src + b->span.start, (int) len);
                 if (len > 0 && src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
                 break;
             case MD_BLOCK_LINK_DEF:
@@ -928,7 +923,7 @@ bool help_topicrawmd(const help_topic *t, varray_char *result) {
         const md_block *b = &t->content_blocks[i];
         size_t len = md_clamp_span(b->span.start, b->span.length, src_len);
         if (len == 0) continue;
-        varray_charadd(result, src + b->span.start, (int) len);
+        varray_charadd(result, (char *) src + b->span.start, (int) len);
         if (src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
     }
     return true;
@@ -1079,10 +1074,8 @@ static void help_queryhint(const char *query, varray_char *result) {
         return;
     }
     char path[MORPHO_MAX_HELPQUERY_LENGTH];
-    int path_len = (int) strlen(segs[0]);
-    if (path_len >= (int) sizeof(path)) path_len = (int) sizeof(path) - 1;
-    memcpy(path, segs[0], (size_t) path_len);
-    path[path_len] = '\0';
+    int path_len = snprintf(path, sizeof(path), "%s", segs[0]);
+    if (path_len < 0 || path_len >= (int) sizeof(path)) path_len = (int) sizeof(path) - 1;
 
     for (int i = 1; i < nsegs; i++) {
         int next = help_findsubtopic(idx, segs[i]);
@@ -1100,15 +1093,8 @@ static void help_queryhint(const char *query, varray_char *result) {
         idx = next;
         // Append "." + segs[i] to path for next level
         if (path_len >= (int) sizeof(path) - 1) continue; // No room
-        path[path_len++] = '.';
-        int seglen = (int) strlen(segs[i]);
-        int avail = (int) sizeof(path) - path_len;
-        if (seglen >= avail) seglen = avail - 1;
-        if (seglen > 0) {
-            memcpy(path + path_len, segs[i], (size_t) seglen);
-            path_len += seglen;
-        }
-        path[path_len] = '\0';
+        int n = snprintf(path + path_len, (size_t)(sizeof(path) - path_len), ".%s", segs[i]);
+        if (n > 0) path_len += (n < (int) sizeof(path) - path_len) ? n : (int) sizeof(path) - 1 - path_len;
     }
     varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -45,9 +45,16 @@ enum {
     MD_RIGHTPAREN,
     MD_LEFTSQUAREBRACE,
     MD_RIGHTSQUAREBRACE,
-    MD_BOLD,
-    MD_ITALIC,
-    MD_BOLDITALIC,
+    MD_ASTERISK,
+    MD_PLUS,
+    MD_DASH,
+    MD_UNDERSCORE,
+    MD_ASTERISK2,
+    MD_UNDERSCORE2,
+    MD_ASTERISK3,
+    MD_UNDERSCORE3,
+    MD_FOURSPACES,
+    MD_TAB,
     MD_NEWLINE,
     MD_EOF
 };
@@ -66,12 +73,16 @@ tokendefn mdtokens[] = {
     { ")",          MD_RIGHTPAREN               , NULL },
     { "[",          MD_LEFTSQUAREBRACE          , NULL },
     { "]",          MD_RIGHTSQUAREBRACE         , NULL },
-    { "*",          MD_ITALIC                   , NULL },
-    { "_",          MD_ITALIC                   , NULL },
-    { "**",         MD_BOLD                     , NULL },
-    { "__",         MD_BOLD                     , NULL },
-    { "***",        MD_BOLDITALIC               , NULL },
-    { "___",        MD_BOLDITALIC               , NULL },
+    { "*",          MD_ASTERISK                 , NULL },
+    { "+",          MD_PLUS                     , NULL },
+    { "-",          MD_DASH                     , NULL },
+    { "_",          MD_UNDERSCORE               , NULL },
+    { "**",         MD_ASTERISK2                , NULL },
+    { "__",         MD_UNDERSCORE2              , NULL },
+    { "***",        MD_ASTERISK3                , NULL },
+    { "___",        MD_UNDERSCORE3              , NULL },
+    { "    ",       MD_FOURSPACES               , NULL },
+    { "\t",         MD_TAB                      , NULL },
     { "\n",         MD_NEWLINE                  , md_lexnewline },
     { "",           TOKEN_NONE                  , NULL }
 };
@@ -109,11 +120,41 @@ void help_initializemdlexer(lexer *l, char *src) {
  * Markdown parse rules
  * ------------------------------------------------------- */
 
+/** Parses text writen in markdown; stops at a non-textual token  */
+bool md_parsetext(parser *p, void *out) {
+    tokentype intokens[] = { MD_TEXT, MD_COLON, MD_LEFTPAREN, MD_RIGHTPAREN };
+    
+    while (parse_checktokenmulti(p, 4, intokens)) {
+        parse_advance(p);
+    }
+    
+    parse_checktokenadvance(p, MD_NEWLINE);
+    
+    return true;
+}
+
 /** Parses a markdown header  */
 bool md_parseheader(parser *p, void *out) {
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
+    parse_checktokenadvance(p, MD_NEWLINE);
     return true;
+}
+
+/** Parses markdown code. */
+bool md_parsecode(parser *p, void *out) {
+    while (!parse_checktoken(p, MD_NEWLINE) &&
+           !parse_checktoken(p, MD_EOF)) {
+        parse_advance(p);
+    }
+    
+    parse_checktokenadvance(p, MD_NEWLINE);
+    
+    return true;
+}
+
+/** Parses a markdown list. */
+bool md_parselist(parser *p, void *out) {
+    return md_parsetext(p, out);
 }
 
 bool md_parseurl(parser *p, void *out) { // TODO: This is a placeholder
@@ -133,20 +174,7 @@ bool md_parselink(parser *p, void *out) {
         PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
         PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTPAREN));
     }
-    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
-    
-    return true;
-}
-
-/** Parses a markdown paragraph  */
-bool md_parseparagraph(parser *p, void *out) {
-    tokentype intokens[] = { MD_TEXT, MD_COLON, MD_LEFTPAREN, MD_RIGHTPAREN };
-    
-    while (parse_checktokenmulti(p, 4, intokens)) {
-        parse_advance(p);
-    }
-    
-    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
+    parse_checktokenadvance(p, MD_NEWLINE);
     
     return true;
 }
@@ -154,15 +182,23 @@ bool md_parseparagraph(parser *p, void *out) {
 /** Parse a markdown 'block'  */
 bool md_parseblock(parser *p, void *out) {
     if (parse_checktokenadvance(p, MD_TEXT)) {
-        return md_parseparagraph(p, out);
+        return md_parsetext(p, out);
+    } else if (parse_checktokenadvance(p, MD_HASH) ||
+               parse_checktokenadvance(p, MD_HASH2)) {
+        return md_parseheader(p, out);
+    } else if (parse_checktokenadvance(p, MD_FOURSPACES) ||
+               parse_checktokenadvance(p, MD_TAB)) {
+        return md_parsecode(p, out);
+    } else if (parse_checktokenadvance(p, MD_ASTERISK) ||
+               parse_checktokenadvance(p, MD_PLUS) ||
+               parse_checktokenadvance(p, MD_DASH)) {
+        return md_parselist(p, out);
     } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
         return md_parselink(p, out);
-    } else if (parse_checktokenadvance(p, MD_HASH)) {
-        return md_parseheader(p, out);
     } else if (parse_checktokenadvance(p, MD_NEWLINE)) { // A blank line
         return true;
     } else {
-        return md_parseparagraph(p, out);
+        UNREACHABLE("Unrecognized token.");
     }
     
     return false;
@@ -170,7 +206,8 @@ bool md_parseblock(parser *p, void *out) {
 
 /** Base markdown parse type */
 bool md_parse(parser *p, void *out) {
-    while(md_parseblock(p, out)) {
+    while (parse_checktoken(p, MD_EOF)) {
+        PARSE_CHECK(md_parseblock(p, out));
     }
     
     return true;
@@ -183,7 +220,7 @@ bool md_parse(parser *p, void *out) {
 parserule md_rules[] = {
     PARSERULE_PREFIX(MD_HASH,            NULL           ),
     PARSERULE_PREFIX(MD_LEFTSQUAREBRACE, NULL           ),
-    PARSERULE_PREFIX(MD_BOLD,            NULL           ),
+    PARSERULE_PREFIX(MD_ASTERISK,        NULL           ),
     PARSERULE_UNUSED(TOKEN_NONE)
 };
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -450,7 +450,14 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
     md_block_set_header(&b, out->current_header_level, title_start, title_len);
     varray_md_blockwrite(&out->file->blocks, b);
 
-    /* Topic: lowercase name from title span */
+    /* Topic: lowercase name from title span (trim leading/trailing whitespace) */
+    while (title_len && (unsigned char) base[title_start] <= ' ') {
+        title_start++;
+        title_len--;
+    }
+    while (title_len && (unsigned char) base[title_start + title_len - 1] <= ' ') {
+        title_len--;
+    }
     char *name = (char *) MORPHO_MALLOC(title_len + 1);
     if (name) {
         for (size_t i = 0; i < title_len; i++)
@@ -557,6 +564,23 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
     return true;
 }
 
+bool help_topicrawmd(const help_topic *t, varray_char *result) {
+    if (!t || !t->file || !t->file->source || !result) return false;
+    const char *src = t->file->source;
+    size_t src_len = t->file->sourcelen;
+
+    for (unsigned int i = 0; i < t->nblocks; i++) {
+        const md_block *b = &t->content_blocks[i];
+        if (b->span.start >= src_len) continue;
+        size_t len = b->span.length;
+        if (b->span.start + len > src_len) len = src_len - b->span.start;
+        if (len == 0) continue;
+        varray_charadd(result, src + b->span.start, (int) len);
+        if (src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
+    }
+    return true;
+}
+
 bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     error err;
     error_init(&err);
@@ -635,7 +659,7 @@ void help_findfiles(void) {
  * ********************************************************************** */
 
 /** Interface to the morpho help system */
-bool morpho_helptopic(const char *query, help_topic *out) {
+bool morpho_helpastopic(const char *query, help_topic *out) {
     /* Topic names are stored lowercase; search key must match. */
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
     size_t qlen = 0;
@@ -659,10 +683,16 @@ bool morpho_helptopic(const char *query, help_topic *out) {
     return true;
 }
 
-bool morpho_help(char *query, varray_char *result) {
+bool morpho_helpastext(char *query, varray_char *result) {
     help_topic t;
-    if (!morpho_helptopic(query, &t)) return false;
+    if (!morpho_helpastopic(query, &t)) return false;
     return help_topictotext(&t, result);
+}
+
+bool morpho_helpasmd(char *query, varray_char *result) {
+    help_topic t;
+    if (!morpho_helpastopic(query, &t)) return false;
+    return help_topicrawmd(&t, result);
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -196,6 +196,12 @@ static size_t md_end_previous(parser *p, const char *base) {
  * Markdown parse rules
  * ------------------------------------------------------- */
 
+/** Consume newline or require EOF; return true if valid line end. */
+static bool md_parselineend(parser *p) {
+    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
+    return parse_checktoken(p, MD_EOF);
+}
+
 /** Check if a token type is a 'textual' token (incl. * _ for italic, ** __ for bold, ` for code) */
 tokentype _inlinetokens[] = {
     MD_TEXT, MD_COLON, MD_BACKTICK, MD_LEFTPAREN, MD_RIGHTPAREN,
@@ -220,10 +226,7 @@ bool md_parsetext(parser *p, void *out) {
             if (!rule->prefix(p, out)) return false;
         }
     }
-    /* Line terminator: newline or end of file */
-    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
-    else if (!parse_checktoken(p, MD_EOF)) return false;
-
+    PARSE_CHECK(md_parselineend(p));
     md_push_paragraph(p, ctx, block_start);
     return true;
 }
@@ -238,9 +241,7 @@ bool md_parseheader(parser *p, void *out) {
     size_t title_start = (size_t)(p->previous.start - base);
     size_t title_len = p->previous.length;
 
-    if (parse_checktoken(p, MD_NEWLINE)) { PARSE_CHECK(parse_advance(p)); }
-    else if (!parse_checktoken(p, MD_EOF)) return false;
-
+    PARSE_CHECK(md_parselineend(p));
     md_push_header(p, ctx, block_start, title_start, title_len);
     return true;
 }
@@ -250,12 +251,8 @@ bool md_parsecode(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     size_t block_start = (size_t)(p->previous.start - ctx->file->source);  /* 4 spaces / tab already consumed */
 
-    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) {
-        parse_advance(p);
-    }
-    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
-    else if (!parse_checktoken(p, MD_EOF)) return false;
-
+    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) parse_advance(p);
+    PARSE_CHECK(md_parselineend(p));
     md_push_code(p, ctx, block_start);
     return true;
 }
@@ -274,9 +271,7 @@ bool md_parselist(parser *p, void *out) {
             if (!rule->prefix(p, out)) return false;
         }
     }
-    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
-    else if (!parse_checktoken(p, MD_EOF)) return false;
-
+    PARSE_CHECK(md_parselineend(p));
     md_push_list(p, ctx, block_start);
     return true;
 }
@@ -421,6 +416,12 @@ static void md_span_set(md_span *s, size_t start, size_t length) {
     s->length = length;
 }
 
+/** Trim leading and trailing whitespace from (start, len) in place. */
+static void md_trimspan(const char *base, size_t *start, size_t *len) {
+    while (*len && (unsigned char) base[*start] <= ' ') { (*start)++; (*len)--; }
+    while (*len && (unsigned char) base[*start + *len - 1] <= ' ') (*len)--;
+}
+
 /** Initialize common block fields (type, span, parent, children). */
 static void md_block_init(md_block *b, md_blocktype type, size_t block_start, size_t block_end) {
     b->type = type;
@@ -441,6 +442,14 @@ static void md_block_set_link_def(md_block *b, size_t label_start, size_t label_
     md_span_set(&b->as.link_def.target, target_start, target_len);
 }
 
+/** Push a simple block (paragraph, code, list); type and span only. */
+static void md_push_simpleblock(parser *p, md_parseout *out, size_t block_start, md_blocktype type) {
+    const char *base = out->file->source;
+    md_block b;
+    md_block_init(&b, type, block_start, md_block_end(p, base));
+    varray_md_blockwrite(&out->file->blocks, b);
+}
+
 static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len) {
     const char *base = out->file->source;
     size_t block_end = md_block_end(p, base);
@@ -450,19 +459,14 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
     md_block_set_header(&b, out->current_header_level, title_start, title_len);
     varray_md_blockwrite(&out->file->blocks, b);
 
-    /* Topic: lowercase name from title span (trim leading/trailing whitespace) */
-    while (title_len && (unsigned char) base[title_start] <= ' ') {
-        title_start++;
-        title_len--;
-    }
-    while (title_len && (unsigned char) base[title_start + title_len - 1] <= ' ') {
-        title_len--;
-    }
-    char *name = (char *) MORPHO_MALLOC(title_len + 1);
+    /* Topic: lowercase name from trimmed title span */
+    size_t ns = title_start, nl = title_len;
+    md_trimspan(base, &ns, &nl);
+    char *name = (char *) MORPHO_MALLOC(nl + 1);
     if (name) {
-        for (size_t i = 0; i < title_len; i++)
-            name[i] = (char) tolower((unsigned char) base[title_start + i]);
-        name[title_len] = '\0';
+        for (size_t i = 0; i < nl; i++)
+            name[i] = (char) tolower((unsigned char) base[ns + i]);
+        name[nl] = '\0';
         md_topic topic = {
             .name = name,
             .file_index = out->file_index,
@@ -475,27 +479,13 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
 }
 
 static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start) {
-    const char *base = out->file->source;
-    size_t block_end = md_block_end(p, base);
-    md_block b;
-    md_block_init(&b, MD_BLOCK_PARAGRAPH, block_start, block_end);
-    varray_md_blockwrite(&out->file->blocks, b);
+    md_push_simpleblock(p, out, block_start, MD_BLOCK_PARAGRAPH);
 }
-
 static void md_push_code(parser *p, md_parseout *out, size_t block_start) {
-    const char *base = out->file->source;
-    size_t block_end = md_block_end(p, base);
-    md_block b;
-    md_block_init(&b, MD_BLOCK_CODE, block_start, block_end);
-    varray_md_blockwrite(&out->file->blocks, b);
+    md_push_simpleblock(p, out, block_start, MD_BLOCK_CODE);
 }
-
 static void md_push_list(parser *p, md_parseout *out, size_t block_start) {
-    const char *base = out->file->source;
-    size_t block_end = md_block_end(p, base);
-    md_block b;
-    md_block_init(&b, MD_BLOCK_LIST, block_start, block_end);
-    varray_md_blockwrite(&out->file->blocks, b);
+    md_push_simpleblock(p, out, block_start, MD_BLOCK_LIST);
 }
 
 static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t label_start, size_t label_len, size_t target_start, size_t target_len) {
@@ -516,6 +506,30 @@ static varray_md_topic s_topics;
 
 /** Maximum number of query segments (e.g. "System respondsto" -> 2). */
 #define MORPHO_HELP_QUERY_MAXSEGMENTS 8
+/** Max edit distance to suggest a topic (only suggest if close enough). */
+#define MORPHO_HELP_SUGGEST_MAXDIST 3
+/** Edit distance return when string too long (no match). */
+#define MORPHO_HELP_EDIT_NOMATCH 255
+
+/** Parse query into lowercased segments in qbuf; segs[] points into qbuf. Returns nsegs (0 if none). */
+static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
+    size_t qlen = 0;
+    while (query[qlen] && qlen < MORPHO_MAX_HELPQUERY_LENGTH - 1) {
+        char c = query[qlen];
+        qbuf[qlen] = (c == '.' || c == ' ') ? '\0' : (char) tolower((unsigned char) c);
+        qlen++;
+    }
+    qbuf[qlen] = '\0';
+    int nsegs = 0;
+    const char *p = qbuf;
+    while (nsegs < MORPHO_HELP_QUERY_MAXSEGMENTS && p < qbuf + qlen) {
+        while (p < qbuf + qlen && *p == '\0') p++;
+        if (p >= qbuf + qlen) break;
+        segs[nsegs++] = p;
+        while (p < qbuf + qlen && *p != '\0') p++;
+    }
+    return nsegs;
+}
 
 /** Find topic index by file and block index. Returns -1 if not found. */
 static int help_findtopicbyblock(int file_index, unsigned int block_index) {
@@ -528,8 +542,7 @@ static int help_findtopicbyblock(int file_index, unsigned int block_index) {
 
 /** True if header title span (trimmed, lowercased) equals name. */
 static bool help_headertitleeq(const char *base, size_t start, size_t len, const char *name) {
-    while (len && (unsigned char) base[start] <= ' ') { start++; len--; }
-    while (len && (unsigned char) base[start + len - 1] <= ' ') len--;
+    md_trimspan(base, &start, &len);
     while (len && *name && (char) tolower((unsigned char) base[start]) == *name) {
         start++;
         len--;
@@ -560,6 +573,61 @@ static int help_findsubtopic(int parent_idx, const char *name) {
     return -1;
 }
 
+/** Levenshtein distance between two strings (for "did you mean"). */
+static unsigned int help_editdistance(const char *a, const char *b) {
+    size_t na = strlen(a), nb = strlen(b);
+    if (na == 0) return (unsigned int) nb;
+    if (nb == 0) return (unsigned int) na;
+    if (na > MORPHO_HELP_EDITMAXLEN || nb > MORPHO_HELP_EDITMAXLEN) return MORPHO_HELP_EDIT_NOMATCH;
+    unsigned int row0[MORPHO_HELP_EDITMAXLEN + 1], row1[MORPHO_HELP_EDITMAXLEN + 1];
+    unsigned int *prev = row0, *curr = row1;
+    for (size_t j = 0; j <= nb; j++) prev[j] = (unsigned int) j;
+    for (size_t i = 1; i <= na; i++) {
+        curr[0] = (unsigned int) i;
+        for (size_t j = 1; j <= nb; j++) {
+            unsigned int cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+            unsigned int del = prev[j] + 1, ins = curr[j - 1] + 1, sub = prev[j - 1] + cost;
+            curr[j] = (del < ins) ? (del < sub ? del : sub) : (ins < sub ? ins : sub);
+        }
+        { unsigned int *t = prev; prev = curr; curr = t; }
+    }
+    return prev[nb];
+}
+
+static const char MORPHO_HELP_NOTFOUND[] = "Topic not found.";
+
+/** Find top-level topic name closest to name; NULL if none within distance. */
+static const char *help_findclosesttopic(const char *name) {
+    const char *best = NULL;
+    unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (s_topics.data[i].level != 1 || !s_topics.data[i].name) continue;
+        unsigned int d = help_editdistance(name, s_topics.data[i].name);
+        if (d < best_d) { best_d = d; best = s_topics.data[i].name; }
+    }
+    return best;
+}
+
+/** Find subtopic name under parent closest to name; NULL if none within distance. */
+static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
+    if (parent_idx < 0 || (unsigned int) parent_idx >= s_topics.count) return NULL;
+    const md_topic *parent = &s_topics.data[parent_idx];
+    if (parent->file_index < 0 || (unsigned int) parent->file_index >= s_files.count) return NULL;
+    const md_file *file = &s_files.data[parent->file_index];
+    const char *best = NULL;
+    unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
+    for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
+        const md_block *b = &file->blocks.data[i];
+        if (b->type != MD_BLOCK_HEADER) continue;
+        if (b->as.header.level <= parent->level) break;
+        int ti = help_findtopicbyblock(parent->file_index, i);
+        if (ti < 0 || !s_topics.data[ti].name) continue;
+        unsigned int d = help_editdistance(name, s_topics.data[ti].name);
+        if (d < best_d) { best_d = d; best = s_topics.data[ti].name; }
+    }
+    return best;
+}
+
 /** Number of blocks that form this topic's content (header + following until next same-level or higher header). */
 static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_file *file) {
     unsigned int i = topic->block_index;
@@ -574,11 +642,26 @@ static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_fil
     return i - topic->block_index;
 }
 
-bool help_topictotext(const help_topic *t, varray_char *result) {
-    if (!t || !t->file || !t->file->source || !result) return false;
-    const char *src = t->file->source;
-    size_t src_len = t->file->sourcelen;
+/** Fill a help_topic view from resolved topic and file. */
+static void help_topicfill(help_topic *out, const md_topic *topic, const md_file *file) {
+    out->topic = topic;
+    out->file = file;
+    out->content_blocks = &file->blocks.data[topic->block_index];
+    out->nblocks = help_topiccontentnblocks(topic, file);
+}
 
+/** Validate topic and get source pointer/length; return false if invalid. */
+static bool help_topicsrc(const help_topic *t, varray_char *result, const char **src, size_t *src_len) {
+    if (!t || !t->file || !t->file->source || !result) return false;
+    *src = t->file->source;
+    *src_len = t->file->sourcelen;
+    return true;
+}
+
+bool help_topictotext(const help_topic *t, varray_char *result) {
+    const char *src;
+    size_t src_len;
+    if (!help_topicsrc(t, result, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
         if (b->span.start >= src_len) continue;
@@ -611,10 +694,9 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
 }
 
 bool help_topicrawmd(const help_topic *t, varray_char *result) {
-    if (!t || !t->file || !t->file->source || !result) return false;
-    const char *src = t->file->source;
-    size_t src_len = t->file->sourcelen;
-
+    const char *src;
+    size_t src_len;
+    if (!help_topicsrc(t, result, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
         if (b->span.start >= src_len) continue;
@@ -643,13 +725,10 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
 
     parser p;
     help_initializemdparser(&p, &l, &err, &parseout);
-
-    bool success = parse(&p);
-
+    bool ok = parse(&p);
     parse_clear(&p);
     lex_clear(&l);
-
-    return success;
+    return ok;
 }
 
 /* **********************************************************************
@@ -658,10 +737,8 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
 
 /** Loads a help file into the AST (appends to s_files and s_topics). */
 bool help_load(char *filename) {
-    bool success = false;
     FILE *f = fopen(filename, "r");
     if (!f) return false;
-
     varray_char contents;
     varray_charinit(&contents);
     if (!file_readintovarray(f, &contents)) {
@@ -670,18 +747,14 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
-
     md_file mdfile;
     md_file_init(&mdfile);
     mdfile.source = contents.data;
     mdfile.sourcelen = (contents.count > 0) ? contents.count - 1 : 0;
-
-    int file_index = (int) s_files.count;
-    success = help_parse(&mdfile, &s_topics, file_index);
-    if (success) varray_md_filewrite(&s_files, mdfile);
+    bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
+    if (ok) varray_md_filewrite(&s_files, mdfile);
     else md_file_clear(&mdfile);
-
-    return success;
+    return ok;
 }
 
 /** Finds and loads all help files; populates s_files and s_topics, then sorts topics. */
@@ -701,34 +774,16 @@ void help_findfiles(void) {
 }
 
 /* **********************************************************************
- * Morpho help files
+ * Help API
  * ********************************************************************** */
 
 /** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
 bool morpho_helpastopic(const char *query, help_topic *out) {
-    /* Copy query, lowercase, and replace '.' and ' ' with nul to form segments. */
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
-    size_t qlen = 0;
-    while (query[qlen] && qlen < MORPHO_MAX_HELPQUERY_LENGTH - 1) {
-        char c = query[qlen];
-        qbuf[qlen] = (c == '.' || c == ' ') ? '\0' : (char) tolower((unsigned char) c);
-        qlen++;
-    }
-    qbuf[qlen] = '\0';
-
-    /* Collect segment pointers (non-empty runs). */
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
-    int nsegs = 0;
-    const char *p = qbuf;
-    while (nsegs < MORPHO_HELP_QUERY_MAXSEGMENTS && p < qbuf + qlen) {
-        while (p < qbuf + qlen && *p == '\0') p++;
-        if (p >= qbuf + qlen) break;
-        segs[nsegs++] = p;
-        while (p < qbuf + qlen && *p != '\0') p++;
-    }
-    if (nsegs == 0) return false;
+    int nsegs = help_parsequery(query, qbuf, segs);
+    if (nsegs <= 0) return false;
 
-    /* Resolve first segment to a topic. */
     int idx = help_findtopic(&s_topics, segs[0]);
     if (idx < 0) return false;
 
@@ -743,23 +798,60 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     const md_file *file = &s_files.data[topic->file_index];
     if (topic->block_index >= file->blocks.count) return false;
 
-    out->topic = topic;
-    out->file = file;
-    out->content_blocks = &file->blocks.data[topic->block_index];
-    out->nblocks = help_topiccontentnblocks(topic, file);
+    help_topicfill(out, topic, file);
     return true;
+}
+
+/** Append "Topic 'query' not found [. Did you mean 'suggest'?]." to result. suggest2 optional (then suggest is "suggest1.suggest2"). */
+static void help_hintappend(varray_char *result, const char *query, const char *suggest1, const char *suggest2) {
+    char buf[MORPHO_HELP_HINTBUFSIZE];
+    int n = suggest1
+        ? (suggest2 ? snprintf(buf, sizeof(buf), "Topic '%s' not found. Did you mean '%s.%s'?", query, suggest1, suggest2)
+                    : snprintf(buf, sizeof(buf), "Topic '%s' not found. Did you mean '%s'?", query, suggest1))
+        : snprintf(buf, sizeof(buf), "Topic '%s' not found.", query);
+    if (n > 0 && (size_t) n < sizeof(buf)) varray_charadd(result, buf, n);
+}
+
+/** Build a hint for a failed query and append to result (caller may clear result first). */
+static void help_queryhint(const char *query, varray_char *result) {
+    if (!result) return;
+    char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
+    const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
+    int nsegs = help_parsequery(query, qbuf, segs);
+    if (nsegs == 0) {
+        varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+        return;
+    }
+    int idx = help_findtopic(&s_topics, segs[0]);
+    if (idx < 0) {
+        help_hintappend(result, query, help_findclosesttopic(segs[0]), NULL);
+        return;
+    }
+    for (int i = 1; i < nsegs; i++) {
+        int next = help_findsubtopic(idx, segs[i]);
+        if (next < 0) {
+            const md_topic *parent = &s_topics.data[idx];
+            const char *closest = help_findclosestsubtopic(idx, segs[i]);
+            help_hintappend(result, query, closest ? parent->name : NULL, closest);
+            return;
+        }
+        idx = next;
+    }
+    varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
 }
 
 bool morpho_helpastext(char *query, varray_char *result) {
     help_topic t;
-    if (!morpho_helpastopic(query, &t)) return false;
-    return help_topictotext(&t, result);
+    if (morpho_helpastopic(query, &t)) return help_topictotext(&t, result);
+    help_queryhint(query, result);
+    return false;
 }
 
 bool morpho_helpasmd(char *query, varray_char *result) {
     help_topic t;
-    if (!morpho_helpastopic(query, &t)) return false;
-    return help_topicrawmd(&t, result);
+    if (morpho_helpastopic(query, &t)) return help_topicrawmd(&t, result);
+    help_queryhint(query, result);
+    return false;
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -514,6 +514,52 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
 static varray_md_file s_files;
 static varray_md_topic s_topics;
 
+/** Maximum number of query segments (e.g. "System respondsto" -> 2). */
+#define MORPHO_HELP_QUERY_MAXSEGMENTS 8
+
+/** Find topic index by file and block index. Returns -1 if not found. */
+static int help_findtopicbyblock(int file_index, unsigned int block_index) {
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (s_topics.data[i].file_index == file_index && s_topics.data[i].block_index == block_index)
+            return (int) i;
+    }
+    return -1;
+}
+
+/** True if header title span (trimmed, lowercased) equals name. */
+static bool help_headertitleeq(const char *base, size_t start, size_t len, const char *name) {
+    while (len && (unsigned char) base[start] <= ' ') { start++; len--; }
+    while (len && (unsigned char) base[start + len - 1] <= ' ') len--;
+    while (len && *name && (char) tolower((unsigned char) base[start]) == *name) {
+        start++;
+        len--;
+        name++;
+    }
+    return len == 0 && *name == '\0';
+}
+
+/** Find first subtopic of parent with given name (same file, block after parent, level > parent). Returns topic index or -1. */
+static int help_findsubtopic(int parent_idx, const char *name) {
+    if (parent_idx < 0 || (unsigned int) parent_idx >= s_topics.count) return -1;
+    const md_topic *parent = &s_topics.data[parent_idx];
+    if (parent->file_index < 0 || (unsigned int) parent->file_index >= s_files.count) return -1;
+    const md_file *file = &s_files.data[parent->file_index];
+    const char *base = file->source;
+    size_t base_len = file->sourcelen;
+
+    for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
+        const md_block *b = &file->blocks.data[i];
+        if (b->type != MD_BLOCK_HEADER) continue;
+        if (b->as.header.level <= parent->level) return -1; /* left section */
+        size_t start = b->as.header.title.start;
+        size_t len = b->as.header.title.length;
+        if (start + len > base_len) len = base_len - start;
+        if (help_headertitleeq(base, start, len, name))
+            return help_findtopicbyblock(parent->file_index, i);
+    }
+    return -1;
+}
+
 /** Number of blocks that form this topic's content (header + following until next same-level or higher header). */
 static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_file *file) {
     unsigned int i = topic->block_index;
@@ -658,19 +704,40 @@ void help_findfiles(void) {
  * Morpho help files
  * ********************************************************************** */
 
-/** Interface to the morpho help system */
+/** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
 bool morpho_helpastopic(const char *query, help_topic *out) {
-    /* Topic names are stored lowercase; search key must match. */
+    /* Copy query, lowercase, and replace '.' and ' ' with nul to form segments. */
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
     size_t qlen = 0;
     while (query[qlen] && qlen < MORPHO_MAX_HELPQUERY_LENGTH - 1) {
-        qbuf[qlen] = (char) tolower((unsigned char) query[qlen]);
+        char c = query[qlen];
+        qbuf[qlen] = (c == '.' || c == ' ') ? '\0' : (char) tolower((unsigned char) c);
         qlen++;
     }
     qbuf[qlen] = '\0';
 
-    int idx = help_findtopic(&s_topics, qbuf);
+    /* Collect segment pointers (non-empty runs). */
+    const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
+    int nsegs = 0;
+    const char *p = qbuf;
+    while (nsegs < MORPHO_HELP_QUERY_MAXSEGMENTS && p < qbuf + qlen) {
+        while (p < qbuf + qlen && *p == '\0') p++;
+        if (p >= qbuf + qlen) break;
+        segs[nsegs++] = p;
+        while (p < qbuf + qlen && *p != '\0') p++;
+    }
+    if (nsegs == 0) return false;
+
+    /* Resolve first segment to a topic. */
+    int idx = help_findtopic(&s_topics, segs[0]);
     if (idx < 0) return false;
+
+    /* Resolve remaining segments as subtopics. */
+    for (int i = 1; i < nsegs; i++) {
+        idx = help_findsubtopic(idx, segs[i]);
+        if (idx < 0) return false;
+    }
+
     const md_topic *topic = &s_topics.data[idx];
     if (topic->file_index < 0 || (unsigned int) topic->file_index >= s_files.count) return false;
     const md_file *file = &s_files.data[topic->file_index];

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -15,6 +15,7 @@
 #include "help.h"
 #include "resources.h"
 
+#include "error.h"
 #include "lex.h"
 #include "parse.h"
 #include "file.h"
@@ -66,6 +67,22 @@ enum {
     MD_NEWLINE,
     MD_EOF
 };
+
+/* Markdown parser error codes (registered in help_initialize) */
+#define MD_UNCLOSEDITALIC       "MDUnclItal"
+#define MD_UNCLOSEDITALIC_MSG   "Unclosed italic (missing closing * or _)."
+#define MD_EXPECTLINEEND        "MDExpLnEnd"
+#define MD_EXPECTLINEEND_MSG    "Expected end of line."
+#define MD_EXPECTHEADERTEXT     "MDExpHdrTxt"
+#define MD_EXPECTHEADERTEXT_MSG "Expected header text after #."
+#define MD_LINKEXPECTTEXT       "MDLnkExpTxt"
+#define MD_LINKEXPECTTEXT_MSG   "Link definition expects label text after [."
+#define MD_LINKEXPECTBRACKET    "MDLnkExpBr"
+#define MD_LINKEXPECTBRACKET_MSG "Link definition expects ] after label."
+#define MD_LINKEXPECTCOLON      "MDLnkExpCol"
+#define MD_LINKEXPECTCOLON_MSG  "Link definition expects : after ]."
+#define MD_UNEXPECTEDTOKEN      "MDUnexpTok"
+#define MD_UNEXPECTEDTOKEN_MSG  "Unexpected markdown token."
 
 bool md_lexnewline(lexer *l, token *tok, error *err) {
     lex_newline(l);
@@ -143,7 +160,11 @@ bool md_parsebold(parser *p, void *out) {
 bool md_parseitalic(parser *p, void *out) {
     tokentype delim = p->previous.type; /* MD_ASTERISK or MD_UNDERSCORE */
     while (parse_checktokenadvance(p, MD_TEXT));
-    return parse_checktokenadvance(p, delim);
+    if (!parse_checktokenadvance(p, delim)) {
+        parse_error(p, false, MD_UNCLOSEDITALIC);
+        return false;
+    }
+    return true;
 }
 
 parserule md_rules[] = {
@@ -225,7 +246,10 @@ bool md_parsetext(parser *p, void *out) {
             if (!leading_asterisk_or_underscore && !rule->prefix(p, out)) return false;
         }
     }
-    PARSE_CHECK(md_parselineend(p));
+    if (!md_parselineend(p)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
     md_push_paragraph(p, ctx, block_start);
     return true;
 }
@@ -236,14 +260,20 @@ bool md_parseheader(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* # token already consumed */
 
-    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    if (!parse_checktokenadvance(p, MD_TEXT)) {
+        parse_error(p, false, MD_EXPECTHEADERTEXT);
+        return false;
+    }
     size_t title_start = (size_t)(p->previous.start - base);
     size_t title_len = p->previous.length;
     while (parse_checktokenadvance(p, MD_TEXT)) {
         title_len = (size_t)((p->previous.start - base) + p->previous.length - title_start);
     }
 
-    PARSE_CHECK(md_parselineend(p));
+    if (!md_parselineend(p)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
     md_push_header(p, ctx, block_start, title_start, title_len);
     return true;
 }
@@ -254,7 +284,10 @@ bool md_parsecode(parser *p, void *out) {
     size_t block_start = (size_t)(p->previous.start - ctx->file->source);  /* 4 spaces / tab already consumed */
 
     while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) parse_advance(p);
-    PARSE_CHECK(md_parselineend(p));
+    if (!md_parselineend(p)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
     md_push_code(p, ctx, block_start);
     return true;
 }
@@ -273,7 +306,10 @@ bool md_parselist(parser *p, void *out) {
             if (!rule->prefix(p, out)) return false;
         }
     }
-    PARSE_CHECK(md_parselineend(p));
+    if (!md_parselineend(p)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
     md_push_list(p, ctx, block_start);
     return true;
 }
@@ -295,7 +331,10 @@ bool md_parselink(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* [ already consumed */
 
-    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    if (!parse_checktokenadvance(p, MD_TEXT)) {
+        parse_error(p, false, MD_LINKEXPECTTEXT);
+        return false;
+    }
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
     size_t target_start;
@@ -319,10 +358,19 @@ bool md_parselink(parser *p, void *out) {
             target_len--;
         /* Rest of line (and newline) was in the TEXT token; next token is next line */
     } else {
-        PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
-        PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
+        if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) {
+            parse_error(p, false, MD_LINKEXPECTBRACKET);
+            return false;
+        }
+        if (!parse_checktokenadvance(p, MD_COLON)) {
+            parse_error(p, false, MD_LINKEXPECTCOLON);
+            return false;
+        }
         target_start = (size_t)(p->current.start - base);
-        PARSE_CHECK(md_parseurl(p, out));
+        if (!md_parseurl(p, out)) {
+            parse_error(p, true, MD_EXPECTLINEEND);
+            return false;
+        }
         size_t target_end = md_end_previous(p, base);
         target_len = (target_end > target_start) ? (target_end - target_start) : 0;
     }
@@ -359,9 +407,9 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktoken(p, MD_EOF)) {
         return true; /* let outer loop exit */
     } else {
-        UNREACHABLE("Unrecognized token.");
+        parse_error(p, false, MD_UNEXPECTEDTOKEN);
+        return false;
     }
-    return false;
 }
 
 /** Base markdown parse type */
@@ -805,6 +853,17 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     bool ok = parse(&p);
     parse_clear(&p);
     lex_clear(&l);
+    if (!ok && morpho_checkerror(&err)) {
+        fprintf(stderr, "Help parse error [%s]: %s", err.id ? err.id : "?", err.msg);
+        if (err.line != ERROR_POSNUNIDENTIFIABLE || err.posn != ERROR_POSNUNIDENTIFIABLE) {
+            fprintf(stderr, " (");
+            if (err.line != ERROR_POSNUNIDENTIFIABLE) fprintf(stderr, "line %d", err.line);
+            if (err.posn != ERROR_POSNUNIDENTIFIABLE)
+                fprintf(stderr, "%sposition %d", err.line != ERROR_POSNUNIDENTIFIABLE ? ", " : "", err.posn);
+            fprintf(stderr, ")");
+        }
+        fprintf(stderr, "\n");
+    }
     return ok;
 }
 
@@ -1023,6 +1082,15 @@ bool morpho_helpasmd(char *query, varray_char *result) {
 
 /** @brief Initialize help system */
 void help_initialize(void) {
+    /* Markdown parser errors */
+    morpho_defineerror(MD_UNCLOSEDITALIC, ERROR_PARSE, MD_UNCLOSEDITALIC_MSG);
+    morpho_defineerror(MD_EXPECTLINEEND, ERROR_PARSE, MD_EXPECTLINEEND_MSG);
+    morpho_defineerror(MD_EXPECTHEADERTEXT, ERROR_PARSE, MD_EXPECTHEADERTEXT_MSG);
+    morpho_defineerror(MD_LINKEXPECTTEXT, ERROR_PARSE, MD_LINKEXPECTTEXT_MSG);
+    morpho_defineerror(MD_LINKEXPECTBRACKET, ERROR_PARSE, MD_LINKEXPECTBRACKET_MSG);
+    morpho_defineerror(MD_LINKEXPECTCOLON, ERROR_PARSE, MD_LINKEXPECTCOLON_MSG);
+    morpho_defineerror(MD_UNEXPECTEDTOKEN, ERROR_PARSE, MD_UNEXPECTEDTOKEN_MSG);
+
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
     help_findfiles();

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -599,34 +599,29 @@ static void help_nameindex_remove(int topic_index, unsigned int keep_count) {
 /** Add topic_index under name (buf, len). Look up with static key; if present use existing key and update value, else allocate and insert. Returns canonical name value. */
 static value help_nameindex_add(const char *buf, size_t len, int topic_index) {
     objectstring key_obj = MORPHO_STATICSTRINGWITHLENGTH(buf, len);
-    value key = MORPHO_OBJECT(&key_obj);
-    value v;
-    value existing = dictionary_getkey(&s_names, key, &v);
-    if (!MORPHO_ISNIL(existing)) {
-        if (MORPHO_ISNIL(v)) {
-            dictionary_insert(&s_names, existing, MORPHO_INTEGER(topic_index));
-        } else if (MORPHO_ISINTEGER(v)) {
-            if (MORPHO_GETINTEGERVALUE(v) == topic_index) return existing;
-            objectlist *list = object_newlist(0, NULL);
-            if (list) {
-                list_append(list, v);
-                list_append(list, MORPHO_INTEGER(topic_index));
-                if (dictionary_insert(&s_names, existing, MORPHO_OBJECT(list)))
-                    return existing;
-                morpho_freeobject(MORPHO_OBJECT(list));
-            }
-        } else {
-            list_append(MORPHO_GETLIST(v), MORPHO_INTEGER(topic_index));
+    value name = MORPHO_OBJECT(&key_obj), v;
+    value key = dictionary_getkey(&s_names, name, &v);
+    if (MORPHO_ISNIL(key)) {
+        key = object_stringfromcstring(buf, len);
+        if (!MORPHO_ISSTRING(key)) return MORPHO_NIL;
+        if (!dictionary_insert(&s_names, key, MORPHO_INTEGER(topic_index))) {
+            morpho_freeobject(key);
+            return MORPHO_NIL;
         }
-        return existing;
-    }
-    value name_val = object_stringfromcstring(buf, len);
-    if (!MORPHO_ISSTRING(name_val)) return MORPHO_NIL;
-    if (!dictionary_insert(&s_names, name_val, MORPHO_INTEGER(topic_index))) {
-        morpho_freeobject(name_val);
-        return MORPHO_NIL;
-    }
-    return name_val;
+    } else {
+        if (MORPHO_ISNIL(v)) {
+            dictionary_insert(&s_names, key, MORPHO_INTEGER(topic_index));
+        } else if (MORPHO_ISINTEGER(v)) {
+            if (MORPHO_GETINTEGERVALUE(v) == topic_index) return key;
+            value new[2] = { v, MORPHO_INTEGER(topic_index) };
+            objectlist *list = object_newlist(2, new);
+            if (list) {
+                if (!dictionary_insert(&s_names, key, MORPHO_OBJECT(list)))
+                    morpho_freeobject(MORPHO_OBJECT(list));
+            }
+        } else if (MORPHO_ISLIST(v)) list_append(MORPHO_GETLIST(v), MORPHO_INTEGER(topic_index));
+    } 
+    return key;
 }
 
 /** Get first topic index from dict value (integer or first element of list). Returns -1 if not found or invalid. */

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -214,6 +214,13 @@ static size_t md_end_previous(parser *p, const char *base) {
     return (size_t)(p->previous.start - base) + p->previous.length;
 }
 
+/** Clamp span length to fit within source length. Returns clamped length. */
+static size_t md_clamp_span(size_t start, size_t len, size_t src_len) {
+    if (start >= src_len) return 0;
+    if (start + len > src_len) return src_len - start;
+    return len;
+}
+
 /* -------------------------------------------------------
  * Markdown parse rules
  * ------------------------------------------------------- */
@@ -655,9 +662,16 @@ static int help_findparent(int idx) {
 
 /** Write full display path for topic (e.g. "System.clock") into buf. */
 static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
-    if (!bufsize || idx < 0 || (unsigned int) idx >= s_topics.count) { if (bufsize) buf[0] = '\0'; return; }
+    if (!bufsize) return;
+    if (idx < 0 || (unsigned int) idx >= s_topics.count) {
+        buf[0] = '\0';
+        return;
+    }
     const md_topic *t = &s_topics.data[idx];
-    if (!t->name) { buf[0] = '\0'; return; }
+    if (!t->name) {
+        buf[0] = '\0';
+        return;
+    }
     int p = (t->level > 1) ? help_findparent(idx) : -1;
     if (p >= 0) {
         // Recurse for parent path, then append ".name"
@@ -717,22 +731,28 @@ static int help_findsubtopic(int parent_idx, const char *name) {
     for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
         const md_block *b = &file->blocks.data[i];
         if (b->type != MD_BLOCK_HEADER) continue;
-        if (b->as.header.level <= parent->level) return -1;  // left section
+        if (b->as.header.level <= parent->level) return -1; // left section
         size_t start = b->as.header.title.start;
-        size_t len = b->as.header.title.length;
-        if (start + len > base_len) len = base_len - start;
+        size_t len = md_clamp_span(start, b->as.header.title.length, base_len);
         if (help_headertitleeq(base, start, len, name))
             return help_findtopicbyblock(parent->file_index, i);
     }
     return -1;
 }
 
-/** Levenshtein distance between two strings (for "did you mean"). */
-static unsigned int help_editdistance(const char *a, const char *b) {
+/** Levenshtein distance between two strings (for "did you mean").
+ * If max_dist is provided (> 0), returns early if distance exceeds it (returns max_dist + 1).
+ * This allows early exit when we only care about distances within a threshold. */
+static unsigned int help_editdistance(const char *a, const char *b, unsigned int max_dist) {
     size_t na = strlen(a), nb = strlen(b);
     if (na == 0) return (unsigned int) nb;
     if (nb == 0) return (unsigned int) na;
     if (na > MORPHO_HELP_EDITMAXLEN || nb > MORPHO_HELP_EDITMAXLEN) return MORPHO_HELP_EDIT_NOMATCH;
+    
+    // Early exit: if length difference exceeds max_dist, distance must be at least that
+    size_t len_diff = (na > nb) ? na - nb : nb - na;
+    if (max_dist > 0 && len_diff > max_dist) return max_dist + 1;
+    
     // Two-row DP: prev row and current row, swap each iteration
     unsigned int row0[MORPHO_HELP_EDITMAXLEN + 1], row1[MORPHO_HELP_EDITMAXLEN + 1];
     unsigned int *prev = row0, *curr = row1;
@@ -742,8 +762,11 @@ static unsigned int help_editdistance(const char *a, const char *b) {
         for (size_t j = 1; j <= nb; j++) {
             unsigned int cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
             unsigned int del = prev[j] + 1, ins = curr[j - 1] + 1, sub = prev[j - 1] + cost;
-            curr[j] = (del < ins) ? (del < sub ? del : sub) : (ins < sub ? ins : sub);
+            unsigned int min = (del < ins) ? del : ins;
+            curr[j] = (min < sub) ? min : sub;
         }
+        // Early exit: if the final column (curr[nb]) exceeds max_dist, we can stop
+        if (max_dist > 0 && curr[nb] > max_dist) return max_dist + 1;
         { unsigned int *t = prev; prev = curr; curr = t; }
     }
     return prev[nb];
@@ -757,7 +780,7 @@ static const char *help_findclosesttopic(const char *name) {
     unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
     for (unsigned int i = 0; i < s_topics.count; i++) {
         if (s_topics.data[i].level != 1 || !s_topics.data[i].name) continue;
-        unsigned int d = help_editdistance(name, s_topics.data[i].name);
+        unsigned int d = help_editdistance(name, s_topics.data[i].name, best_d - 1);
         if (d < best_d) { best_d = d; best = s_topics.data[i].name; }
     }
     return best;
@@ -777,7 +800,7 @@ static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
         if (b->as.header.level <= parent->level) break;
         int ti = help_findtopicbyblock(parent->file_index, i);
         if (ti < 0 || !s_topics.data[ti].name) continue;
-        unsigned int d = help_editdistance(name, s_topics.data[ti].name);
+        unsigned int d = help_editdistance(name, s_topics.data[ti].name, best_d - 1);
         if (d < best_d) { best_d = d; best = s_topics.data[ti].name; }
     }
     return best;
@@ -819,17 +842,15 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
     if (!help_topicsrc(t, result, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
-        if (b->span.start >= src_len) continue;
-        size_t len = b->span.length;
-        if (b->span.start + len > src_len) len = src_len - b->span.start;
+        size_t len = md_clamp_span(b->span.start, b->span.length, src_len);
+        if (len == 0) continue;
 
         // Per-block: header (title only, no #), paragraph/list/code (span), link/blank skip
         switch (b->type) {
             case MD_BLOCK_HEADER: {
+                size_t tlen = md_clamp_span(b->as.header.title.start, b->as.header.title.length, src_len);
                 const char *p = src + b->as.header.title.start;
-                size_t tlen = b->as.header.title.length;
-                if (b->as.header.title.start + tlen > src_len) tlen = src_len - b->as.header.title.start;
-                while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; }  // strip leading # and space
+                while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; } // strip leading # and space
                 if (tlen > 0) varray_charadd(result, p, (int) tlen);
                 varray_charadd(result, "\n\n", 2);
                 break;
@@ -842,7 +863,7 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 break;
             case MD_BLOCK_LINK_DEF:
             case MD_BLOCK_BLANK:
-                break;  // omit from plain text
+                break; // omit from plain text
         }
     }
     return true;
@@ -854,9 +875,7 @@ bool help_topicrawmd(const help_topic *t, varray_char *result) {
     if (!help_topicsrc(t, result, &src, &src_len)) return false;
     for (unsigned int i = 0; i < t->nblocks; i++) {
         const md_block *b = &t->content_blocks[i];
-        if (b->span.start >= src_len) continue;
-        size_t len = b->span.length;
-        if (b->span.start + len > src_len) len = src_len - b->span.start;
+        size_t len = md_clamp_span(b->span.start, b->span.length, src_len);
         if (len == 0) continue;
         varray_charadd(result, src + b->span.start, (int) len);
         if (src[b->span.start + len - 1] != '\n') varray_charadd(result, "\n", 1);
@@ -882,11 +901,12 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     lex_clear(&l);
     if (!ok && morpho_checkerror(&err)) {
         fprintf(stderr, "Help parse error [%s]: %s", err.id ? err.id : "?", err.msg);
-        if (err.line != ERROR_POSNUNIDENTIFIABLE || err.posn != ERROR_POSNUNIDENTIFIABLE) {
+        bool has_line = (err.line != ERROR_POSNUNIDENTIFIABLE);
+        bool has_posn = (err.posn != ERROR_POSNUNIDENTIFIABLE);
+        if (has_line || has_posn) {
             fprintf(stderr, " (");
-            if (err.line != ERROR_POSNUNIDENTIFIABLE) fprintf(stderr, "line %d", err.line + 1);
-            if (err.posn != ERROR_POSNUNIDENTIFIABLE)
-                fprintf(stderr, "%sposition %d", err.line != ERROR_POSNUNIDENTIFIABLE ? ", " : "", err.posn + 1);
+            if (has_line) fprintf(stderr, "line %d", err.line + 1);
+            if (has_posn) fprintf(stderr, "%sposition %d", has_line ? ", " : "", err.posn + 1);
             fprintf(stderr, ")");
         }
         fprintf(stderr, "\n");
@@ -968,12 +988,9 @@ static void help_hintappend_multi(varray_char *result, const char *query, int in
     // First: "'A'"; middle: ", 'B'"; last: " or 'C'?"
     for (int i = 0; i < count && n < (int) sizeof(buf) - 4; i++) {
         help_topic_displaypath(indices[i], path, sizeof(path));
-        if (i == 0)
-            n += snprintf(buf + n, sizeof(buf) - (size_t) n, "'%s'", path);
-        else if (i == count - 1)
-            n += snprintf(buf + n, sizeof(buf) - (size_t) n, " or '%s'?", path);
-        else
-            n += snprintf(buf + n, sizeof(buf) - (size_t) n, ", '%s'", path);
+        if (i == 0) n += snprintf(buf + n, sizeof(buf) - (size_t) n, "'%s'", path);
+        else if (i == count - 1) n += snprintf(buf + n, sizeof(buf) - (size_t) n, " or '%s'?", path);
+        else n += snprintf(buf + n, sizeof(buf) - (size_t) n, ", '%s'", path);
     }
     if (n > 0 && (size_t) n < sizeof(buf)) varray_charadd(result, buf, n);
 }
@@ -1019,23 +1036,27 @@ static void help_queryhint(const char *query, varray_char *result) {
         int next = help_findsubtopic(idx, segs[i]);
         if (next < 0) {
             const char *closest = help_findclosestsubtopic(idx, segs[i]);
-            char suggest[MORPHO_MAX_HELPQUERY_LENGTH];
-            if (closest && path_len + 1 + (int) strlen(closest) < (int) sizeof(suggest))
-                snprintf(suggest, sizeof(suggest), "%s.%s", path, closest);
-            else
-                suggest[0] = '\0';
+            char suggest[MORPHO_MAX_HELPQUERY_LENGTH] = {0};
+            if (closest) {
+                int needed = path_len + 1 + (int) strlen(closest);
+                if (needed < (int) sizeof(suggest))
+                    snprintf(suggest, sizeof(suggest), "%s.%s", path, closest);
+            }
             help_hintappend(result, query, suggest[0] ? suggest : NULL);
             return;
         }
         idx = next;
         // Append "." + segs[i] to path for next level
-        if (path_len > 0 && path_len < (int) sizeof(path) - 1) {
-            path[path_len++] = '.';
-            int seglen = (int) strlen(segs[i]);
-            if (path_len + seglen >= (int) sizeof(path)) seglen = (int) sizeof(path) - 1 - path_len;
-            if (seglen > 0) { memcpy(path + path_len, segs[i], (size_t) seglen); path_len += seglen; }
-            path[path_len] = '\0';
+        if (path_len >= (int) sizeof(path) - 1) continue; // No room
+        path[path_len++] = '.';
+        int seglen = (int) strlen(segs[i]);
+        int avail = (int) sizeof(path) - path_len;
+        if (seglen >= avail) seglen = avail - 1;
+        if (seglen > 0) {
+            memcpy(path + path_len, segs[i], (size_t) seglen);
+            path_len += seglen;
         }
+        path[path_len] = '\0';
     }
     varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
 }
@@ -1065,10 +1086,10 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
         if (n == 1) {
             idx = multi[0];
         } else if (n == 0) {
-            idx = help_findtopic(&s_topics, segs[0]);  /* fallback: bsearch by name */
+            idx = help_findtopic(&s_topics, segs[0]); // fallback: bsearch by name
             if (idx < 0) return false;
         } else {
-            return false;  /* multiple matches: caller will show hint */
+            return false; // multiple matches: caller will show hint
         }
     } else {
         idx = help_findtopic(&s_topics, segs[0]);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -24,15 +24,18 @@
 
 #ifdef MORPHO_INCLUDE_HELP
 
-/** Static data structures */
+/* **********************************************************************
+ * Data structures and static data
+ * ********************************************************************** */
+
 DEFINE_VARRAY(md_block, md_block);
 DEFINE_VARRAY(md_file, md_file);
 DEFINE_VARRAY(md_topic, md_topic);
 DEFINE_VARRAY(md_alias, md_alias);
 
-static varray_md_file s_files;    // List of help files
-static varray_md_topic s_topics;  // List of topics
-static varray_md_alias s_aliases; // List of aliases
+static varray_md_file s_files;
+static varray_md_topic s_topics;
+static varray_md_alias s_aliases;
 
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
@@ -175,7 +178,7 @@ bool md_lexpreprocess(lexer *l, token *tok, error *err) {
 }
 
 /* -------------------------------------------------------
- * Initialize a Markdown lexer
+ * Lexer initialization
  * ------------------------------------------------------- */
 
 void help_initializemdlexer(lexer *l, const char *src) {
@@ -536,7 +539,7 @@ void help_initializemdparser(parser *p, lexer *l, error *err, void *out) {
 }
 
 /* **********************************************************************
- * Markdown AST: definitions and topic list helpers
+ * Markdown AST: block and file life cycle
  * ********************************************************************** */
 
 void md_block_clear(md_block *b) {
@@ -559,6 +562,10 @@ void md_file_clear(md_file *f) {
     for (unsigned int i = 0; i < f->blocks.count; i++) md_block_clear(&f->blocks.data[i]);
     varray_md_blockclear(&f->blocks);
 }
+
+/* -------------------------------------------------------
+ * Topic and alias comparison and sorting
+ * ------------------------------------------------------- */
 
 int md_topic_compare(const void *a, const void *b) {
     const md_topic *ta = (const md_topic *) a;
@@ -595,6 +602,10 @@ int help_findtopic(varray_md_topic *topics, const char *name) {
     
     return help_findalias(name); // Not found in topics, check aliases
 }
+
+/* -------------------------------------------------------
+ * Block construction (spans, init, push)
+ * ------------------------------------------------------- */
 
 /** End offset of the block from the last consumed token. */
 static size_t md_block_end(parser *p, const char *base) {
@@ -760,10 +771,15 @@ static bool help_createalias(const char *base, size_t label_start, size_t label_
 
 /** Maximum number of query segments (e.g. "System respondsto" -> 2). */
 #define MORPHO_HELP_QUERY_MAXSEGMENTS 8
+#define MORPHO_HELP_MAX_MULTIMATCH 8
 /** Max edit distance to suggest a topic (only suggest if close enough). */
 #define MORPHO_HELP_SUGGEST_MAXDIST 3
 /** Edit distance return when string too long (no match). */
 #define MORPHO_HELP_EDIT_NOMATCH 255
+
+/* -------------------------------------------------------
+ * Query parsing
+ * ------------------------------------------------------- */
 
 /** Parse query into lowercased segments in qbuf; segs[] points into qbuf. Returns nsegs (0 if none). */
 static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
@@ -786,6 +802,10 @@ static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
     }
     return nsegs;
 }
+
+/* -------------------------------------------------------
+ * Topic hierarchy (parent, display path, subtopic)
+ * ------------------------------------------------------- */
 
 /** Find parent topic index (same file, level < current, block_index < current, largest block_index). */
 static int help_findparent(int idx) {
@@ -832,8 +852,11 @@ static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
     }
 }
 
+/* -------------------------------------------------------
+ * Topic lookup by name or block
+ * ------------------------------------------------------- */
+
 /** Find all topic indices with given name. Fills indices[] up to max, returns count. */
-#define MORPHO_HELP_MAX_MULTIMATCH 8
 static int help_findallbyname(const char *name, int indices[], int max) {
     int n = 0;
     for (unsigned int i = 0; i < s_topics.count && n < max; i++) {
@@ -884,6 +907,10 @@ static int help_findsubtopic(int parent_idx, const char *name) {
     }
     return -1;
 }
+
+/* -------------------------------------------------------
+ * Edit distance and suggestions
+ * ------------------------------------------------------- */
 
 /** Levenshtein distance between two strings (for "did you mean").
  * If max_dist is provided (> 0), returns early if distance exceeds it (returns max_dist + 1).
@@ -948,6 +975,10 @@ static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
     }
     return best;
 }
+
+/* -------------------------------------------------------
+ * Topic content and rendering
+ * ------------------------------------------------------- */
 
 /** Number of blocks that form this topic's content (header + following until next header of any level). */
 static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_file *file) {
@@ -1032,6 +1063,11 @@ bool help_topicrawmd(const help_topic *t, varray_char *result) {
     return true;
 }
 
+/* **********************************************************************
+ * Morpho help files (load and parse)
+ * ********************************************************************** */
+
+/** Parse a markdown file and append blocks/topics to the given arrays. */
 bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     error err;
     error_init(&err);
@@ -1064,10 +1100,6 @@ bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     }
     return ok;
 }
-
-/* **********************************************************************
- * Morpho help files
- * ********************************************************************** */
 
 /** Loads a help file into the AST (appends to s_files and s_topics). */
 bool help_load(char *filename) {

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -970,7 +970,7 @@ static unsigned int help_editdistance(const char *a, const char *b, unsigned int
     for (size_t i = 1; i <= na; i++) {
         curr[0] = (unsigned int) i;
         for (size_t j = 1; j <= nb; j++) {
-            unsigned int cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+            unsigned int cost = (tolower((unsigned char) a[i - 1]) == tolower((unsigned char) b[j - 1])) ? 0 : 1;
             unsigned int del = prev[j] + 1, ins = curr[j - 1] + 1, sub = prev[j - 1] + cost;
             unsigned int min = (del < ins) ? del : ins;
             curr[j] = (min < sub) ? min : sub;
@@ -982,12 +982,12 @@ static unsigned int help_editdistance(const char *a, const char *b, unsigned int
     return prev[nb];
 }
 
-/** Find top-level topic name closest to name; NULL if none within distance. */
+/** Find topic name closest to name (searches all topics); NULL if none within distance. */
 static const char *help_findclosesttopic(const char *name) {
     const char *best = NULL;
     unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
     for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (s_topics.data[i].level != 1 || !MORPHO_ISSTRING(s_topics.data[i].name)) continue;
+        if (!MORPHO_ISSTRING(s_topics.data[i].name)) continue;
         const char *tn = MORPHO_GETCSTRING(s_topics.data[i].name);
         unsigned int d = help_editdistance(name, tn, best_d - 1);
         if (d < best_d) { best_d = d; best = tn; }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -128,7 +128,7 @@ void help_initializemdlexer(lexer *l, const char *src) {
 
 bool md_parseinlinecode(parser *p, void *out) {
     while (parse_checktokenadvance(p, MD_TEXT));
-    parse_checktokenadvance(p, MD_BACKTICK);
+    parse_checktokenadvance(p, MD_BACKTICK);  /* optional closing; unclosed is ok */
     return true;
 }
 
@@ -136,11 +136,10 @@ bool md_parsebold(parser *p, void *out) {
     while (parse_checktokenadvance(p, MD_TEXT));
     if (parse_checktoken(p, MD_ASTERISK2) ||
         parse_checktoken(p, MD_UNDERSCORE2)) parse_advance(p);
-    
     return true;
 }
 
-/** Parses italic: called after consuming opening * or _; consumes TEXT then closing delimiter (same as bold). */
+/** Parses italic: called after consuming opening * or _; consumes TEXT then closing delimiter. */
 bool md_parseitalic(parser *p, void *out) {
     tokentype delim = p->previous.type; /* MD_ASTERISK or MD_UNDERSCORE */
     while (parse_checktokenadvance(p, MD_TEXT));
@@ -214,12 +213,16 @@ bool md_parsetext(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->current.start - base);
 
-    // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers
+    // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers.
+    // A leading * or _ is treated as text (list-marker style); we could parse as list item later.
     while (md_checktexttoken(p)) {
         parse_advance(p);
+        size_t tok_start = (size_t)(p->previous.start - base);
         parserule *rule = parse_getrule(p, p->previous.type);
         if (rule && rule->prefix) {
-            if (!rule->prefix(p, out)) return false;
+            bool leading_asterisk_or_underscore = (tok_start == block_start &&
+                (p->previous.type == MD_ASTERISK || p->previous.type == MD_UNDERSCORE));
+            if (!leading_asterisk_or_underscore && !rule->prefix(p, out)) return false;
         }
     }
     PARSE_CHECK(md_parselineend(p));
@@ -227,7 +230,7 @@ bool md_parsetext(parser *p, void *out) {
     return true;
 }
 
-/** Parses a markdown header (title then newline or EOF). */
+/** Parses a markdown header (title then newline or EOF). Accepts one or more MD_TEXT tokens for the title. */
 bool md_parseheader(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
@@ -236,6 +239,9 @@ bool md_parseheader(parser *p, void *out) {
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
     size_t title_start = (size_t)(p->previous.start - base);
     size_t title_len = p->previous.length;
+    while (parse_checktokenadvance(p, MD_TEXT)) {
+        title_len = (size_t)((p->previous.start - base) + p->previous.length - title_start);
+    }
 
     PARSE_CHECK(md_parselineend(p));
     md_push_header(p, ctx, block_start, title_start, title_len);
@@ -309,7 +315,8 @@ bool md_parselink(parser *p, void *out) {
         label_len = (size_t)(found - txt);
         target_start = label_start + label_len + sep_len;
         target_len = (txt_len > label_len + sep_len) ? (txt_len - label_len - sep_len) : 0;
-        if (target_len > 0 && base[target_start + target_len - 1] == '\n') target_len--;
+        while (target_len > 0 && (base[target_start + target_len - 1] == '\n' || base[target_start + target_len - 1] == '\r'))
+            target_len--;
         /* Rest of line (and newline) was in the TEXT token; next token is next line */
     } else {
         PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
@@ -817,17 +824,27 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
+    // Own a copy of the source so each file in s_files has independent storage.
+    size_t len = (contents.count > 0) ? contents.count - 1 : 0;
+    char *copy = (char *) MORPHO_MALLOC(len + 1);
+    if (!copy) {
+        varray_charclear(&contents);
+        return false;
+    }
+    memcpy(copy, contents.data, len + 1);
+    varray_charclear(&contents);
     // Parse appends topics to s_topics with file_index = s_files.count. If parse fails we must
     // remove those topics so they don't point at the next file we append.
     md_file mdfile;
     md_file_init(&mdfile);
-    mdfile.source = contents.data;
-    mdfile.sourcelen = (contents.count > 0) ? contents.count - 1 : 0;
+    mdfile.source = copy;
+    mdfile.sourcelen = len;
     unsigned int n_topics_before = s_topics.count;
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
     if (ok) {
         varray_md_filewrite(&s_files, mdfile);
     } else {
+        fprintf(stderr, "Help file failed to parse: %s\n", filename);
         md_file_clear(&mdfile);
         /* Remove topics added during the failed parse; they have file_index = s_files.count */
         while (s_topics.count > n_topics_before) {
@@ -870,9 +887,14 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     if (nsegs == 1) {
         int multi[MORPHO_HELP_MAX_MULTIMATCH];
         int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
-        if (n == 0) return false;
-        if (n >= 2) return false;  // multiple matches: caller will show hint
-        idx = multi[0];
+        if (n == 1) {
+            idx = multi[0];
+        } else if (n == 0) {
+            idx = help_findtopic(&s_topics, segs[0]);  /* fallback: bsearch by name */
+            if (idx < 0) return false;
+        } else {
+            return false;  /* multiple matches: caller will show hint */
+        }
     } else {
         idx = help_findtopic(&s_topics, segs[0]);
         if (idx < 0) return false;

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -909,7 +909,7 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; } // strip leading # and space
                 if (tlen > 0) {
                     varray_charadd(result, (char *) p, (int) tlen);
-                    varray_charadd(result, "\n", 1);
+                    varray_charwrite(result, '\n');
                 }
                 break;
             }
@@ -923,10 +923,11 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
             case MD_BLOCK_THEMATIC_BREAK:
                 break; // omit from plain text (thematic breaks render as blank lines)
             case MD_BLOCK_BLANK:
-                varray_charadd(result, "\n", 1);
+                varray_charwrite(result, '\n');
                 break;
         }
     }
+    varray_charwrite(result, '\0');
     return true;
 }
 
@@ -1064,7 +1065,8 @@ void help_queryhint(const char *query, varray_char *result) {
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs == 0) {
-        varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+        varray_charadd(result, MORPHO_HELP_NOTFOUND, strlen(MORPHO_HELP_NOTFOUND));
+        varray_charwrite(result, '\0');
         return;
     }
     // Single segment: multi-match hint, or "not found" + closest, or NOTFOUND
@@ -1073,19 +1075,23 @@ void help_queryhint(const char *query, varray_char *result) {
         int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
         if (n >= 2) {
             help_hintappend_multi(result, query, multi, n);
+            varray_charwrite(result, '\0');
             return;
         }
         if (n == 0) {
             help_hintappend(result, query, help_findclosesttopic(segs[0]));
+            varray_charwrite(result, '\0');
             return;
         }
-        varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+        varray_charadd(result, MORPHO_HELP_NOTFOUND, strlen(MORPHO_HELP_NOTFOUND));
+        varray_charwrite(result, '\0');
         return;
     }
     // Multi-segment: resolve first, then walk subtopics; on first failure suggest path.closest
     int idx = help_findtopic(&s_topics, segs[0]);
     if (idx < 0) {
         help_hintappend(result, query, help_findclosesttopic(segs[0]));
+        varray_charwrite(result, '\0');
         return;
     }
     char path[MORPHO_MAX_HELPQUERY_LENGTH];
@@ -1103,6 +1109,7 @@ void help_queryhint(const char *query, varray_char *result) {
                     snprintf(suggest, sizeof(suggest), "%s.%s", path, closest);
             }
             help_hintappend(result, query, suggest[0] ? suggest : NULL);
+            varray_charwrite(result, '\0');
             return;
         }
         idx = next;
@@ -1111,7 +1118,8 @@ void help_queryhint(const char *query, varray_char *result) {
         int n = snprintf(path + path_len, (size_t)(sizeof(path) - path_len), ".%s", segs[i]);
         if (n > 0) path_len += (n < (int) sizeof(path) - path_len) ? n : (int) sizeof(path) - 1 - path_len;
     }
-    varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+    varray_charadd(result, MORPHO_HELP_NOTFOUND, strlen(MORPHO_HELP_NOTFOUND));
+    varray_charwrite(result, '\0');
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -7,6 +7,8 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 #include <varray.h>
 
 #include "classes.h"
@@ -16,6 +18,7 @@
 #include "lex.h"
 #include "parse.h"
 #include "file.h"
+#include "memory.h"
 
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
@@ -159,6 +162,37 @@ parserule md_rules[] = {
 };
 
 /* -------------------------------------------------------
+ * Parse output: build AST (blocks + topic list)
+ * ------------------------------------------------------- */
+
+/** Output context for the parser: current file, topic list, and base for span offsets. */
+typedef struct {
+    md_file *file;
+    varray_md_topic *topics;
+    int file_index;
+    int current_header_level;  /* 1–3, set before md_parseheader */
+} md_parseout;
+
+static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len);
+static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start);
+static void md_push_code(parser *p, md_parseout *out, size_t block_start);
+static void md_push_list(parser *p, md_parseout *out, size_t block_start);
+static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t label_start, size_t label_len, size_t target_start, size_t target_len);
+
+/** Span from the token we just consumed (p->previous). */
+static md_span md_span_previous(parser *p, const char *base) {
+    md_span s;
+    s.start = (size_t)(p->previous.start - base);
+    s.length = p->previous.length;
+    return s;
+}
+
+/** End position of the token we just consumed. */
+static size_t md_end_previous(parser *p, const char *base) {
+    return (size_t)(p->previous.start - base) + p->previous.length;
+}
+
+/* -------------------------------------------------------
  * Markdown parse rules
  * ------------------------------------------------------- */
 
@@ -175,6 +209,10 @@ bool md_checktexttoken(parser *p) {
 
 /** Parses text written in markdown; stops at a non-textual token. Line ends with NEWLINE or EOF. */
 bool md_parsetext(parser *p, void *out) {
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    size_t block_start = (size_t)(p->current.start - base);
+
     while (md_checktexttoken(p)) {
         parse_advance(p);
         parserule *rule = parse_getrule(p, p->previous.type);
@@ -183,33 +221,64 @@ bool md_parsetext(parser *p, void *out) {
         }
     }
     /* Line terminator: newline or end of file */
-    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
-    if (parse_checktoken(p, MD_EOF)) return true;
-    return false;
+    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
+    else if (!parse_checktoken(p, MD_EOF)) return false;
+
+    md_push_paragraph(p, ctx, block_start);
+    return true;
 }
 
 /** Parses a markdown header (title then newline or EOF). */
 bool md_parseheader(parser *p, void *out) {
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    size_t block_start = (size_t)(p->previous.start - base);  /* # token already consumed */
+
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
-    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
-    if (parse_checktoken(p, MD_EOF)) return true;
-    return false;
+    size_t title_start = (size_t)(p->previous.start - base);
+    size_t title_len = p->previous.length;
+
+    if (parse_checktoken(p, MD_NEWLINE)) { PARSE_CHECK(parse_advance(p)); }
+    else if (!parse_checktoken(p, MD_EOF)) return false;
+
+    md_push_header(p, ctx, block_start, title_start, title_len);
+    return true;
 }
 
 /** Parses markdown code block (indented lines until newline or EOF). */
 bool md_parsecode(parser *p, void *out) {
-    while (!parse_checktoken(p, MD_NEWLINE) &&
-           !parse_checktoken(p, MD_EOF)) {
+    md_parseout *ctx = (md_parseout *) out;
+    size_t block_start = (size_t)(p->previous.start - ctx->file->source);  /* 4 spaces / tab already consumed */
+
+    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF)) {
         parse_advance(p);
     }
-    if (parse_checktoken(p, MD_NEWLINE)) return parse_advance(p);
-    if (parse_checktoken(p, MD_EOF)) return true;
-    return false;
+    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
+    else if (!parse_checktoken(p, MD_EOF)) return false;
+
+    md_push_code(p, ctx, block_start);
+    return true;
 }
 
-/** Parses a markdown list. */
+/** Parses a markdown list (list item line; records as list block). */
 bool md_parselist(parser *p, void *out) {
-    return md_parsetext(p, out);
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    size_t block_start = (size_t)(p->previous.start - base);  /* *, +, or - already consumed */
+
+    /* Reuse text parsing but record as list block */
+    while (md_checktexttoken(p)) {
+        parse_advance(p);
+        parserule *rule = parse_getrule(p, p->previous.type);
+        if (rule && rule->prefix) {
+            if (!rule->prefix(p, out)) return false;
+        }
+    }
+    if (parse_checktoken(p, MD_NEWLINE)) { if (!parse_advance(p)) return false; }
+    else if (!parse_checktoken(p, MD_EOF)) return false;
+
+    md_push_list(p, ctx, block_start);
+    return true;
 }
 
 /** Parses the rest of a link definition after ]:  (e.g. " # (target)" or " # (subtopics)"). Consumes until newline or EOF. */
@@ -223,20 +292,39 @@ bool md_parseurl(parser *p, void *out) {
 
 /** Parses a markdown link definition [label]: # (optional) ... */
 bool md_parselink(parser *p, void *out) {
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    size_t block_start = (size_t)(p->previous.start - base);  /* [ already consumed */
+
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    size_t label_start = (size_t)(p->previous.start - base);
+    size_t label_len = p->previous.length;
+
     PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
     PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
+
+    size_t target_start = (size_t)(p->current.start - base);
     PARSE_CHECK(md_parseurl(p, out));
+    size_t target_end = md_end_previous(p, base);
+    size_t target_len = (target_end > target_start) ? (target_end - target_start) : 0;
+
+    md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }
 
 /** Parse a markdown 'block'  */
 bool md_parseblock(parser *p, void *out) {
+    md_parseout *ctx = (md_parseout *) out;
     if (md_checktexttoken(p)) {
         return md_parsetext(p, out);
-    } else if (parse_checktokenadvance(p, MD_HASH) ||
-               parse_checktokenadvance(p, MD_HASH2) ||
-               parse_checktokenadvance(p, MD_HASH3)) {
+    } else if (parse_checktokenadvance(p, MD_HASH)) {
+        ctx->current_header_level = 1;
+        return md_parseheader(p, out);
+    } else if (parse_checktokenadvance(p, MD_HASH2)) {
+        ctx->current_header_level = 2;
+        return md_parseheader(p, out);
+    } else if (parse_checktokenadvance(p, MD_HASH3)) {
+        ctx->current_header_level = 3;
         return md_parseheader(p, out);
     } else if (parse_checktokenadvance(p, MD_FOURSPACES) ||
                parse_checktokenadvance(p, MD_TAB)) {
@@ -279,24 +367,168 @@ void help_initializemdparser(parser *p, lexer *l, error *err, void *out) {
 }
 
 /* **********************************************************************
+ * Markdown AST: definitions and topic list helpers
+ * ********************************************************************** */
+
+DEFINE_VARRAY(md_block, md_block);
+DEFINE_VARRAY(md_file, md_file);
+DEFINE_VARRAY(md_topic, md_topic);
+
+void md_block_clear(md_block *b) {
+    varray_intclear(&b->children);
+}
+
+void md_file_init(md_file *f) {
+    f->source = NULL;
+    f->sourcelen = 0;
+    varray_md_blockinit(&f->blocks);
+}
+
+void md_file_clear(md_file *f) {
+    if (f->source) MORPHO_FREE(f->source);
+    f->source = NULL;
+    f->sourcelen = 0;
+    for (unsigned int i = 0; i < f->blocks.count; i++) md_block_clear(&f->blocks.data[i]);
+    varray_md_blockclear(&f->blocks);
+}
+
+int md_topic_compare(const void *a, const void *b) {
+    const md_topic *ta = (const md_topic *) a;
+    const md_topic *tb = (const md_topic *) b;
+    return strcmp(ta->name, tb->name);
+}
+
+void help_sorttopics(varray_md_topic *topics) {
+    if (topics->data && topics->count > 0)
+        qsort(topics->data, topics->count, sizeof(md_topic), md_topic_compare);
+}
+
+int help_findtopic(varray_md_topic *topics, const char *name) {
+    if (!topics->data || topics->count == 0) return -1;
+    md_topic key = { .name = (char *) name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
+    md_topic *found = (md_topic *) bsearch(&key, topics->data, topics->count, sizeof(md_topic), md_topic_compare);
+    return found ? (int) (found - topics->data) : -1;
+}
+
+/** End offset of the block from the last consumed token. */
+static size_t md_block_end(parser *p, const char *base) {
+    return md_end_previous(p, base);
+}
+
+/** Set a span to (start, length). */
+static void md_span_set(md_span *s, size_t start, size_t length) {
+    s->start = start;
+    s->length = length;
+}
+
+/** Initialize common block fields (type, span, parent, children). */
+static void md_block_init(md_block *b, md_blocktype type, size_t block_start, size_t block_end) {
+    b->type = type;
+    md_span_set(&b->span, block_start, block_end - block_start);
+    b->parent = -1;
+    varray_intinit(&b->children);
+}
+
+/** Set header block fields (level and title span). */
+static void md_block_set_header(md_block *b, int level, size_t title_start, size_t title_len) {
+    b->as.header.level = level;
+    md_span_set(&b->as.header.title, title_start, title_len);
+}
+
+/** Set link-def block fields (label and target spans). */
+static void md_block_set_link_def(md_block *b, size_t label_start, size_t label_len, size_t target_start, size_t target_len) {
+    md_span_set(&b->as.link_def.label, label_start, label_len);
+    md_span_set(&b->as.link_def.target, target_start, target_len);
+}
+
+static void md_push_header(parser *p, md_parseout *out, size_t block_start, size_t title_start, size_t title_len) {
+    const char *base = out->file->source;
+    size_t block_end = md_block_end(p, base);
+
+    md_block b;
+    md_block_init(&b, MD_BLOCK_HEADER, block_start, block_end);
+    md_block_set_header(&b, out->current_header_level, title_start, title_len);
+    varray_md_blockwrite(&out->file->blocks, b);
+
+    /* Topic: lowercase name from title span */
+    char *name = (char *) MORPHO_MALLOC(title_len + 1);
+    if (name) {
+        for (size_t i = 0; i < title_len; i++)
+            name[i] = (char) tolower((unsigned char) base[title_start + i]);
+        name[title_len] = '\0';
+        md_topic topic = {
+            .name = name,
+            .file_index = out->file_index,
+            .block_index = out->file->blocks.count - 1,
+            .level = out->current_header_level,
+            .parent_topic = -1
+        };
+        varray_md_topicwrite(out->topics, topic);
+    }
+}
+
+static void md_push_paragraph(parser *p, md_parseout *out, size_t block_start) {
+    const char *base = out->file->source;
+    size_t block_end = md_block_end(p, base);
+    md_block b;
+    md_block_init(&b, MD_BLOCK_PARAGRAPH, block_start, block_end);
+    varray_md_blockwrite(&out->file->blocks, b);
+}
+
+static void md_push_code(parser *p, md_parseout *out, size_t block_start) {
+    const char *base = out->file->source;
+    size_t block_end = md_block_end(p, base);
+    md_block b;
+    md_block_init(&b, MD_BLOCK_CODE, block_start, block_end);
+    varray_md_blockwrite(&out->file->blocks, b);
+}
+
+static void md_push_list(parser *p, md_parseout *out, size_t block_start) {
+    const char *base = out->file->source;
+    size_t block_end = md_block_end(p, base);
+    md_block b;
+    md_block_init(&b, MD_BLOCK_LIST, block_start, block_end);
+    varray_md_blockwrite(&out->file->blocks, b);
+}
+
+static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t label_start, size_t label_len, size_t target_start, size_t target_len) {
+    const char *base = out->file->source;
+    size_t block_end = md_block_end(p, base);
+    md_block b;
+    md_block_init(&b, MD_BLOCK_LINK_DEF, block_start, block_end);
+    md_block_set_link_def(&b, label_start, label_len, target_start, target_len);
+    varray_md_blockwrite(&out->file->blocks, b);
+}
+
+/* **********************************************************************
  * Parse help files
  * ********************************************************************** */
 
-bool help_parse(char *src) {
+static varray_md_file s_files;
+static varray_md_topic s_topics;
+
+bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     error err;
     error_init(&err);
-    
+
+    md_parseout parseout = {
+        .file = file,
+        .topics = topics,
+        .file_index = file_index,
+        .current_header_level = 1
+    };
+
     lexer l;
-    help_initializemdlexer(&l, src);
-    
+    help_initializemdlexer(&l, file->source);
+
     parser p;
-    help_initializemdparser(&p, &l, &err, NULL);
-    
+    help_initializemdparser(&p, &l, &err, &parseout);
+
     bool success = parse(&p);
-    
+
     parse_clear(&p);
     lex_clear(&l);
-    
+
     return success;
 }
 
@@ -304,42 +536,48 @@ bool help_parse(char *src) {
  * Morpho help files
  * ********************************************************************** */
 
-/** Loads a help file
- *  @param file     file to load
- *  @returns true if any help entries were successfully loaded */
+/** Loads a help file into the AST (appends to s_files and s_topics). */
 bool help_load(char *filename) {
-    bool success=false;
-    
+    bool success = false;
     FILE *f = fopen(filename, "r");
-    if (f) {
-        varray_char contents;
-        varray_charinit(&contents);
-        
-        if (file_readintovarray(f, &contents)) {
-            success=help_parse(contents.data);
-        }
-        
-        varray_charclear(&contents);
-        
+    if (!f) return false;
+
+    varray_char contents;
+    varray_charinit(&contents);
+    if (!file_readintovarray(f, &contents)) {
         fclose(f);
+        varray_charclear(&contents);
+        return false;
     }
-    
+    fclose(f);
+
+    md_file mdfile;
+    md_file_init(&mdfile);
+    mdfile.source = contents.data;
+    mdfile.sourcelen = (contents.count > 0) ? contents.count - 1 : 0;
+
+    int file_index = (int) s_files.count;
+    success = help_parse(&mdfile, &s_topics, file_index);
+    if (success) varray_md_filewrite(&s_files, mdfile);
+    else md_file_clear(&mdfile);
+
     return success;
 }
 
-/** Searches for help files
- *  @returns true if any help files were successfully processed. */
+/** Finds and loads all help files; populates s_files and s_topics, then sorts topics. */
 void help_findfiles(void) {
     varray_value files;
     varray_valueinit(&files);
-    
+
     if (morpho_listresources(MORPHO_RESOURCE_HELP, &files)) {
-        for (int i=0; i<files.count; i++) {
+        for (unsigned int i = 0; i < files.count; i++) {
             if (MORPHO_ISSTRING(files.data[i])) help_load(MORPHO_GETCSTRING(files.data[i]));
         }
+        for (unsigned int i = 0; i < files.count; i++) morpho_freeobject(files.data[i]);
     }
-    
     varray_valueclear(&files);
+
+    help_sorttopics(&s_topics);
 }
 
 /* **********************************************************************
@@ -355,13 +593,21 @@ bool morpho_help(char *query, varray_char *result) {
  * Initialization/finalization
  * ********************************************************************** */
 
-/** @brief Initialization/finalization */
+/** @brief Initialize help system */
 void help_initialize(void) {
+    varray_md_fileinit(&s_files);
+    varray_md_topicinit(&s_topics);
     help_findfiles();
-    
     morpho_addfinalizefn(help_finalize);
 }
 
-/** @brief Initialization/finalization */
+/** @brief Finalization: free all files and topics. */
 void help_finalize(void) {
+    for (unsigned int i = 0; i < s_files.count; i++)
+        md_file_clear(&s_files.data[i]);
+    varray_md_fileclear(&s_files);
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (s_topics.data[i].name) MORPHO_FREE(s_topics.data[i].name);
+    }
+    varray_md_topicclear(&s_topics);
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -4,7 +4,15 @@
  *  @brief Morpho help
 */
 
-#include <string.h>
 #include <ctype.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <varray.h>
 
 #include "help.h"
+
+/** Interface to the morpho help system */
+bool morpho_help(char *query, varray_char *result) {
+    return false;
+}
+

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -553,16 +553,33 @@ int md_topic_compare(const void *a, const void *b) {
     return strcmp(ta->name, tb->name);
 }
 
+int md_alias_compare(const void *a, const void *b) {
+    const md_alias *aa = (const md_alias *) a;
+    const md_alias *ab = (const md_alias *) b;
+    return strcmp(aa->name, ab->name);
+}
+
 void help_sorttopics(varray_md_topic *topics) {
     if (topics->data && topics->count > 0)
         qsort(topics->data, topics->count, sizeof(md_topic), md_topic_compare);
 }
 
+void help_sortaliases(varray_md_alias *aliases) {
+    if (aliases->data && aliases->count > 0)
+        qsort(aliases->data, aliases->count, sizeof(md_alias), md_alias_compare);
+}
+
 int help_findtopic(varray_md_topic *topics, const char *name) {
-    if (!topics->data || topics->count == 0) return -1;
+    if (!topics->data || topics->count == 0) {
+        // If no topics, check aliases
+        return help_findalias(name);
+    }
     md_topic key = { .name = (char *) name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
     md_topic *found = (md_topic *) bsearch(&key, topics->data, topics->count, sizeof(md_topic), md_topic_compare);
-    return found ? (int) (found - topics->data) : -1;
+    if (found) return (int) (found - topics->data);
+    
+    // Not found in topics, check aliases
+    return help_findalias(name);
 }
 
 /** End offset of the block from the last consumed token. */
@@ -665,6 +682,81 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
 }
 
 /* **********************************************************************
+ * Help topic aliases
+ * ********************************************************************** */
+
+/** Alias entry: maps an alias name to a topic index. */
+typedef struct {
+    char *name;              /* lowercase, owned */
+    int topic_index;
+} md_alias;
+
+DECLARE_VARRAY(md_alias, md_alias);
+
+static varray_md_alias s_aliases;
+
+/** Process link definitions in a file to create aliases from [tag...]: # (alias) entries. */
+static void help_processlinkdefs(int file_index) {
+    if (file_index < 0 || (unsigned int) file_index >= s_files.count) return;
+    const md_file *file = &s_files.data[file_index];
+    const char *base = file->source;
+    
+    for (unsigned int i = 0; i < file->blocks.count; i++) {
+        const md_block *b = &file->blocks.data[i];
+        if (b->type != MD_BLOCK_LINK_DEF) continue;
+        
+        // Check if label starts with "tag"
+        size_t label_len = md_clamp_span(b->as.link_def.label.start, b->as.link_def.label.length, file->sourcelen);
+        if (label_len < 3) continue;
+        const char *label = base + b->as.link_def.label.start;
+        if (tolower((unsigned char) label[0]) != 't' || tolower((unsigned char) label[1]) != 'a' || tolower((unsigned char) label[2]) != 'g') continue;
+        
+        // Extract alias name from target (find text in parentheses)
+        size_t target_start = b->as.link_def.target.start;
+        size_t target_len = md_clamp_span(target_start, b->as.link_def.target.length, file->sourcelen);
+        const char *target = base + target_start, *open = NULL, *close = NULL;
+        for (const char *p = target; p < target + target_len && !close; p++) {
+            if (!open && *p == '(') open = p + 1;
+            else if (open && *p == ')') { close = p; break; }
+        }
+        if (!open || !close || close == open) continue;
+        
+        // Allocate and lowercase alias name
+        size_t len = (size_t)(close - open);
+        char *alias_name = (char *) MORPHO_MALLOC(len + 1);
+        if (!alias_name) continue;
+        for (size_t j = 0; j < len; j++) alias_name[j] = (char) tolower((unsigned char) open[j]);
+        alias_name[len] = '\0';
+        
+        // Check for duplicates (topics and existing aliases)
+        bool duplicate = false;
+        if (s_topics.data && s_topics.count > 0) {
+            md_topic key = { .name = alias_name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
+            if (bsearch(&key, s_topics.data, s_topics.count, sizeof(md_topic), md_topic_compare)) duplicate = true;
+        }
+        if (!duplicate) {
+            for (unsigned int j = 0; j < s_aliases.count; j++) {
+                if (s_aliases.data[j].name && strcmp(s_aliases.data[j].name, alias_name) == 0) { duplicate = true; break; }
+            }
+        }
+        if (duplicate) { MORPHO_FREE(alias_name); continue; }
+        
+        // Find topic (most recent header before this block)
+        int topic_idx = -1;
+        for (int j = (int) i - 1; j >= 0; j--) {
+            if (file->blocks.data[j].type == MD_BLOCK_HEADER) {
+                topic_idx = help_findtopicbyblock(file_index, (unsigned int) j);
+                break;
+            }
+        }
+        if (topic_idx < 0) { MORPHO_FREE(alias_name); continue; }
+        
+        // Create alias
+        varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_index = topic_idx });
+    }
+}
+
+/* **********************************************************************
  * Help topic lookup and content range
  * ********************************************************************** */
 
@@ -763,6 +855,14 @@ static int help_findtopicbyblock(int file_index, unsigned int block_index) {
             return (int) i;
     }
     return -1;
+}
+
+/** Find topic index by alias name. Returns -1 if not found. */
+static int help_findalias(const char *name) {
+    if (!s_aliases.data || s_aliases.count == 0) return -1;
+    md_alias key = { .name = (char *) name, .topic_index = 0 };
+    md_alias *found = (md_alias *) bsearch(&key, s_aliases.data, s_aliases.count, sizeof(md_alias), md_alias_compare);
+    return found ? found->topic_index : -1;
 }
 
 /** True if header title span (trimmed, lowercased) equals name. */
@@ -1003,6 +1103,7 @@ bool help_load(char *filename) {
     bool ok = help_parse(&mdfile, &s_topics, (int) s_files.count);
     if (ok) {
         varray_md_filewrite(&s_files, mdfile);
+        help_processlinkdefs((int) s_files.count - 1);
     } else {
         md_file_clear(&mdfile);
         // Remove topics added during the failed parse; they have file_index = s_files.count
@@ -1028,6 +1129,7 @@ void help_findfiles(void) {
     }
     varray_valueclear(&files);
     help_sorttopics(&s_topics);
+    help_sortaliases(&s_aliases);
 }
 
 /* **********************************************************************
@@ -1203,6 +1305,7 @@ void help_initialize(void) {
 
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
+    varray_md_aliasinit(&s_aliases);
     morpho_addfinalizefn(help_finalize);
 }
 
@@ -1215,6 +1318,10 @@ void help_finalize(void) {
         if (s_topics.data[i].name) MORPHO_FREE(s_topics.data[i].name);
     }
     varray_md_topicclear(&s_topics);
+    for (unsigned int i = 0; i < s_aliases.count; i++) {
+        if (s_aliases.data[i].name) MORPHO_FREE(s_aliases.data[i].name);
+    }
+    varray_md_aliasclear(&s_aliases);
 }
 
 #endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1389,20 +1389,20 @@ void help_initialize(void) {
     morpho_defineerror(MD_LINKEXPECTCOLON, ERROR_PARSE, MD_LINKEXPECTCOLON_MSG);
     morpho_defineerror(MD_UNEXPECTEDTOKEN, ERROR_PARSE, MD_UNEXPECTEDTOKEN_MSG);
 
-    varray_md_fileinit(&s_files);
+    /*varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
     dictionary_init(&s_names);
-    morpho_addfinalizefn(help_finalize);
+    morpho_addfinalizefn(help_finalize);*/
 }
 
 /** @brief Finalization: free all files, topics, and name index. */
 void help_finalize(void) {
-    for (unsigned int i = 0; i < s_files.count; i++)
+    /*for (unsigned int i = 0; i < s_files.count; i++)
         md_file_clear(&s_files.data[i]);
     varray_md_fileclear(&s_files);
     dictionary_freecontents(&s_names, true, true);
     dictionary_clear(&s_names);
-    varray_md_topicclear(&s_topics);
+    varray_md_topicclear(&s_topics);*/
 }
 
 #endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -140,6 +140,14 @@ bool md_parselink(parser *p, void *out) {
 
 /** Parses a markdown paragraph  */
 bool md_parseparagraph(parser *p, void *out) {
+    tokentype intokens[] = { MD_TEXT, MD_COLON, MD_LEFTPAREN, MD_RIGHTPAREN };
+    
+    while (parse_checktokenmulti(p, 4, intokens)) {
+        parse_advance(p);
+    }
+    
+    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
+    
     return true;
 }
 
@@ -201,11 +209,6 @@ bool help_parse(char *src) {
     
     lexer l;
     help_initializemdlexer(&l, src);
-    
-    /*token tok;
-    while (lex(&l, &tok, &err)) {
-        if (tok.type==MD_EOF) break;
-    }*/
     
     parser p;
     help_initializemdparser(&p, &l, &err, NULL);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -129,7 +129,11 @@ bool md_parseinlinecode(parser *p, void *out) {
 }
 
 bool md_parsebold(parser *p, void *out) {
+    while (parse_checktokenadvance(p, MD_TEXT));
+    if (parse_checktoken(p, MD_ASTERISK2) ||
+        parse_checktoken(p, MD_UNDERSCORE2)) parse_advance(p);
     
+    return true;
 }
 
 parserule md_rules[] = {

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -412,10 +412,8 @@ bool md_parselink(parser *p, void *out) {
 /** Parse a markdown 'block' */
 bool md_parseblock(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
-    // Dispatch by first token: text, #/##/###, indent, list, [link], newline, EOF
-    if (md_checktexttoken(p)) {
-        return md_parsetext(p, out);
-    } else if (parse_checktokenadvance(p, MD_HASH)) {
+    /* Dispatch by first token. Check block-start alternatives first. */
+    if (parse_checktokenadvance(p, MD_HASH)) {
         ctx->current_header_level = 1;
         return md_parseheader(p, out);
     } else if (parse_checktokenadvance(p, MD_HASH2)) {
@@ -427,16 +425,24 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktokenadvance(p, MD_FOURSPACES) ||
                parse_checktokenadvance(p, MD_TAB)) {
         return md_parsecode(p, out);
-    } else if (parse_checktokenadvance(p, MD_ASTERISK) ||
-               parse_checktokenadvance(p, MD_PLUS) ||
-               parse_checktokenadvance(p, MD_DASH)) {
-        return md_parselist(p, out);
+    } else if (parse_checktoken(p, MD_ASTERISK) ||
+               parse_checktoken(p, MD_PLUS) ||
+               parse_checktoken(p, MD_DASH)) {
+        /* CommonMark: list marker must be followed by space or tab; else treat as paragraph (e.g. *Goodbye* italic). */
+        char c = lex_peekahead(p->lex, p->current.length);
+        if (c == ' ' || c == '\t') {
+            parse_advance(p);
+            return md_parselist(p, out);
+        }
+        return md_parsetext(p, out);
     } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
         return md_parselink(p, out);
     } else if (parse_checktokenadvance(p, MD_NEWLINE)) { /* blank line */
         return true;
     } else if (parse_checktoken(p, MD_EOF)) {
         return true; /* let outer loop exit */
+    } else if (md_checktexttoken(p)) {
+        return md_parsetext(p, out);
     } else {
         parse_error(p, false, MD_UNEXPECTEDTOKEN);
         return false;

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -41,23 +41,29 @@ enum {
     MD_HASH2,
     MD_HASH3,
     MD_COLON,
-    MD_LEFTBRACE,
-    MD_RIGHTBRACE,
+    MD_LEFTPAREN,
+    MD_RIGHTPAREN,
     MD_LEFTSQUAREBRACE,
     MD_RIGHTSQUAREBRACE,
     MD_BOLD,
     MD_ITALIC,
     MD_BOLDITALIC,
+    MD_NEWLINE,
     MD_EOF
 };
+
+bool md_lexnewline(lexer *l, token *tok, error *err) {
+    lex_newline(l);
+    return true;
+}
 
 tokendefn mdtokens[] = {
     { "#",          MD_HASH                     , NULL },
     { "##",         MD_HASH2                    , NULL },
     { "###",        MD_HASH3                    , NULL },
     { ":",          MD_COLON                    , NULL },
-    { "(",          MD_LEFTBRACE                , NULL },
-    { ")",          MD_RIGHTBRACE               , NULL },
+    { "(",          MD_LEFTPAREN                , NULL },
+    { ")",          MD_RIGHTPAREN               , NULL },
     { "[",          MD_LEFTSQUAREBRACE          , NULL },
     { "]",          MD_RIGHTSQUAREBRACE         , NULL },
     { "*",          MD_ITALIC                   , NULL },
@@ -66,6 +72,7 @@ tokendefn mdtokens[] = {
     { "__",         MD_BOLD                     , NULL },
     { "***",        MD_BOLDITALIC               , NULL },
     { "___",        MD_BOLDITALIC               , NULL },
+    { "\n",         MD_NEWLINE                  , md_lexnewline },
     { "",           TOKEN_NONE                  , NULL }
 };
 
@@ -102,13 +109,62 @@ void help_initializemdlexer(lexer *l, char *src) {
  * Markdown parse rules
  * ------------------------------------------------------- */
 
+/** Parses a markdown header  */
+bool md_parseheader(parser *p, void *out) {
+    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
+    return true;
+}
+
+bool md_parseurl(parser *p, void *out) { // TODO: This is a placeholder
+    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    PARSE_CHECK(parse_checktokenadvance(p, MD_HASH));
+    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    return true;
+}
+
 /** Parses a markdown link  */
 bool md_parselink(parser *p, void *out) {
+    PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+    PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
+    PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
+    PARSE_CHECK(md_parseurl(p, out));
+    if (parse_checktokenadvance(p, MD_LEFTPAREN)) {
+        PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
+        PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTPAREN));
+    }
+    PARSE_CHECK(parse_checktokenadvance(p, MD_NEWLINE));
+    
     return true;
+}
+
+/** Parses a markdown paragraph  */
+bool md_parseparagraph(parser *p, void *out) {
+    return true;
+}
+
+/** Parse a markdown 'block'  */
+bool md_parseblock(parser *p, void *out) {
+    if (parse_checktokenadvance(p, MD_TEXT)) {
+        return md_parseparagraph(p, out);
+    } else if (parse_checktokenadvance(p, MD_LEFTSQUAREBRACE)) {
+        return md_parselink(p, out);
+    } else if (parse_checktokenadvance(p, MD_HASH)) {
+        return md_parseheader(p, out);
+    } else if (parse_checktokenadvance(p, MD_NEWLINE)) { // A blank line
+        return true;
+    } else {
+        return md_parseparagraph(p, out);
+    }
+    
+    return false;
 }
 
 /** Base markdown parse type */
 bool md_parse(parser *p, void *out) {
+    while(md_parseblock(p, out)) {
+    }
+    
     return true;
 }
 
@@ -117,7 +173,9 @@ bool md_parse(parser *p, void *out) {
  * ------------------------------------------------------- */
 
 parserule md_rules[] = {
-    PARSERULE_PREFIX(MD_LEFTSQUAREBRACE, md_parselink),
+    PARSERULE_PREFIX(MD_HASH,            NULL           ),
+    PARSERULE_PREFIX(MD_LEFTSQUAREBRACE, NULL           ),
+    PARSERULE_PREFIX(MD_BOLD,            NULL           ),
     PARSERULE_UNUSED(TOKEN_NONE)
 };
 
@@ -144,16 +202,15 @@ bool help_parse(char *src) {
     lexer l;
     help_initializemdlexer(&l, src);
     
-    token tok;
+    /*token tok;
     while (lex(&l, &tok, &err)) {
         if (tok.type==MD_EOF) break;
-    }
+    }*/
     
-    /*
     parser p;
     help_initializemdparser(&p, &l, &err, NULL);
     
-    parse(&p);*/
+    parse(&p);
     
     return true;
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -982,30 +982,17 @@ static unsigned int help_editdistance(const char *a, const char *b, unsigned int
     return prev[nb];
 }
 
-/** Find topic name closest to name (searches all topics); NULL if none within distance. */
-static const char *help_findclosesttopic(const char *name) {
-    const char *best = NULL;
-    unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
-    for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (!MORPHO_ISSTRING(s_topics.data[i].name)) continue;
-        const char *tn = MORPHO_GETCSTRING(s_topics.data[i].name);
-        unsigned int d = help_editdistance(name, tn, best_d - 1);
-        if (d < best_d) { best_d = d; best = tn; }
-    }
-    return best;
-}
-
 /** Find subtopic name under parent closest to name; NULL if none within distance. */
-static const char *help_findclosestsubtopic(int parent_idx, const char *name) {
-    if (parent_idx < 0 || (unsigned int) parent_idx >= s_topics.count) return NULL;
+static const char *help_findclosesttopic(const char *name, int parent_idx) {
     const char *best = NULL;
-    unsigned int best_d = MORPHO_HELP_SUGGEST_MAXDIST + 1;
+    unsigned int best_d = -1;
+    size_t len = strlen(name);
     for (unsigned int j = 0; j < s_topics.count; j++) {
-        if (s_topics.data[j].parent_topic != parent_idx) continue;
+        if (parent_idx >=0 && s_topics.data[j].parent_topic != parent_idx) continue;
         if (!MORPHO_ISSTRING(s_topics.data[j].name)) continue;
         const char *tn = MORPHO_GETCSTRING(s_topics.data[j].name);
-        unsigned int d = help_editdistance(name, tn, best_d - 1);
-        if (d < best_d) { best_d = d; best = tn; }
+        unsigned int d = help_editdistance(name, tn, (unsigned int) len);
+        if (d < best_d || best_d<0) { best_d = d; best = tn; }
     }
     return best;
 }
@@ -1234,7 +1221,7 @@ void help_queryhint(const char *query, varray_char *result) {
             return;
         }
         if (n == 0) {
-            help_hintappend(result, query, help_findclosesttopic(segs[0]));
+            help_hintappend(result, query, help_findclosesttopic(segs[0], -1));
             varray_charwrite(result, '\0');
             return;
         }
@@ -1245,7 +1232,7 @@ void help_queryhint(const char *query, varray_char *result) {
     // Multi-segment: resolve first, then walk subtopics; on first failure suggest path.closest
     int idx = help_findtopic(segs[0]);
     if (idx < 0) {
-        help_hintappend(result, query, help_findclosesttopic(segs[0]));
+        help_hintappend(result, query, help_findclosesttopic(segs[0], -1));
         varray_charwrite(result, '\0');
         return;
     }
@@ -1256,7 +1243,7 @@ void help_queryhint(const char *query, varray_char *result) {
     for (int i = 1; i < nsegs; i++) {
         int next = help_findchild(idx, segs[i]);
         if (next < 0) {
-            const char *closest = help_findclosestsubtopic(idx, segs[i]);
+            const char *closest = help_findclosesttopic(segs[i], idx);
             char suggest[MORPHO_MAX_HELPQUERY_LENGTH] = {0};
             if (closest) {
                 int needed = path_len + 1 + (int) strlen(closest);
@@ -1388,7 +1375,6 @@ void help_initialize(void) {
     morpho_defineerror(MD_LINKEXPECTBRACKET, ERROR_PARSE, MD_LINKEXPECTBRACKET_MSG);
     morpho_defineerror(MD_LINKEXPECTCOLON, ERROR_PARSE, MD_LINKEXPECTCOLON_MSG);
     morpho_defineerror(MD_UNEXPECTEDTOKEN, ERROR_PARSE, MD_UNEXPECTEDTOKEN_MSG);
-
     
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -62,6 +62,7 @@ enum {
     MD_UNDERSCORE2,
     MD_ASTERISK3,
     MD_UNDERSCORE3,
+    MD_THEMATIC_BREAK,
     MD_FOURSPACES,
     MD_TAB,
     MD_NEWLINE,
@@ -72,6 +73,7 @@ bool md_lexnewline(lexer *l, token *tok, error *err) {
     lex_newline(l);
     return true;
 }
+
 
 tokendefn mdtokens[] = {
     { "#",          MD_HASH                     , NULL },
@@ -104,8 +106,38 @@ static bool md_isasciipunct(char c) {
     return (unsigned char)c <= 0x7F && ispunct((unsigned char)c);
 }
 
+/** Check if current position is a thematic break and record it as MD_THEMATIC_BREAK token.
+ * Returns true if a thematic break token was recorded, false otherwise. */
+static bool md_lexthematicbreak(lexer *l, token *tok) {
+    char c = lex_peek(l);
+    if (c != '-' && c != '*' && c != '_') return false;
+    
+    int count = 0; // Count consecutive matching characters using peekahead (must be 3+)
+    while (lex_peekahead(l, count) == c && count < 100) count++; // reasonable limit
+    if (count < 3) return false;
+    
+    int spaces = 0; // Check for optional spaces after break characters
+    while (lex_peekahead(l, count + spaces) == ' ') spaces++;
+    
+    char next = lex_peekahead(l, count + spaces); // Must be followed by newline or EOF
+    if (next != '\n' && next != '\r' && next != '\0') return false;
+    
+    size_t total_len = (size_t)count + (size_t)spaces; // Calculate total length to advance
+    if (next == '\r' && lex_peekahead(l, count + spaces + 1) == '\n') {
+        total_len += 2; // \r\n
+    } else if (next == '\n' || next == '\r') {
+        total_len += 1; // \n or \r
+    }
+    
+    lex_advanceby(l, total_len); // Advance by total length and record token
+    lex_recordtoken(l, MD_THEMATIC_BREAK, tok);
+    return true;
+}
+
 /** Lexer token preprocessor function */
 bool md_lexpreprocess(lexer *l, token *tok, error *err) {
+    if (md_lexthematicbreak(l, tok)) return true; // Check for thematic break before processing other tokens
+    
     while (!lex_identifytoken(l, false, NULL) && !lex_isatend(l)) {
         char c = lex_peek(l);
         if (c == '\\') {
@@ -327,6 +359,15 @@ bool md_parsecode(parser *p, void *out) {
     return true;
 }
 
+/** Parses a thematic break (---, ***, or ___). Token already consumed by lexer (includes newline). */
+static bool md_parsethematicbreak(parser *p, void *out) {
+    md_parseout *ctx = (md_parseout *) out;
+    const char *base = ctx->file->source;
+    size_t block_start = (size_t)(p->previous.start - base);
+    md_push_simpleblock(p, ctx, block_start, MD_BLOCK_THEMATIC_BREAK);
+    return true;
+}
+
 /** Parses a markdown list (list item line; records as list block). */
 bool md_parselist(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
@@ -422,6 +463,8 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktokenadvance(p, MD_FOURSPACES) ||
                parse_checktokenadvance(p, MD_TAB)) {
         return md_parsecode(p, out);
+    } else if (parse_checktokenadvance(p, MD_THEMATIC_BREAK)) {
+        return md_parsethematicbreak(p, out);
     } else if (parse_checktoken(p, MD_ASTERISK) ||
                parse_checktoken(p, MD_PLUS) ||
                parse_checktoken(p, MD_DASH)) {
@@ -863,7 +906,8 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 break;
             case MD_BLOCK_LINK_DEF:
             case MD_BLOCK_BLANK:
-                break; // omit from plain text
+            case MD_BLOCK_THEMATIC_BREAK:
+                break; // omit from plain text (thematic breaks render as blank lines)
         }
     }
     return true;

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1389,6 +1389,7 @@ void help_initialize(void) {
     morpho_defineerror(MD_LINKEXPECTCOLON, ERROR_PARSE, MD_LINKEXPECTCOLON_MSG);
     morpho_defineerror(MD_UNEXPECTEDTOKEN, ERROR_PARSE, MD_UNEXPECTEDTOKEN_MSG);
 
+    
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
     dictionary_init(&s_names);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -982,17 +982,17 @@ static unsigned int help_editdistance(const char *a, const char *b, unsigned int
     return prev[nb];
 }
 
-/** Find subtopic name under parent closest to name; NULL if none within distance. */
+/** Find topic name closest to name. If parent_idx >= 0, only consider subtopics of that parent; otherwise search all topics. Returns NULL if no topics to compare. */
 static const char *help_findclosesttopic(const char *name, int parent_idx) {
     const char *best = NULL;
-    unsigned int best_d = -1;
+    int best_d = -1; /* no candidate yet */
     size_t len = strlen(name);
     for (unsigned int j = 0; j < s_topics.count; j++) {
-        if (parent_idx >=0 && s_topics.data[j].parent_topic != parent_idx) continue;
+        if (parent_idx >= 0 && s_topics.data[j].parent_topic != parent_idx) continue;
         if (!MORPHO_ISSTRING(s_topics.data[j].name)) continue;
         const char *tn = MORPHO_GETCSTRING(s_topics.data[j].name);
-        unsigned int d = help_editdistance(name, tn, (unsigned int) len);
-        if (d < best_d || best_d<0) { best_d = d; best = tn; }
+        int d = help_editdistance(name, tn, (unsigned int) len);
+        if (d < best_d || best_d < 0) { best_d = d; best = tn; }
     }
     return best;
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -22,6 +22,8 @@
 #include "file.h"
 #include "memory.h"
 
+#ifdef MORPHO_INCLUDE_HELP
+
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
  *  valid Markdown, although only a subset is used, and the help system interprets
@@ -1193,3 +1195,5 @@ void help_finalize(void) {
     }
     varray_md_topicclear(&s_topics);
 }
+
+#endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -422,8 +422,8 @@ bool md_parseblock(parser *p, void *out) {
     } else if (parse_checktoken(p, MD_ASTERISK) ||
                parse_checktoken(p, MD_PLUS) ||
                parse_checktoken(p, MD_DASH)) {
-        /* CommonMark: list marker must be followed by space or tab; else treat as paragraph (e.g. *Goodbye* italic). */
-        char c = lex_peekahead(p->lex, p->current.length);
+        /* CommonMark: list marker must be followed by space or tab; else treat as paragraph. */
+        char c = lex_peek(p->lex);
         if (c == ' ' || c == '\t') {
             parse_advance(p);
             return md_parselist(p, out);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1,0 +1,10 @@
+/** @file help.c
+ *  @author T J Atherton
+ *
+ *  @brief Morpho help
+*/
+
+#include <string.h>
+#include <ctype.h>
+
+#include "help.h"

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -71,6 +71,8 @@ enum {
 /* Markdown parser error codes (registered in help_initialize) */
 #define MD_UNCLOSEDITALIC       "MDUnclItal"
 #define MD_UNCLOSEDITALIC_MSG   "Unclosed italic (missing closing * or _)."
+#define MD_UNCLOSEDINLINECODE   "MDUnclCode"
+#define MD_UNCLOSEDINLINECODE_MSG "Unclosed inline code (missing closing `)."
 #define MD_EXPECTLINEEND        "MDExpLnEnd"
 #define MD_EXPECTLINEEND_MSG    "Expected end of line."
 #define MD_EXPECTHEADERTEXT     "MDExpHdrTxt"
@@ -143,9 +145,14 @@ void help_initializemdlexer(lexer *l, const char *src) {
  * Markdown parse table (for inline syntax)
  * ------------------------------------------------------- */
 
+/** Parses inline code span. Content is ignored until closing backtick. */
 bool md_parseinlinecode(parser *p, void *out) {
-    while (parse_checktokenadvance(p, MD_TEXT));
-    parse_checktokenadvance(p, MD_BACKTICK);  /* optional closing; unclosed is ok */
+    while (!parse_checktoken(p, MD_BACKTICK) && !parse_checktoken(p, MD_EOF))
+        parse_advance(p);
+    if (!parse_checktokenadvance(p, MD_BACKTICK)) {
+        parse_error(p, false, MD_UNCLOSEDINLINECODE);
+        return false;
+    }
     return true;
 }
 
@@ -1084,6 +1091,7 @@ bool morpho_helpasmd(char *query, varray_char *result) {
 void help_initialize(void) {
     /* Markdown parser errors */
     morpho_defineerror(MD_UNCLOSEDITALIC, ERROR_PARSE, MD_UNCLOSEDITALIC_MSG);
+    morpho_defineerror(MD_UNCLOSEDINLINECODE, ERROR_PARSE, MD_UNCLOSEDINLINECODE_MSG);
     morpho_defineerror(MD_EXPECTLINEEND, ERROR_PARSE, MD_EXPECTLINEEND_MSG);
     morpho_defineerror(MD_EXPECTHEADERTEXT, ERROR_PARSE, MD_EXPECTHEADERTEXT_MSG);
     morpho_defineerror(MD_LINKEXPECTTEXT, ERROR_PARSE, MD_LINKEXPECTTEXT_MSG);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -348,13 +348,49 @@ bool md_parseurl(parser *p, void *out) {
     return true; /* EOF is valid end of link line */
 }
 
-/** Parses a markdown link definition [label]: # (optional) ...
- *  The lexer often gives one MD_TEXT for "label]: target" (no separate ] : tokens).
- *  Accept either: TEXT then ] then : then rest, or one TEXT containing "]: " and split it. */
+/** Parses inline link [text](url)... after [ and label and ] are consumed. Consumes ( url ) and rest of line, pushes paragraph. */
+static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
+    md_parseout *ctx = (md_parseout *) out;
+    parse_advance(p);  /* consume ( */
+    while (!parse_checktoken(p, MD_RIGHTPAREN) && !parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF))
+        parse_advance(p);
+    if (!parse_checktokenadvance(p, MD_RIGHTPAREN)) {
+        parse_error(p, false, MD_LINKEXPECTBRACKET);
+        return false;
+    }
+    while (!parse_checktoken(p, MD_NEWLINE) && !parse_checktoken(p, MD_EOF))
+        parse_advance(p);
+    if (!md_parselineend(p)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
+    md_push_paragraph(p, ctx, block_start);
+    return true;
+}
+
+/** Link definition: label and target in one TEXT token (e.g. "tag]: # (target)"). Returns true if found and sets *target_* out params. */
+static bool md_link_def_in_one_token(const char *base, const char *txt, size_t txt_len, size_t label_start,
+    size_t *label_len, size_t *target_start, size_t *target_len) {
+    const char *sep = "]: ";
+    const size_t sep_len = 3;
+    if (txt_len < sep_len) return false;
+    for (size_t i = 0; i + sep_len <= txt_len; i++) {
+        if (memcmp(txt + i, sep, sep_len) != 0) continue;
+        *label_len = i;
+        *target_start = label_start + i + sep_len;
+        *target_len = (txt_len > i + sep_len) ? (txt_len - i - sep_len) : 0;
+        while (*target_len > 0 && (base[*target_start + *target_len - 1] == '\n' || base[*target_start + *target_len - 1] == '\r'))
+            (*target_len)--;
+        return true;
+    }
+    return false;
+}
+
+/** Parses [label]: target (link def) or [text](url) (inline link). Caller has already consumed [. */
 bool md_parselink(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
-    size_t block_start = (size_t)(p->previous.start - base);  /* [ already consumed */
+    size_t block_start = (size_t)(p->previous.start - base);
 
     if (!parse_checktokenadvance(p, MD_TEXT)) {
         parse_error(p, false, MD_LINKEXPECTTEXT);
@@ -362,43 +398,32 @@ bool md_parselink(parser *p, void *out) {
     }
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
-    size_t target_start;
-    size_t target_len;
+    size_t target_start, target_len;
 
-    const char *txt = p->previous.start;
-    size_t txt_len = p->previous.length;
-    const char *sep = "]: ";
-    size_t sep_len = 3;
-    const char *found = NULL;
-    if (txt_len >= sep_len) {
-        for (size_t i = 0; i + sep_len <= txt_len; i++) {
-            if (memcmp(txt + i, sep, sep_len) == 0) { found = txt + i; break; }
-        }
+    /* Link def in one token: "label]: target" */
+    if (md_link_def_in_one_token(base, p->previous.start, p->previous.length, label_start, &label_len, &target_start, &target_len)) {
+        md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
+        return true;
     }
-    if (found != NULL) {
-        label_len = (size_t)(found - txt);
-        target_start = label_start + label_len + sep_len;
-        target_len = (txt_len > label_len + sep_len) ? (txt_len - label_len - sep_len) : 0;
-        while (target_len > 0 && (base[target_start + target_len - 1] == '\n' || base[target_start + target_len - 1] == '\r'))
-            target_len--;
-        /* Rest of line (and newline) was in the TEXT token; next token is next line */
-    } else {
-        if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) {
-            parse_error(p, false, MD_LINKEXPECTBRACKET);
-            return false;
-        }
-        if (!parse_checktokenadvance(p, MD_COLON)) {
-            parse_error(p, false, MD_LINKEXPECTCOLON);
-            return false;
-        }
-        target_start = (size_t)(p->current.start - base);
-        if (!md_parseurl(p, out)) {
-            parse_error(p, true, MD_EXPECTLINEEND);
-            return false;
-        }
-        size_t target_end = md_end_previous(p, base);
-        target_len = (target_end > target_start) ? (target_end - target_start) : 0;
+
+    if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) {
+        parse_error(p, false, MD_LINKEXPECTBRACKET);
+        return false;
     }
+    if (parse_checktoken(p, MD_LEFTPAREN))
+        return md_parseinlinelink(p, out, block_start);
+
+    if (!parse_checktokenadvance(p, MD_COLON)) {
+        parse_error(p, false, MD_LINKEXPECTCOLON);
+        return false;
+    }
+    target_start = (size_t)(p->current.start - base);
+    if (!md_parseurl(p, out)) {
+        parse_error(p, true, MD_EXPECTLINEEND);
+        return false;
+    }
+    size_t target_end = md_end_previous(p, base);
+    target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1325,20 +1325,27 @@ bool morpho_helpasmd(const char *query, varray_char *result) {
 }
 
 /** Fill out with top-level topic names (level == 1, or level == 2 when file has [toplevel] tag); each name added once (by identity). */
+/** True if topic at index i is top-level (level 1 or promoted level 2). */
+static bool help_topic_is_toplevel(unsigned int i) {
+    if (i >= s_topics.count) return false;
+    const md_topic *t = &s_topics.data[i];
+    bool include = (t->level == 1);
+    if (!include && t->file_index >= 0 && (unsigned int) t->file_index < s_files.count)
+        include = s_files.data[t->file_index].promote_subtopics;
+    return include;
+}
+
+/** Fill a varray_value with top-level topic names. */
 void morpho_helptopics(varray_value *out) {
     if (!out) return;
     help_ensureloaded();
-    for (unsigned int i = 0; i < s_topics.count; i++) {
-        const md_topic *t = &s_topics.data[i];
-        if (!MORPHO_ISSTRING(t->name)) continue;
-        bool include = (t->level == 1);
-        if (!include && t->file_index >= 0 && (unsigned int) t->file_index < s_files.count)
-            include = s_files.data[t->file_index].promote_subtopics;
-        if (!include) continue;
-        value name = t->name;
-        unsigned int idx;
-        if (varray_valuefindsame(out, name, &idx)) continue;
-        varray_valuewrite(out, name);
+    if (!s_names.contents) return;
+    for (unsigned int i = 0; i < s_names.capacity; i++) {
+        const dictionaryentry *e = &s_names.contents[i];
+        if (MORPHO_ISNIL(e->key) || !MORPHO_ISSTRING(e->key)) continue;
+        int ti = help_indexvalue_first(e->val);
+        if (ti < 0 || !help_topic_is_toplevel((unsigned int) ti)) continue;
+        varray_valuewrite(out, e->key);
     }
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -592,10 +592,6 @@ void help_sortaliases(varray_md_alias *aliases) {
 static int help_findalias(const char *name);
 
 int help_findtopic(varray_md_topic *topics, const char *name) {
-    if (!topics->data || topics->count == 0) {
-        // If no topics, check aliases
-        return help_findalias(name);
-    }
     md_topic key = { .name = (char *) name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
     md_topic *found = (md_topic *) bsearch(&key, topics->data, topics->count, sizeof(md_topic), md_topic_compare);
     if (found) return (int) (found - topics->data);
@@ -713,17 +709,18 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
  * Help topic aliases
  * ********************************************************************** */
 
-/** Find topic index by alias name. Returns -1 if not found. */
+/** Find topic index by alias name. Returns -1 if not found. Resolves topic by name so index is correct after sorting. */
 static int help_findalias(const char *name) {
     if (!s_aliases.data || s_aliases.count == 0) return -1;
-    md_alias key = { .name = (char *) name, .topic_index = 0 };
+    md_alias key = { .name = (char *) name, .topic_name = NULL };
     md_alias *found = (md_alias *) bsearch(&key, s_aliases.data, s_aliases.count, sizeof(md_alias), md_alias_compare);
-    return found ? found->topic_index : -1;
+    if (!found || !found->topic_name) return -1;
+    return help_findtopic(&s_topics, found->topic_name);
 }
 
-/** Create an alias from a tag link definition. Returns true if alias was created. */
+/** Create an alias from a tag link definition. Returns true if alias was created. Stores a pointer to the topic's name so resolution stays valid after topics are sorted. */
 static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index) {
-    if (topic_index < 0) return false;
+    if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return false;
     
     // Check if label starts with "tag"
     if (label_len < 3) return false;
@@ -745,14 +742,7 @@ static bool help_createalias(const char *base, size_t label_start, size_t label_
     for (size_t j = 0; j < len; j++) alias_name[j] = (char) tolower((unsigned char) open[j]);
     alias_name[len] = '\0';
     
-    // Check for duplicates (topics and existing aliases)
-    if (s_topics.data && s_topics.count > 0) {
-        md_topic key = { .name = alias_name, .file_index = 0, .block_index = 0, .level = 0, .parent_topic = -1 };
-        if (bsearch(&key, s_topics.data, s_topics.count, sizeof(md_topic), md_topic_compare)) {
-            MORPHO_FREE(alias_name);
-            return false;
-        }
-    }
+    // Check for duplicate alias name
     for (unsigned int j = 0; j < s_aliases.count; j++) {
         if (s_aliases.data[j].name && strcmp(s_aliases.data[j].name, alias_name) == 0) {
             MORPHO_FREE(alias_name);
@@ -760,8 +750,9 @@ static bool help_createalias(const char *base, size_t label_start, size_t label_
         }
     }
     
-    // Create alias
-    varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_index = topic_index });
+    // Store pointer to topic's name
+    const char *topic_name = s_topics.data[topic_index].name;
+    varray_md_aliaswrite(&s_aliases, (md_alias) { .name = alias_name, .topic_name = topic_name });
     return true;
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -33,7 +33,11 @@
 
 /* **********************************************************************
  * Markdown lexer
- * ********************************************************************** */
+ * **********************************************************************
+ * Token table is sorted for longest-match (e.g. ### before ## before #).
+ * The preprocessor captures any run of characters that does not match a
+ * defined token as a single MD_TEXT token. Whitespace is not skipped,
+ * so newlines and indentation are visible to the parser. */
 
 enum {
     MD_TEXT,
@@ -85,7 +89,9 @@ tokendefn mdtokens[] = {
     { "___",        MD_UNDERSCORE3              , NULL },
     { "    ",       MD_FOURSPACES               , NULL },
     { "\t",         MD_TAB                      , NULL },
+    { "\r\n",       MD_NEWLINE                  , md_lexnewline },
     { "\n",         MD_NEWLINE                  , md_lexnewline },
+    { "\r",         MD_NEWLINE                  , md_lexnewline },
     { "",           TOKEN_NONE                  , NULL }
 };
 
@@ -110,7 +116,7 @@ bool md_lexpreprocess(lexer *l, token *tok, error *err) {
  * Initialize a Markdown lexer
  * ------------------------------------------------------- */
 
-void help_initializemdlexer(lexer *l, char *src) {
+void help_initializemdlexer(lexer *l, const char *src) {
     lex_init(l, src, 0);
     lex_settokendefns(l, mdtokens);
     lex_setprefn(l, md_lexpreprocess);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -461,7 +461,7 @@ static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
     return true;
 }
 
-static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index);
+static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t paren_start, size_t paren_len, int topic_index);
 
 /** Case-insensitive comparison of substring (s, n) with literal (lit, lit_len). */
 static bool help_casencmp(const char *s, size_t n, const char *lit, size_t lit_len) {
@@ -508,7 +508,7 @@ bool md_parselink(parser *p, void *out) {
     }
     
     // Normal reference link: create alias/link block
-    help_createalias(base, label_start, label_len, target_start, target_len, ctx->current_topic_index);
+    help_createalias(base, label_start, label_len, paren_start, paren_len, ctx->current_topic_index);
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }
@@ -843,21 +843,15 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
  * Help topic aliases
  * ********************************************************************** */
 
-/** Create an alias from a tag link definition. Inserts alias -> topic index into s_names. */
-static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index) {
+/** Create an alias from a tag link definition. Inserts alias -> topic index into s_names.
+ *  Alias text is the parenthesized part from the URL (e.g. [tagvar]: # (var) -> "var"). Requires paren_len > 0. */
+static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t paren_start, size_t paren_len, int topic_index) {
     if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return false;
     if (label_len < 3 || !help_casencmp(base + label_start, 3, "tag", 3)) return false;
-    const char *target = base + target_start, *open = NULL, *close = NULL;
-    for (const char *p = target; p < target + target_len && !close; p++) {
-        if (!open && *p == '(') open = p + 1;
-        else if (open && *p == ')') { close = p; break; }
-    }
-    if (!open || !close || close == open) return false;
-    size_t len = (size_t)(close - open);
-    if (len > MORPHO_MAX_HELPQUERY_LENGTH) return false;
-    char alias_buf[len + 1];
-    help_lowercase_into(open, len, alias_buf);
-    return !MORPHO_ISNIL(help_nameindex_add(alias_buf, len, topic_index));
+    if (paren_len == 0 || paren_len > MORPHO_MAX_HELPQUERY_LENGTH) return false;
+    char alias_buf[paren_len + 1];
+    help_lowercase_into(base + paren_start, paren_len, alias_buf);
+    return !MORPHO_ISNIL(help_nameindex_add(alias_buf, paren_len, topic_index));
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1245,12 +1245,16 @@ void help_queryhint(const char *query, varray_char *result) {
 
 static bool s_help_files_loaded = false;
 
-/** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
-bool morpho_helpastopic(const char *query, help_topic *out) {
-    if (!s_help_files_loaded) { // Load help files on first use
+static void help_ensureloaded(void) {
+    if (!s_help_files_loaded) {
         help_findfiles();
         s_help_files_loaded = true;
     }
+}
+
+/** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
+bool morpho_helpastopic(const char *query, help_topic *out) {
+    help_ensureloaded();
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
     int nsegs = help_parsequery(query, qbuf, segs);
@@ -1299,6 +1303,19 @@ bool morpho_helpasmd(const char *query, varray_char *result) {
     if (morpho_helpastopic(query, &t)) return help_topicrawmd(&t, result);
     help_queryhint(query, result);
     return false;
+}
+
+/** Fill out with top-level topic names (level == 1); each name added once (by identity). */
+void morpho_helptopics(varray_value *out) {
+    if (!out) return;
+    help_ensureloaded();
+    for (unsigned int i = 0; i < s_topics.count; i++) {
+        if (s_topics.data[i].level != 1 || !MORPHO_ISSTRING(s_topics.data[i].name)) continue;
+        value name = s_topics.data[i].name;
+        unsigned int idx;
+        if (varray_valuefindsame(out, name, &idx)) continue;
+        varray_valuewrite(out, name);
+    }
 }
 
 /* **********************************************************************

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -68,24 +68,6 @@ enum {
     MD_EOF
 };
 
-/* Markdown parser error codes (registered in help_initialize) */
-#define MD_UNCLOSEDITALIC       "MDUnclItal"
-#define MD_UNCLOSEDITALIC_MSG   "Unclosed italic (missing closing * or _)."
-#define MD_UNCLOSEDINLINECODE   "MDUnclCode"
-#define MD_UNCLOSEDINLINECODE_MSG "Unclosed inline code (missing closing `)."
-#define MD_EXPECTLINEEND        "MDExpLnEnd"
-#define MD_EXPECTLINEEND_MSG    "Expected end of line."
-#define MD_EXPECTHEADERTEXT     "MDExpHdrTxt"
-#define MD_EXPECTHEADERTEXT_MSG "Expected header text after #."
-#define MD_LINKEXPECTTEXT       "MDLnkExpTxt"
-#define MD_LINKEXPECTTEXT_MSG   "Link definition expects label text after [."
-#define MD_LINKEXPECTBRACKET    "MDLnkExpBr"
-#define MD_LINKEXPECTBRACKET_MSG "Link definition expects ] after label."
-#define MD_LINKEXPECTCOLON      "MDLnkExpCol"
-#define MD_LINKEXPECTCOLON_MSG  "Link definition expects : after ]."
-#define MD_UNEXPECTEDTOKEN      "MDUnexpTok"
-#define MD_UNEXPECTEDTOKEN_MSG  "Unexpected markdown token."
-
 bool md_lexnewline(lexer *l, token *tok, error *err) {
     lex_newline(l);
     return true;
@@ -256,6 +238,7 @@ tokentype _literalintext[] = {
 };
 int _nliteralintext = sizeof(_literalintext)/sizeof(tokentype);
 
+/** True if current token can be consumed as text (MD_TEXT or inline formatting tokens). */
 bool md_checktexttoken(parser *p) {
     return parse_checktokenmulti(p, _ninlinetokens, _inlinetokens);
 }
@@ -388,25 +371,25 @@ bool md_parselink(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);
 
-    if (!parse_checktokenadvance(p, MD_TEXT)) {
+    if (!parse_checktokenadvance(p, MD_TEXT)) { // Parse label text
         parse_error(p, false, MD_LINKEXPECTTEXT);
         return false;
     }
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
 
-    if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) {
+    if (!parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE)) { // Parse closing ]
         parse_error(p, false, MD_LINKEXPECTBRACKET);
         return false;
     }
-    if (parse_checktoken(p, MD_LEFTPAREN)) return md_parseinlinelink(p, out, block_start);
+    if (parse_checktoken(p, MD_LEFTPAREN)) return md_parseinlinelink(p, out, block_start); // Inline link [text](url)
 
-    if (!parse_checktokenadvance(p, MD_COLON)) {
+    if (!parse_checktokenadvance(p, MD_COLON)) { // Parse : for link definition
         parse_error(p, false, MD_LINKEXPECTCOLON);
         return false;
     }
     size_t target_start = (size_t)(p->current.start - base);
-    if (!md_parseurl(p, out)) {
+    if (!md_parseurl(p, out)) { // Parse target URL until newline/EOF
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }
@@ -965,53 +948,8 @@ void help_findfiles(void) {
 }
 
 /* **********************************************************************
- * Help API
+ * Hints for failed queries
  * ********************************************************************** */
-
-static bool s_help_files_loaded = false;
-
-/** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
-bool morpho_helpastopic(const char *query, help_topic *out) {
-    if (!s_help_files_loaded) { // Load help files on first use
-        help_findfiles();
-        s_help_files_loaded = true;
-    }
-    char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
-    const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
-    int nsegs = help_parsequery(query, qbuf, segs);
-    if (nsegs <= 0) return false;
-
-    // Single segment: resolve by name; fail if 0 or multiple matches (caller shows hint)
-    int idx;
-    if (nsegs == 1) {
-        int multi[MORPHO_HELP_MAX_MULTIMATCH];
-        int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
-        if (n == 1) {
-            idx = multi[0];
-        } else if (n == 0) {
-            idx = help_findtopic(&s_topics, segs[0]);  /* fallback: bsearch by name */
-            if (idx < 0) return false;
-        } else {
-            return false;  /* multiple matches: caller will show hint */
-        }
-    } else {
-        idx = help_findtopic(&s_topics, segs[0]);
-        if (idx < 0) return false;
-    }
-
-    // Resolve remaining segments as subtopics
-    for (int i = 1; i < nsegs; i++) {
-        idx = help_findsubtopic(idx, segs[i]);
-        if (idx < 0) return false;
-    }
-
-    const md_topic *topic = &s_topics.data[idx];
-    if (topic->file_index < 0 || (unsigned int) topic->file_index >= s_files.count) return false;
-    const md_file *file = &s_files.data[topic->file_index];
-    if (topic->block_index >= file->blocks.count) return false;
-    help_topicfill(out, topic, file);
-    return true;
-}
 
 /** Append "Topic 'query' not found [. Did you mean 'suggest'?]." to result. suggest is full path or NULL. */
 static void help_hintappend(varray_char *result, const char *query, const char *suggest) {
@@ -1100,6 +1038,55 @@ static void help_queryhint(const char *query, varray_char *result) {
         }
     }
     varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
+}
+
+/* **********************************************************************
+ * Help API
+ * ********************************************************************** */
+
+static bool s_help_files_loaded = false;
+
+/** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
+bool morpho_helpastopic(const char *query, help_topic *out) {
+    if (!s_help_files_loaded) { // Load help files on first use
+        help_findfiles();
+        s_help_files_loaded = true;
+    }
+    char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
+    const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
+    int nsegs = help_parsequery(query, qbuf, segs);
+    if (nsegs <= 0) return false;
+
+    // Single segment: resolve by name; fail if 0 or multiple matches (caller shows hint)
+    int idx;
+    if (nsegs == 1) {
+        int multi[MORPHO_HELP_MAX_MULTIMATCH];
+        int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
+        if (n == 1) {
+            idx = multi[0];
+        } else if (n == 0) {
+            idx = help_findtopic(&s_topics, segs[0]);  /* fallback: bsearch by name */
+            if (idx < 0) return false;
+        } else {
+            return false;  /* multiple matches: caller will show hint */
+        }
+    } else {
+        idx = help_findtopic(&s_topics, segs[0]);
+        if (idx < 0) return false;
+    }
+
+    // Resolve remaining segments as subtopics
+    for (int i = 1; i < nsegs; i++) {
+        idx = help_findsubtopic(idx, segs[i]);
+        if (idx < 0) return false;
+    }
+
+    const md_topic *topic = &s_topics.data[idx];
+    if (topic->file_index < 0 || (unsigned int) topic->file_index >= s_files.count) return false;
+    const md_file *file = &s_files.data[topic->file_index];
+    if (topic->block_index >= file->blocks.count) return false;
+    help_topicfill(out, topic, file);
+    return true;
 }
 
 bool morpho_helpastext(char *query, varray_char *result) {

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -437,6 +437,14 @@ static bool md_parseinlinelink(parser *p, void *out, size_t block_start) {
 
 static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index);
 
+/** Case-insensitive comparison of substring (s, n) with literal (lit, lit_len). */
+static bool help_casencmp(const char *s, size_t n, const char *lit, size_t lit_len) {
+    if (n != lit_len) return false;
+    for (size_t i = 0; i < n; i++)
+        if (tolower((unsigned char) s[i]) != (unsigned char) lit[i]) return false;
+    return true;
+}
+
 /** Parses [label]: target (link def) or [text](url) an inline link. Caller has already consumed [. */
 bool md_parselink(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
@@ -468,9 +476,8 @@ bool md_parselink(parser *p, void *out) {
     size_t target_end = md_end_previous(p, base);
     size_t target_len = target_end > target_start ? (size_t)(target_end - target_start) : 0;
     
-    // Check if this is a tag link definition and create alias if so
+    if (help_casencmp(base + label_start, label_len, "toplevel", 8)) ctx->file->promote_subtopics = true;
     help_createalias(base, label_start, label_len, target_start, target_len, ctx->current_topic_index);
-    
     md_push_link(p, ctx, block_start, label_start, label_len, target_start, target_len);
     return true;
 }
@@ -551,6 +558,7 @@ void md_file_init(md_file *f) {
     f->source = NULL;
     f->sourcelen = 0;
     f->filename = NULL;
+    f->promote_subtopics = false;
     varray_md_blockinit(&f->blocks);
 }
 
@@ -807,9 +815,7 @@ static void md_push_link(parser *p, md_parseout *out, size_t block_start, size_t
 /** Create an alias from a tag link definition. Inserts alias -> topic index into s_names. */
 static bool help_createalias(const char *base, size_t label_start, size_t label_len, size_t target_start, size_t target_len, int topic_index) {
     if (topic_index < 0 || (unsigned int) topic_index >= s_topics.count) return false;
-    if (label_len < 3) return false;
-    const char *label = base + label_start;
-    if (tolower((unsigned char) label[0]) != 't' || tolower((unsigned char) label[1]) != 'a' || tolower((unsigned char) label[2]) != 'g') return false;
+    if (label_len < 3 || !help_casencmp(base + label_start, 3, "tag", 3)) return false;
     const char *target = base + target_start, *open = NULL, *close = NULL;
     for (const char *p = target; p < target + target_len && !close; p++) {
         if (!open && *p == '(') open = p + 1;
@@ -1305,13 +1311,18 @@ bool morpho_helpasmd(const char *query, varray_char *result) {
     return false;
 }
 
-/** Fill out with top-level topic names (level == 1); each name added once (by identity). */
+/** Fill out with top-level topic names (level == 1, or level == 2 when file has [toplevel] tag); each name added once (by identity). */
 void morpho_helptopics(varray_value *out) {
     if (!out) return;
     help_ensureloaded();
     for (unsigned int i = 0; i < s_topics.count; i++) {
-        if (s_topics.data[i].level != 1 || !MORPHO_ISSTRING(s_topics.data[i].name)) continue;
-        value name = s_topics.data[i].name;
+        const md_topic *t = &s_topics.data[i];
+        if (!MORPHO_ISSTRING(t->name)) continue;
+        bool include = (t->level == 1);
+        if (!include && t->file_index >= 0 && (unsigned int) t->file_index < s_files.count)
+            include = s_files.data[t->file_index].promote_subtopics;
+        if (!include) continue;
+        value name = t->name;
         unsigned int idx;
         if (varray_valuefindsame(out, name, &idx)) continue;
         varray_valuewrite(out, name);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -219,6 +219,7 @@ bool md_parsetext(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->current.start - base);
 
+    // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers
     while (md_checktexttoken(p)) {
         parse_advance(p);
         parserule *rule = parse_getrule(p, p->previous.type);
@@ -263,7 +264,7 @@ bool md_parselist(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* *, +, or - already consumed */
 
-    /* Reuse text parsing but record as list block */
+    // Reuse text parsing (inline rules) but record as list block
     while (md_checktexttoken(p)) {
         parse_advance(p);
         parserule *rule = parse_getrule(p, p->previous.type);
@@ -291,13 +292,12 @@ bool md_parselink(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* [ already consumed */
 
+    // [ label ] : then rest of line (target)
     PARSE_CHECK(parse_checktokenadvance(p, MD_TEXT));
     size_t label_start = (size_t)(p->previous.start - base);
     size_t label_len = p->previous.length;
-
     PARSE_CHECK(parse_checktokenadvance(p, MD_RIGHTSQUAREBRACE));
     PARSE_CHECK(parse_checktokenadvance(p, MD_COLON));
-
     size_t target_start = (size_t)(p->current.start - base);
     PARSE_CHECK(md_parseurl(p, out));
     size_t target_end = md_end_previous(p, base);
@@ -307,9 +307,10 @@ bool md_parselink(parser *p, void *out) {
     return true;
 }
 
-/** Parse a markdown 'block'  */
+/** Parse a markdown 'block' */
 bool md_parseblock(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
+    // Dispatch by first token: text, #/##/###, indent, list, [link], newline, EOF
     if (md_checktexttoken(p)) {
         return md_parsetext(p, out);
     } else if (parse_checktokenadvance(p, MD_HASH)) {
@@ -459,7 +460,7 @@ static void md_push_header(parser *p, md_parseout *out, size_t block_start, size
     md_block_set_header(&b, out->current_header_level, title_start, title_len);
     varray_md_blockwrite(&out->file->blocks, b);
 
-    /* Topic: lowercase name from trimmed title span */
+    // Topic: trimmed title span, lowercased, for index lookup
     size_t ns = title_start, nl = title_len;
     md_trimspan(base, &ns, &nl);
     char *name = (char *) MORPHO_MALLOC(nl + 1);
@@ -513,6 +514,7 @@ static varray_md_topic s_topics;
 
 /** Parse query into lowercased segments in qbuf; segs[] points into qbuf. Returns nsegs (0 if none). */
 static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
+    // Copy query, lowercase, replace '.' and ' ' with nul
     size_t qlen = 0;
     while (query[qlen] && qlen < MORPHO_MAX_HELPQUERY_LENGTH - 1) {
         char c = query[qlen];
@@ -520,6 +522,7 @@ static int help_parsequery(const char *query, char *qbuf, const char *segs[]) {
         qlen++;
     }
     qbuf[qlen] = '\0';
+    // Collect segment start pointers (skip nuls, take runs)
     int nsegs = 0;
     const char *p = qbuf;
     while (nsegs < MORPHO_HELP_QUERY_MAXSEGMENTS && p < qbuf + qlen) {
@@ -537,6 +540,7 @@ static int help_findparent(int idx) {
     const md_topic *t = &s_topics.data[idx];
     int level = t->level;
     if (level <= 1) return -1;
+    // Same file, strictly earlier block, lower level; keep one with largest block_index
     int parent = -1;
     unsigned int best_block = 0;
     for (unsigned int i = 0; i < s_topics.count; i++) {
@@ -558,10 +562,12 @@ static void help_topic_displaypath(int idx, char *buf, size_t bufsize) {
     if (!t->name) { buf[0] = '\0'; return; }
     int p = (t->level > 1) ? help_findparent(idx) : -1;
     if (p >= 0) {
+        // Recurse for parent path, then append ".name"
         help_topic_displaypath(p, buf, bufsize);
         size_t len = strlen(buf);
         if (len + 1 < bufsize) snprintf(buf + len, bufsize - len, ".%s", t->name);
     } else {
+        // Top-level or no parent: just the topic name
         size_t n = strlen(t->name);
         if (n >= bufsize) n = bufsize - 1;
         memcpy(buf, t->name, n);
@@ -609,10 +615,11 @@ static int help_findsubtopic(int parent_idx, const char *name) {
     const char *base = file->source;
     size_t base_len = file->sourcelen;
 
+    // Scan blocks after parent; stop when we hit same-or-higher level (left section)
     for (unsigned int i = parent->block_index + 1; i < file->blocks.count; i++) {
         const md_block *b = &file->blocks.data[i];
         if (b->type != MD_BLOCK_HEADER) continue;
-        if (b->as.header.level <= parent->level) return -1; /* left section */
+        if (b->as.header.level <= parent->level) return -1;  // left section
         size_t start = b->as.header.title.start;
         size_t len = b->as.header.title.length;
         if (start + len > base_len) len = base_len - start;
@@ -628,6 +635,7 @@ static unsigned int help_editdistance(const char *a, const char *b) {
     if (na == 0) return (unsigned int) nb;
     if (nb == 0) return (unsigned int) na;
     if (na > MORPHO_HELP_EDITMAXLEN || nb > MORPHO_HELP_EDITMAXLEN) return MORPHO_HELP_EDIT_NOMATCH;
+    // Two-row DP: prev row and current row, swap each iteration
     unsigned int row0[MORPHO_HELP_EDITMAXLEN + 1], row1[MORPHO_HELP_EDITMAXLEN + 1];
     unsigned int *prev = row0, *curr = row1;
     for (size_t j = 0; j <= nb; j++) prev[j] = (unsigned int) j;
@@ -682,6 +690,7 @@ static unsigned int help_topiccontentnblocks(const md_topic *topic, const md_fil
     unsigned int i = topic->block_index;
     unsigned int n = file->blocks.count;
     int level = topic->level;
+    // Advance until we hit a header at same or higher level (or end of file)
     while (i < n) {
         const md_block *b = &file->blocks.data[i];
         if (b->type == MD_BLOCK_HEADER && b->as.header.level <= level && i > topic->block_index)
@@ -717,13 +726,13 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
         size_t len = b->span.length;
         if (b->span.start + len > src_len) len = src_len - b->span.start;
 
+        // Per-block: header (title only, no #), paragraph/list/code (span), link/blank skip
         switch (b->type) {
             case MD_BLOCK_HEADER: {
-                /* Skip leading # and space for plain text */
                 const char *p = src + b->as.header.title.start;
                 size_t tlen = b->as.header.title.length;
                 if (b->as.header.title.start + tlen > src_len) tlen = src_len - b->as.header.title.start;
-                while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; }
+                while (tlen && (*p == '#' || (unsigned char)*p <= ' ')) { p++; tlen--; }  // strip leading # and space
                 if (tlen > 0) varray_charadd(result, p, (int) tlen);
                 varray_charadd(result, "\n\n", 2);
                 break;
@@ -736,7 +745,7 @@ bool help_topictotext(const help_topic *t, varray_char *result) {
                 break;
             case MD_BLOCK_LINK_DEF:
             case MD_BLOCK_BLANK:
-                break;
+                break;  // omit from plain text
         }
     }
     return true;
@@ -761,17 +770,14 @@ bool help_topicrawmd(const help_topic *t, varray_char *result) {
 bool help_parse(md_file *file, varray_md_topic *topics, int file_index) {
     error err;
     error_init(&err);
-
     md_parseout parseout = {
         .file = file,
         .topics = topics,
         .file_index = file_index,
         .current_header_level = 1
     };
-
     lexer l;
     help_initializemdlexer(&l, file->source);
-
     parser p;
     help_initializemdparser(&p, &l, &err, &parseout);
     bool ok = parse(&p);
@@ -796,6 +802,7 @@ bool help_load(char *filename) {
         return false;
     }
     fclose(f);
+    // Steal buffer into md_file; parse appends topics to s_topics
     md_file mdfile;
     md_file_init(&mdfile);
     mdfile.source = contents.data;
@@ -810,7 +817,6 @@ bool help_load(char *filename) {
 void help_findfiles(void) {
     varray_value files;
     varray_valueinit(&files);
-
     if (morpho_listresources(MORPHO_RESOURCE_HELP, &files)) {
         for (unsigned int i = 0; i < files.count; i++) {
             if (MORPHO_ISSTRING(files.data[i])) help_load(MORPHO_GETCSTRING(files.data[i]));
@@ -818,7 +824,6 @@ void help_findfiles(void) {
         for (unsigned int i = 0; i < files.count; i++) morpho_freeobject(files.data[i]);
     }
     varray_valueclear(&files);
-
     help_sorttopics(&s_topics);
 }
 
@@ -833,19 +838,20 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs <= 0) return false;
 
+    // Single segment: resolve by name; fail if 0 or multiple matches (caller shows hint)
     int idx;
     if (nsegs == 1) {
         int multi[MORPHO_HELP_MAX_MULTIMATCH];
         int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
         if (n == 0) return false;
-        if (n >= 2) return false; /* multiple matches: caller will show hint */
+        if (n >= 2) return false;  // multiple matches: caller will show hint
         idx = multi[0];
     } else {
         idx = help_findtopic(&s_topics, segs[0]);
         if (idx < 0) return false;
     }
 
-    /* Resolve remaining segments as subtopics. */
+    // Resolve remaining segments as subtopics
     for (int i = 1; i < nsegs; i++) {
         idx = help_findsubtopic(idx, segs[i]);
         if (idx < 0) return false;
@@ -855,7 +861,6 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     if (topic->file_index < 0 || (unsigned int) topic->file_index >= s_files.count) return false;
     const md_file *file = &s_files.data[topic->file_index];
     if (topic->block_index >= file->blocks.count) return false;
-
     help_topicfill(out, topic, file);
     return true;
 }
@@ -874,6 +879,7 @@ static void help_hintappend_multi(varray_char *result, const char *query, int in
     char buf[MORPHO_HELP_HINTBUFSIZE];
     char path[MORPHO_MAX_HELPQUERY_LENGTH];
     int n = snprintf(buf, sizeof(buf), "Topic '%s' had multiple matches: did you mean ", query);
+    // First: "'A'"; middle: ", 'B'"; last: " or 'C'?"
     for (int i = 0; i < count && n < (int) sizeof(buf) - 4; i++) {
         help_topic_displaypath(indices[i], path, sizeof(path));
         if (i == 0)
@@ -896,6 +902,7 @@ static void help_queryhint(const char *query, varray_char *result) {
         varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
         return;
     }
+    // Single segment: multi-match hint, or "not found" + closest, or NOTFOUND
     if (nsegs == 1) {
         int multi[MORPHO_HELP_MAX_MULTIMATCH];
         int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
@@ -910,6 +917,7 @@ static void help_queryhint(const char *query, varray_char *result) {
         varray_charadd(result, MORPHO_HELP_NOTFOUND, (int) (sizeof(MORPHO_HELP_NOTFOUND) - 1));
         return;
     }
+    // Multi-segment: resolve first, then walk subtopics; on first failure suggest path.closest
     int idx = help_findtopic(&s_topics, segs[0]);
     if (idx < 0) {
         help_hintappend(result, query, help_findclosesttopic(segs[0]));
@@ -934,6 +942,7 @@ static void help_queryhint(const char *query, varray_char *result) {
             return;
         }
         idx = next;
+        // Append "." + segs[i] to path for next level
         if (path_len > 0 && path_len < (int) sizeof(path) - 1) {
             path[path_len++] = '.';
             int seglen = (int) strlen(segs[i]);

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1045,7 +1045,7 @@ static void help_hintappend_multi(varray_char *result, const char *query, int in
 }
 
 /** Build a hint for a failed query and append to result (caller may clear result first). */
-static void help_queryhint(const char *query, varray_char *result) {
+void help_queryhint(const char *query, varray_char *result) {
     if (!result) return;
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -712,14 +712,12 @@ int help_findallbyname(const char *name, int indices[], int max) {
     return help_indexvalue_collect(v, indices, max);
 }
 
-/** Find child of parent topic with given name. Returns topic index or -1. */
+/** Find child of parent topic with given name. Returns topic index or -1. Uses s_names then filters by parent. */
 static int help_findchild(int parent_idx, const char *name) {
-    objectstring key_str = MORPHO_STATICSTRING(name);
-    value key = MORPHO_OBJECT(&key_str);
-    for (unsigned int j = 0; j < s_topics.count; j++) {
-        if (s_topics.data[j].parent_topic != parent_idx) continue;
-        if (MORPHO_ISEQUAL(s_topics.data[j].name, key)) return (int) j;
-    }
+    int cand[MORPHO_HELP_MAX_MULTIMATCH];
+    int n = help_findallbyname(name, cand, MORPHO_HELP_MAX_MULTIMATCH);
+    for (int i = 0; i < n; i++)
+        if (s_topics.data[cand[i]].parent_topic == parent_idx) return cand[i];
     return -1;
 }
 
@@ -858,11 +856,6 @@ static bool help_createalias(const char *base, size_t label_start, size_t label_
  * Help topic lookup and content range
  * ********************************************************************** */
 
-/** Maximum number of query segments (e.g. "System respondsto" -> 2). */
-#define MORPHO_HELP_QUERY_MAXSEGMENTS 8
-#define MORPHO_HELP_MAX_MULTIMATCH 8
-/** Max edit distance to suggest a topic (only suggest if close enough). */
-#define MORPHO_HELP_SUGGEST_MAXDIST 3
 /** Edit distance return when string too long (no match). */
 #define MORPHO_HELP_EDIT_NOMATCH 255
 
@@ -1279,24 +1272,12 @@ bool morpho_helpastopic(const char *query, help_topic *out) {
     int nsegs = help_parsequery(query, qbuf, segs);
     if (nsegs <= 0) return false;
 
-    // Single segment: dict gives 0, 1, or many; if many caller shows "did you mean?"
-    int idx;
-    if (nsegs == 1) {
-        int multi[MORPHO_HELP_MAX_MULTIMATCH];
-        int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
-        if (n == 1) {
-            idx = multi[0];
-        } else if (n == 0) {
-            return false;
-        } else {
-            return false; // multiple matches: caller shows hint
-        }
-    } else {
-        idx = help_findtopic(segs[0]); // first match
-        if (idx < 0) return false;
-    }
+    int multi[MORPHO_HELP_MAX_MULTIMATCH];
+    int n = help_findallbyname(segs[0], multi, MORPHO_HELP_MAX_MULTIMATCH);
+    if (n == 0) return false;
+    if (nsegs == 1 && n != 1) return false; /* single segment needs unique match; multiple -> caller shows hint */
+    int idx = multi[0];
 
-    // Resolve remaining segments by walking children
     for (int i = 1; i < nsegs; i++) {
         idx = help_findchild(idx, segs[i]);
         if (idx < 0) return false;
@@ -1324,7 +1305,6 @@ bool morpho_helpasmd(const char *query, varray_char *result) {
     return false;
 }
 
-/** Fill out with top-level topic names (level == 1, or level == 2 when file has [toplevel] tag); each name added once (by identity). */
 /** True if topic at index i is top-level (level 1 or promoted level 2). */
 static bool help_topic_is_toplevel(unsigned int i) {
     if (i >= s_topics.count) return false;

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -964,8 +964,14 @@ void help_findfiles(void) {
  * Help API
  * ********************************************************************** */
 
+static bool s_help_files_loaded = false;
+
 /** Interface to the morpho help system. Query may be "Topic" or "Topic subtopic" / "Topic.subtopic". */
 bool morpho_helpastopic(const char *query, help_topic *out) {
+    if (!s_help_files_loaded) { // Load help files on first use
+        help_findfiles();
+        s_help_files_loaded = true;
+    }
     char qbuf[MORPHO_MAX_HELPQUERY_LENGTH];
     const char *segs[MORPHO_HELP_QUERY_MAXSEGMENTS];
     int nsegs = help_parsequery(query, qbuf, segs);
@@ -1124,7 +1130,6 @@ void help_initialize(void) {
 
     varray_md_fileinit(&s_files);
     varray_md_topicinit(&s_topics);
-    help_findfiles();
     morpho_addfinalizefn(help_finalize);
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -36,7 +36,7 @@ DEFINE_VARRAY(md_topic, md_topic);
 
 static varray_md_file s_files;
 static varray_md_topic s_topics;
-static dictionary s_names; // Map names or aliases to topic index or list of indices
+static dictionary s_names;  /* name (interned on build) -> topic index or list of indices */
 
 /** The interactive help system uses a collection of Markdown files, located in
  *  MORPHO_HELPFOLDER, that define available topics. Help files are all
@@ -568,23 +568,35 @@ void md_file_clear(md_file *f) {
  * Name index (single dict: name/alias -> index or List of indices)
  * ------------------------------------------------------- */
 
-/** Build s_names from topic names (value = index or List). Call once after all files loaded and parent_topic set. Aliases may already be in dict from parse. */
+/** Build s_names from topic names; intern names into s_names (one string per distinct name). Call once after all files loaded and parent_topic set. Aliases may already be in dict from parse. */
 static void help_buildnameindex(void) {
     for (unsigned int i = 0; i < s_topics.count; i++) {
         if (!MORPHO_ISSTRING(s_topics.data[i].name)) continue;
         value key = s_topics.data[i].name;
-        value v;
-        if (!dictionary_get(&s_names, key, &v)) {
+        value interned = dictionary_intern(&s_names, key);
+        if (MORPHO_ISNIL(interned)) {
             dictionary_insert(&s_names, key, MORPHO_INTEGER((int) i));
+            s_topics.data[i].name = key;
             continue;
         }
-        if (MORPHO_ISINTEGER(v) && MORPHO_GETINTEGERVALUE(v) == (int) i) continue; // already points to this topic
+        if (!MORPHO_ISSAME(interned, key)) morpho_freeobject(key);
+        s_topics.data[i].name = interned;
+        value v;
+        if (!dictionary_get(&s_names, interned, &v)) continue;
+        if (MORPHO_ISNIL(v)) {
+            dictionary_insert(&s_names, interned, MORPHO_INTEGER((int) i));
+            continue;
+        }
+        if (MORPHO_ISINTEGER(v) && MORPHO_GETINTEGERVALUE(v) == (int) i) continue; /* already this topic */
         objectlist *list;
         if (MORPHO_ISINTEGER(v)) {
             list = object_newlist(0, NULL);
             if (!list) continue;
             list_append(list, v);
-            dictionary_insert(&s_names, key, MORPHO_OBJECT(list));
+            if (!dictionary_insert(&s_names, interned, MORPHO_OBJECT(list))) {
+                morpho_freeobject(MORPHO_OBJECT(list));
+                continue;
+            }
         } else list = MORPHO_GETLIST(v);
         list_append(list, MORPHO_INTEGER((int) i));
     }
@@ -603,21 +615,22 @@ static int help_indexvalue_first(value v) {
     return -1;
 }
 
-/** Fill indices[] from dict value (integer or list). Returns count. */
+/** Fill indices[] from dict value (integer or list). Returns number of indices written (at most max). */
 static int help_indexvalue_collect(value v, int indices[], int max) {
     if (MORPHO_ISINTEGER(v)) {
         if (max > 0) indices[0] = MORPHO_GETINTEGERVALUE(v);
         return 1;
     } else if (MORPHO_ISLIST(v)) {
         objectlist *list = MORPHO_GETLIST(v);
-        unsigned int n = list_length(list);
-        if ((int) n > max) n = (unsigned int) max;
-        for (unsigned int i = 0; i < n; i++) {
+        unsigned int list_len = list_length(list);
+        int written = 0;
+        for (unsigned int i = 0; i < list_len && written < max; i++) {
             value el;
-            if (list_getelement(list, (int) i, &el) && MORPHO_ISINTEGER(el))
-                indices[i] = MORPHO_GETINTEGERVALUE(el);
+            if (list_getelement(list, (int) i, &el) && MORPHO_ISINTEGER(el)) {
+                indices[written++] = MORPHO_GETINTEGERVALUE(el);
+            }
         }
-        return (int) list_length(list);
+        return written;
     }
     return 0;
 }
@@ -1091,9 +1104,12 @@ bool help_load(char *filename) {
         varray_md_filewrite(&s_files, mdfile);
     } else {
         md_file_clear(&mdfile);
-        // Remove topics added during the failed parse; they have file_index = s_files.count
-        while (s_topics.count > n_topics_before)
+        // Remove topics added during the failed parse; free their names (never interned).
+        while (s_topics.count > n_topics_before) {
+            unsigned int i = s_topics.count - 1;
+            if (MORPHO_ISOBJECT(s_topics.data[i].name)) morpho_freeobject(s_topics.data[i].name);
             s_topics.count--;
+        }
     }
     return ok;
 }
@@ -1290,14 +1306,14 @@ void help_initialize(void) {
     morpho_addfinalizefn(help_finalize);
 }
 
-/** @brief Finalization: free all files and topics. Name keys not owned; free List values then clear dict. */
+/** @brief Finalization: free all files, topics, and name index. */
 void help_finalize(void) {
     for (unsigned int i = 0; i < s_files.count; i++)
         md_file_clear(&s_files.data[i]);
     varray_md_fileclear(&s_files);
-    varray_md_topicclear(&s_topics);
-    dictionary_freecontents(&s_names, false, true); /* free List values; keys (names) are VM-owned */
+    dictionary_freecontents(&s_names, true, true);
     dictionary_clear(&s_names);
+    varray_md_topicclear(&s_topics);
 }
 
 #endif

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -247,6 +247,24 @@ static bool md_checkliteralintext(parser *p) {
     return parse_checktokenmulti(p, _nliteralintext, _literalintext);
 }
 
+/** Consume text content tokens (MD_TEXT and literal tokens like - : etc.). 
+ * If apply_inline_rules is true, applies inline formatting rules (bold/italic/code) to MD_TEXT tokens.
+ * Returns true if we should continue consuming (more text/literal available), false if we hit non-text/non-literal. */
+static bool md_consumetextcontent(parser *p, bool apply_inline_rules, void *out) {
+    if (md_checktexttoken(p)) {
+        parse_advance(p);
+        if (apply_inline_rules) {
+            parserule *rule = parse_getrule(p, p->previous.type);
+            if (rule && rule->prefix && !rule->prefix(p, out)) return false;
+        }
+        return true;
+    } else if (md_checkliteralintext(p)) {
+        parse_advance(p);
+        return true;
+    }
+    return false;
+}
+
 /** Parses text written in markdown; stops at a non-textual token. Line ends with NEWLINE or EOF. */
 bool md_parsetext(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
@@ -254,18 +272,8 @@ bool md_parsetext(parser *p, void *out) {
     size_t block_start = (size_t)(p->current.start - base);
 
     for (;;) {
-        /* Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers. */
-        while (md_checktexttoken(p)) {
-            parse_advance(p);
-            parserule *rule = parse_getrule(p, p->previous.type);
-            if (rule && rule->prefix && !rule->prefix(p, out)) return false;
-        }
+        while (md_consumetextcontent(p, true, out));
         if (md_parselineend(p)) break;
-        // Allow block-style tokens to appear literally in prose (e.g. "+" in "minimization + retriangulation").
-        if (md_checkliteralintext(p)) {
-            parse_advance(p);
-            continue;
-        }
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }
@@ -273,7 +281,7 @@ bool md_parsetext(parser *p, void *out) {
     return true;
 }
 
-/** Parses a markdown header (title then newline or EOF). Accepts one or more MD_TEXT tokens for the title. */
+/** Parses a markdown header (title then newline or EOF). Accepts MD_TEXT and literal tokens (e.g. - for hyphen) for the title. */
 bool md_parseheader(parser *p, void *out) {
     md_parseout *ctx = (md_parseout *) out;
     const char *base = ctx->file->source;
@@ -285,7 +293,7 @@ bool md_parseheader(parser *p, void *out) {
     }
     size_t title_start = (size_t)(p->previous.start - base);
     size_t title_len = p->previous.length;
-    while (parse_checktokenadvance(p, MD_TEXT)) {
+    while (md_consumetextcontent(p, false, out)) {
         title_len = (size_t)((p->previous.start - base) + p->previous.length - title_start);
     }
 
@@ -318,20 +326,8 @@ bool md_parselist(parser *p, void *out) {
     size_t block_start = (size_t)(p->previous.start - base);  /* *, +, or - already consumed */
 
     for (;;) {
-        // Reuse text parsing (inline rules) but record as list block
-        while (md_checktexttoken(p)) {
-            parse_advance(p);
-            parserule *rule = parse_getrule(p, p->previous.type);
-            if (rule && rule->prefix) {
-                if (!rule->prefix(p, out)) return false;
-            }
-        }
+        while (md_consumetextcontent(p, true, out));
         if (md_parselineend(p)) break;
-        // Allow block-style tokens literally in list item (e.g. "+" in "minimization + retriangulation").
-        if (md_checkliteralintext(p)) {
-            parse_advance(p);
-            continue;
-        }
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -622,7 +622,10 @@ static value help_nameindex_add(const char *buf, size_t len, int topic_index) {
     }
     value name_val = object_stringfromcstring(buf, len);
     if (!MORPHO_ISSTRING(name_val)) return MORPHO_NIL;
-    dictionary_insert(&s_names, name_val, MORPHO_INTEGER(topic_index));
+    if (!dictionary_insert(&s_names, name_val, MORPHO_INTEGER(topic_index))) {
+        morpho_freeobject(name_val);
+        return MORPHO_NIL;
+    }
     return name_val;
 }
 

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -184,7 +184,8 @@ bool md_parseblock(parser *p, void *out) {
     if (parse_checktokenadvance(p, MD_TEXT)) {
         return md_parsetext(p, out);
     } else if (parse_checktokenadvance(p, MD_HASH) ||
-               parse_checktokenadvance(p, MD_HASH2)) {
+               parse_checktokenadvance(p, MD_HASH2) ||
+               parse_checktokenadvance(p, MD_HASH3)) {
         return md_parseheader(p, out);
     } else if (parse_checktokenadvance(p, MD_FOURSPACES) ||
                parse_checktokenadvance(p, MD_TAB)) {

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -231,8 +231,20 @@ tokentype _inlinetokens[] = {
 };
 int _ninlinetokens = sizeof(_inlinetokens)/sizeof(tokentype);
 
+/** Token types that can appear literally in paragraph/list text (consumed without inline rules). */
+tokentype _literalintext[] = {
+    MD_HASH, MD_HASH2, MD_HASH3, MD_LEFTSQUAREBRACE, MD_RIGHTSQUAREBRACE,
+    MD_FOURSPACES, MD_TAB, MD_PLUS, MD_DASH
+};
+int _nliteralintext = sizeof(_literalintext)/sizeof(tokentype);
+
 bool md_checktexttoken(parser *p) {
     return parse_checktokenmulti(p, _ninlinetokens, _inlinetokens);
+}
+
+/** True if current token can be consumed as literal in paragraph/list (no prefix rule). */
+static bool md_checkliteralintext(parser *p) {
+    return parse_checktokenmulti(p, _nliteralintext, _literalintext);
 }
 
 /** Parses text written in markdown; stops at a non-textual token. Line ends with NEWLINE or EOF. */
@@ -241,19 +253,25 @@ bool md_parsetext(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->current.start - base);
 
-    // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers.
-    // A leading * or _ is treated as text (list-marker style); we could parse as list item later.
-    while (md_checktexttoken(p)) {
-        parse_advance(p);
-        size_t tok_start = (size_t)(p->previous.start - base);
-        parserule *rule = parse_getrule(p, p->previous.type);
-        if (rule && rule->prefix) {
-            bool leading_asterisk_or_underscore = (tok_start == block_start &&
-                (p->previous.type == MD_ASTERISK || p->previous.type == MD_UNDERSCORE));
-            if (!leading_asterisk_or_underscore && !rule->prefix(p, out)) return false;
+    for (;;) {
+        // Consume text tokens, applying inline rules (bold, italic, code) via prefix handlers.
+        // A leading * or _ is treated as text (list-marker style); we could parse as list item later.
+        while (md_checktexttoken(p)) {
+            parse_advance(p);
+            size_t tok_start = (size_t)(p->previous.start - base);
+            parserule *rule = parse_getrule(p, p->previous.type);
+            if (rule && rule->prefix) {
+                bool leading_asterisk_or_underscore = (tok_start == block_start &&
+                    (p->previous.type == MD_ASTERISK || p->previous.type == MD_UNDERSCORE));
+                if (!leading_asterisk_or_underscore && !rule->prefix(p, out)) return false;
+            }
         }
-    }
-    if (!md_parselineend(p)) {
+        if (md_parselineend(p)) break;
+        // Allow block-style tokens to appear literally in prose (e.g. "+" in "minimization + retriangulation").
+        if (md_checkliteralintext(p)) {
+            parse_advance(p);
+            continue;
+        }
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }
@@ -305,15 +323,21 @@ bool md_parselist(parser *p, void *out) {
     const char *base = ctx->file->source;
     size_t block_start = (size_t)(p->previous.start - base);  /* *, +, or - already consumed */
 
-    // Reuse text parsing (inline rules) but record as list block
-    while (md_checktexttoken(p)) {
-        parse_advance(p);
-        parserule *rule = parse_getrule(p, p->previous.type);
-        if (rule && rule->prefix) {
-            if (!rule->prefix(p, out)) return false;
+    for (;;) {
+        // Reuse text parsing (inline rules) but record as list block
+        while (md_checktexttoken(p)) {
+            parse_advance(p);
+            parserule *rule = parse_getrule(p, p->previous.type);
+            if (rule && rule->prefix) {
+                if (!rule->prefix(p, out)) return false;
+            }
         }
-    }
-    if (!md_parselineend(p)) {
+        if (md_parselineend(p)) break;
+        // Allow block-style tokens literally in list item (e.g. "+" in "minimization + retriangulation").
+        if (md_checkliteralintext(p)) {
+            parse_advance(p);
+            continue;
+        }
         parse_error(p, true, MD_EXPECTLINEEND);
         return false;
     }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -14,6 +14,7 @@
 #include "resources.h"
 
 #include "lex.h"
+#include "parse.h"
 #include "file.h"
 
 /** The interactive help system uses a collection of Markdown files, located in
@@ -61,7 +62,7 @@ tokendefn mdtokens[] = {
 
 
 /* -------------------------------------------------------
- * Initialize a JSON lexer
+ * Initialize a Markdown lexer
  * ------------------------------------------------------- */
 
 void help_initializemdlexer(lexer *l, char *src) {
@@ -72,14 +73,56 @@ void help_initializemdlexer(lexer *l, char *src) {
     lex_seteof(l, MD_EOF);
 }
 
+/* -------------------------------------------------------
+ * Markdown parse rules
+ * ------------------------------------------------------- */
+
+/** Parses a markdown link  */
+bool md_parselink(parser *p, void *out) {
+    return true;
+}
+
+/** Base markdown parse type */
+bool md_parse(parser *p, void *out) {
+    return true;
+}
+
+/* -------------------------------------------------------
+ * Markdown parse table
+ * ------------------------------------------------------- */
+
+parserule md_rules[] = {
+    PARSERULE_PREFIX(MD_LEFTSQUAREBRACE, md_parselink),
+    PARSERULE_UNUSED(TOKEN_NONE)
+};
+
+/* -------------------------------------------------------
+ * Initialize a Markdown parser
+ * ------------------------------------------------------- */
+
+/** Initializes a parser to parse JSON */
+void help_initializemdparser(parser *p, lexer *l, error *err, void *out) {
+    parse_init(p, l, err, out);
+    parse_setbaseparsefn(p, md_parse);
+    parse_setparsetable(p, md_rules);
+    parse_setskipnewline(p, false, TOKEN_NONE);
+}
+
 /* **********************************************************************
  * Parse help files
  * ********************************************************************** */
 
 bool help_parse(char *src) {
+    error err;
+    error_init(&err);
+    
     lexer l;
     help_initializemdlexer(&l, src);
     
+    parser p;
+    help_initializemdparser(&p, &l, &err, NULL);
+    
+    parse(&p);
     
     return false;
 }

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -36,6 +36,7 @@ typedef enum {
     MD_BLOCK_CODE,
     MD_BLOCK_LIST,
     MD_BLOCK_LINK_DEF,
+    MD_BLOCK_THEMATIC_BREAK,
     MD_BLOCK_BLANK
 } md_blocktype;
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -12,8 +12,10 @@
 
 /** Maximum length of a help query string (used for lookup buffer). */
 #define MORPHO_MAX_HELPQUERY_LENGTH 512
+
 /** Maximum length of a single string for edit-distance (suggestion). */
 #define MORPHO_HELP_EDITMAXLEN 128
+
 /** Buffer size for "not found" hint message. */
 #define MORPHO_HELP_HINTBUFSIZE 256
 
@@ -105,6 +107,34 @@ bool help_topictotext(const help_topic *t, varray_char *result);
 
 /** Append a help topic's raw markdown from source into result. Returns true on success. */
 bool help_topicrawmd(const help_topic *t, varray_char *result);
+
+/* -------------------------------------------------------
+ * Markdown parser error codes
+ * ------------------------------------------------------- */
+
+#define MD_UNCLOSEDITALIC         "MDUnclItal"
+#define MD_UNCLOSEDITALIC_MSG     "Unclosed italic (missing closing * or _)."
+
+#define MD_UNCLOSEDINLINECODE     "MDUnclCode"
+#define MD_UNCLOSEDINLINECODE_MSG "Unclosed inline code (missing closing `)."
+
+#define MD_EXPECTLINEEND          "MDExpLnEnd"
+#define MD_EXPECTLINEEND_MSG      "Expected end of line."
+
+#define MD_EXPECTHEADERTEXT       "MDExpHdrTxt"
+#define MD_EXPECTHEADERTEXT_MSG   "Expected header text after #."
+
+#define MD_LINKEXPECTTEXT         "MDLnkExpTxt"
+#define MD_LINKEXPECTTEXT_MSG     "Link definition expects label text after [."
+
+#define MD_LINKEXPECTBRACKET      "MDLnkExpBr"
+#define MD_LINKEXPECTBRACKET_MSG  "Link definition expects ] after label."
+
+#define MD_LINKEXPECTCOLON        "MDLnkExpCol"
+#define MD_LINKEXPECTCOLON_MSG    "Link definition expects : after ]."
+
+#define MD_UNEXPECTEDTOKEN        "MDUnexpTok"
+#define MD_UNEXPECTEDTOKEN_MSG    "Unexpected markdown token."
 
 /* -------------------------------------------------------
  * Help API

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -153,6 +153,9 @@ bool morpho_helpastext(const char *query, varray_char *result);
 /** Look up help for query and write raw markdown into result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topicrawmd.) */
 bool morpho_helpasmd(const char *query, varray_char *result);
 
+/** Fill a varray_value with top-level topic names (Morpho string values). Loads help on first use. Caller must initialize/clear the varray. */
+void morpho_helptopics(varray_value *out);
+
 /** Build a hint for a failed query */
 void help_queryhint(const char *query, varray_char *result);
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -9,4 +9,7 @@
 
 bool morpho_help(char *query, varray_char *result);
 
+void help_initialize(void);
+void help_finalize(void);
+
 #endif /* help_h */

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -63,6 +63,7 @@ typedef struct {
     char *source;
     size_t sourcelen;
     char *filename;  /* Owned filename/path for error reporting */
+    bool promote_subtopics;  /* [toplevel]: # directive: include ## from this file in top-level topic list */
     varray_md_block blocks;
 } md_file;
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -138,12 +138,14 @@ bool help_topicrawmd(const help_topic *t, varray_char *result);
 #define MD_UNEXPECTEDTOKEN        "MDUnexpTok"
 #define MD_UNEXPECTEDTOKEN_MSG    "Unexpected markdown token."
 
+#define MORPHO_HELP_NOTFOUND      "Topic not found."
+
 /* -------------------------------------------------------
  * Help API
  * ------------------------------------------------------- */
 
 /** Resolve a query to a help topic. Fills *out and returns true if found; otherwise returns false and *out is unchanged. */
- bool morpho_helpastopic(const char *query, help_topic *out);
+bool morpho_helpastopic(const char *query, help_topic *out);
 
 /** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topictotext.) */
 bool morpho_helpastext(char *query, varray_char *result);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -10,6 +10,9 @@
 #include <stddef.h>
 #include "varray.h"
 
+/** Maximum length of a help query string (used for lookup buffer). */
+#define MORPHO_MAX_HELPQUERY_LENGTH 512
+
 /* -------------------------------------------------------
  * Markdown AST: source-backed spans, hierarchical blocks
  * ------------------------------------------------------- */
@@ -82,9 +85,28 @@ void help_sorttopics(varray_md_topic *topics);
 int help_findtopic(varray_md_topic *topics, const char *name);
 
 /* -------------------------------------------------------
+ * Help topic view (for flexible rendering)
+ * ------------------------------------------------------- */
+
+/** A resolved help topic: pointer to the topic entry, its file, and the slice of blocks that form its content (header + following blocks until the next same-level or higher header). Callers can use this to render raw MD, plain text, or terminal-styled output. */
+typedef struct {
+    const md_topic *topic;
+    const md_file *file;
+    const md_block *content_blocks;  /* first block of content (header) */
+    unsigned int nblocks;
+} help_topic;
+
+/** Resolve a query to a help topic. Fills *out and returns true if found; otherwise returns false and *out is unchanged. */
+bool morpho_helptopic(const char *query, help_topic *out);
+
+/** Render a help topic as plain text into result (no markdown formatting). Returns true on success. */
+bool help_topictotext(const help_topic *t, varray_char *result);
+
+/* -------------------------------------------------------
  * Help API
  * ------------------------------------------------------- */
 
+/** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helptopic + help_topictotext.) */
 bool morpho_help(char *query, varray_char *result);
 
 void help_initialize(void);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -12,6 +12,10 @@
 
 /** Maximum length of a help query string (used for lookup buffer). */
 #define MORPHO_MAX_HELPQUERY_LENGTH 512
+/** Maximum length of a single string for edit-distance (suggestion). */
+#define MORPHO_HELP_EDITMAXLEN 128
+/** Buffer size for "not found" hint message. */
+#define MORPHO_HELP_HINTBUFSIZE 256
 
 /* -------------------------------------------------------
  * Markdown AST: source-backed spans, hierarchical blocks

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -78,6 +78,14 @@ typedef struct {
 
 DECLARE_VARRAY(md_topic, md_topic);
 
+/** Alias entry: maps an alias name to a topic index. */
+typedef struct {
+    char *name;              /* lowercase, owned */
+    int topic_index;
+} md_alias;
+
+DECLARE_VARRAY(md_alias, md_alias);
+
 /** Initialize / clear a block (clears children). */
 void md_block_clear(md_block *b);
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -96,18 +96,24 @@ typedef struct {
     unsigned int nblocks;
 } help_topic;
 
-/** Resolve a query to a help topic. Fills *out and returns true if found; otherwise returns false and *out is unchanged. */
-bool morpho_helptopic(const char *query, help_topic *out);
-
 /** Render a help topic as plain text into result (no markdown formatting). Returns true on success. */
 bool help_topictotext(const help_topic *t, varray_char *result);
+
+/** Append a help topic's raw markdown from source into result. Returns true on success. */
+bool help_topicrawmd(const help_topic *t, varray_char *result);
 
 /* -------------------------------------------------------
  * Help API
  * ------------------------------------------------------- */
 
-/** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helptopic + help_topictotext.) */
-bool morpho_help(char *query, varray_char *result);
+/** Resolve a query to a help topic. Fills *out and returns true if found; otherwise returns false and *out is unchanged. */
+ bool morpho_helpastopic(const char *query, help_topic *out);
+
+/** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topictotext.) */
+bool morpho_helpastext(char *query, varray_char *result);
+
+/** Look up help for query and write raw markdown into result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topicrawmd.) */
+bool morpho_helpasmd(char *query, varray_char *result);
 
 void help_initialize(void);
 void help_finalize(void);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -155,6 +155,9 @@ bool morpho_helpastext(char *query, varray_char *result);
 /** Look up help for query and write raw markdown into result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topicrawmd.) */
 bool morpho_helpasmd(char *query, varray_char *result);
 
+/** Build a hint for a failed query */
+void help_queryhint(const char *query, varray_char *result);
+
 void help_initialize(void);
 void help_finalize(void);
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -7,6 +7,84 @@
 #ifndef help_h
 #define help_h
 
+#include <stddef.h>
+#include "varray.h"
+
+/* -------------------------------------------------------
+ * Markdown AST: source-backed spans, hierarchical blocks
+ * ------------------------------------------------------- */
+
+/** Span into a stored source buffer (offset + length). */
+typedef struct {
+    size_t start;
+    size_t length;
+} md_span;
+
+/** Block type. */
+typedef enum {
+    MD_BLOCK_HEADER,
+    MD_BLOCK_PARAGRAPH,
+    MD_BLOCK_CODE,
+    MD_BLOCK_LIST,
+    MD_BLOCK_LINK_DEF,
+    MD_BLOCK_BLANK
+} md_blocktype;
+
+/** A single block: maps to a span in source; type-specific data; optional hierarchy. */
+typedef struct {
+    md_blocktype type;
+    md_span span;
+    union {
+        struct { int level; md_span title; } header;
+        struct { md_span label; md_span target; } link_def;
+        /* paragraph, code, list: span covers content */
+    } as;
+    int parent;             /* block index of parent, or -1 if top-level */
+    varray_int children;    /* indices of child blocks within same file */
+} md_block;
+
+DECLARE_VARRAY(md_block, md_block);
+
+/** One source file: owned source text + varray of blocks (with spans into source). */
+typedef struct {
+    char *source;
+    size_t sourcelen;
+    varray_md_block blocks;
+} md_file;
+
+DECLARE_VARRAY(md_file, md_file);
+
+/** Topic entry: header in the master list, sorted by name for O(log n) lookup. */
+typedef struct {
+    char *name;             /* lowercase, owned */
+    int file_index;
+    unsigned int block_index;
+    int level;              /* header level 1–3 */
+    int parent_topic;       /* topic index of parent, or -1 */
+} md_topic;
+
+DECLARE_VARRAY(md_topic, md_topic);
+
+/** Initialize / clear a block (clears children). */
+void md_block_clear(md_block *b);
+
+/** Initialize / clear a file (frees source, clears blocks). */
+void md_file_init(md_file *f);
+void md_file_clear(md_file *f);
+
+/** Topic list: compare by name for bsearch. */
+int md_topic_compare(const void *a, const void *b);
+
+/** Sort topic list by name (call after loading so lookup is O(log n)). */
+void help_sorttopics(varray_md_topic *topics);
+
+/** Find topic index by name (binary search). Returns -1 if not found. */
+int help_findtopic(varray_md_topic *topics, const char *name);
+
+/* -------------------------------------------------------
+ * Help API
+ * ------------------------------------------------------- */
+
 bool morpho_help(char *query, varray_char *result);
 
 void help_initialize(void);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -19,6 +19,11 @@
 /** Maximum length of a single string for edit-distance (suggestion). */
 #define MORPHO_HELP_EDITMAXLEN 128
 
+/** Maximum number of query segments (e.g. "System.clock" -> 2). */
+#define MORPHO_HELP_QUERY_MAXSEGMENTS 8
+/** Maximum number of topic indices returned for a single name (multi-match). */
+#define MORPHO_HELP_MAX_MULTIMATCH 8
+
 /** Buffer size for "not found" hint message. */
 #define MORPHO_HELP_HINTBUFSIZE 256
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -7,4 +7,6 @@
 #ifndef help_h
 #define help_h
 
+bool morpho_help(char *query, varray_char *result);
+
 #endif /* help_h */

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -78,10 +78,10 @@ typedef struct {
 
 DECLARE_VARRAY(md_topic, md_topic);
 
-/** Alias entry: maps an alias name to a topic index. */
+/** Alias entry: maps an alias name to a topic by the topic's name. topic_name is a pointer to the topic's name (not owned); lookup resolves it by bsearch so it remains valid after topics are sorted. */
 typedef struct {
-    char *name;              /* lowercase, owned */
-    int topic_index;
+    char *name;              /* alias name, lowercase, owned */
+    const char *topic_name; /* topic name to resolve (points into topic, not owned) */
 } md_alias;
 
 DECLARE_VARRAY(md_alias, md_alias);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -7,6 +7,8 @@
 #ifndef help_h
 #define help_h
 
+#ifdef MORPHO_INCLUDE_HELP
+
 #include <stddef.h>
 #include "varray.h"
 
@@ -155,5 +157,7 @@ bool morpho_helpasmd(char *query, varray_char *result);
 
 void help_initialize(void);
 void help_finalize(void);
+
+#endif
 
 #endif /* help_h */

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -59,6 +59,7 @@ DECLARE_VARRAY(md_block, md_block);
 typedef struct {
     char *source;
     size_t sourcelen;
+    char *filename;  /* Owned filename/path for error reporting */
     varray_md_block blocks;
 } md_file;
 

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -11,6 +11,7 @@
 
 #include <stddef.h>
 #include "varray.h"
+#include "value.h"
 
 /** Maximum length of a help query string (used for lookup buffer). */
 #define MORPHO_MAX_HELPQUERY_LENGTH 512
@@ -67,9 +68,9 @@ typedef struct {
 
 DECLARE_VARRAY(md_file, md_file);
 
-/** Topic entry: header in the master list, sorted by name for O(log n) lookup. */
+/** Topic entry: header in the master list (load order). Hierarchy by parent_topic; lookup by name/alias via single dictionary (value = index or List of indices). */
 typedef struct {
-    char *name;             /* lowercase, owned */
+    value name;             /* Morpho string (lowercase); not owned */
     int file_index;
     unsigned int block_index;
     int level;              /* header level 1–3 */
@@ -78,14 +79,6 @@ typedef struct {
 
 DECLARE_VARRAY(md_topic, md_topic);
 
-/** Alias entry: maps an alias name to a topic by the topic's name. topic_name is a pointer to the topic's name (not owned); lookup resolves it by bsearch so it remains valid after topics are sorted. */
-typedef struct {
-    char *name;              /* alias name, lowercase, owned */
-    const char *topic_name; /* topic name to resolve (points into topic, not owned) */
-} md_alias;
-
-DECLARE_VARRAY(md_alias, md_alias);
-
 /** Initialize / clear a block (clears children). */
 void md_block_clear(md_block *b);
 
@@ -93,14 +86,11 @@ void md_block_clear(md_block *b);
 void md_file_init(md_file *f);
 void md_file_clear(md_file *f);
 
-/** Topic list: compare by name for bsearch. */
-int md_topic_compare(const void *a, const void *b);
+/** Find one topic index by name or alias (first match if multiple). Returns -1 if not found. */
+int help_findtopic(const char *name);
 
-/** Sort topic list by name (call after loading so lookup is O(log n)). */
-void help_sorttopics(varray_md_topic *topics);
-
-/** Find topic index by name (binary search). Returns -1 if not found. */
-int help_findtopic(varray_md_topic *topics, const char *name);
+/** Find all topic indices with given name. Fills indices[] up to max, returns count. */
+int help_findallbyname(const char *name, int indices[], int max);
 
 /* -------------------------------------------------------
  * Help topic view (for flexible rendering)
@@ -158,10 +148,10 @@ bool help_topicrawmd(const help_topic *t, varray_char *result);
 bool morpho_helpastopic(const char *query, help_topic *out);
 
 /** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topictotext.) */
-bool morpho_helpastext(char *query, varray_char *result);
+bool morpho_helpastext(const char *query, varray_char *result);
 
 /** Look up help for query and write raw markdown into result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topicrawmd.) */
-bool morpho_helpasmd(char *query, varray_char *result);
+bool morpho_helpasmd(const char *query, varray_char *result);
 
 /** Build a hint for a failed query */
 void help_queryhint(const char *query, varray_char *result);

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -1,0 +1,10 @@
+/** @file help.h
+ *  @author T J Atherton and others (see below)
+ *
+ *  @brief Morpho help
+*/
+
+#ifndef help_h
+#define help_h
+
+#endif /* help_h */

--- a/src/support/help.h
+++ b/src/support/help.h
@@ -40,7 +40,8 @@ typedef enum {
     MD_BLOCK_LIST,
     MD_BLOCK_LINK_DEF,
     MD_BLOCK_THEMATIC_BREAK,
-    MD_BLOCK_BLANK
+    MD_BLOCK_BLANK,
+    MD_SHOW_SUBTOPICS
 } md_blocktype;
 
 /** A single block: maps to a span in source; type-specific data; optional hierarchy. */
@@ -156,6 +157,9 @@ bool morpho_helpasmd(const char *query, varray_char *result);
 
 /** Fill a varray_value with top-level topic names (Morpho string values). Loads help on first use. Caller must initialize/clear the varray. */
 void morpho_helptopics(varray_value *out);
+
+/** Fill a varray_value with subtopic names (Morpho string values) for the given topic. Each name is added once (by identity). Loads help on first use. Caller must initialize/clear the varray. */
+void morpho_helpsubtopics(const help_topic *topic, varray_value *out);
 
 /** Build a hint for a failed query */
 void help_queryhint(const char *query, varray_char *result);

--- a/src/support/lex.c
+++ b/src/support/lex.c
@@ -157,11 +157,12 @@ bool lex_matchtoken(lexer *l, tokendefn **defn) {
     return def;
 }
 
-/** @brief Attempts to identify a token from the current point, advances if it finds one.
+/** @brief Attempts to identify a token from the current point
  *  @param[in] l The lexer in use
+ *  @param[in] advance Should we advance if we find the token?
  *  @param[out] defn Type of token, if found
  *  @returns true if the token matched, false if not */
-bool lex_identifytoken(lexer *l, tokendefn **defn) {
+bool lex_identifytoken(lexer *l, bool advance, tokendefn **defn) {
     char c = lex_peek(l);
     
     // Match first character
@@ -177,7 +178,7 @@ bool lex_identifytoken(lexer *l, tokendefn **defn) {
     for (; def->string[0]==c && def>=l->defns; def--) {
         size_t len=strlen(def->string);
         if (strncmp(def->string, l->current, len)==0) {
-            lex_advanceby(l, len);
+            if (advance) lex_advanceby(l, len);
             if (defn) *defn = def;
             return true;
         }
@@ -673,7 +674,7 @@ bool lex(lexer *l, token *tok, error *err) {
     }
     
     tokendefn *defn=NULL;
-    if (lex_identifytoken(l, &defn)) {
+    if (lex_identifytoken(l, true, &defn)) {
         lex_recordtoken(l, defn->type, tok);
     } else {
         morpho_writeerrorwithid(err, LEXER_UNRECOGNIZEDTOKEN, NULL, l->line, l->posn);

--- a/src/support/lex.h
+++ b/src/support/lex.h
@@ -171,6 +171,7 @@ bool lex_matchtoken(lexer *l, tokendefn **defn);
 bool lex_identifytoken(lexer *l, bool advance, tokendefn **defn);
 void lex_recordtoken(lexer *l, tokentype type, token *tok);
 char lex_advance(lexer *l);
+char lex_advanceby(lexer *l, size_t n);
 bool lex_back(lexer *l);
 bool lex_isatend(lexer *l);
 bool lex_isalpha(char c);

--- a/src/support/lex.h
+++ b/src/support/lex.h
@@ -168,6 +168,7 @@ enum {
 
 bool lex_findtoken(lexer *l, tokendefn **defn);
 bool lex_matchtoken(lexer *l, tokendefn **defn);
+bool lex_identifytoken(lexer *l, bool advance, tokendefn **defn);
 void lex_recordtoken(lexer *l, tokentype type, token *tok);
 char lex_advance(lexer *l);
 bool lex_back(lexer *l);

--- a/src/support/parse.c
+++ b/src/support/parse.c
@@ -18,9 +18,6 @@
 /** Varrays of parse rules */
 DEFINE_VARRAY(parserule, parserule)
 
-/** Macro to check return of a bool function */
-#define PARSE_CHECK(f) if (!(f)) return false;
-
 /* **********************************************************************
  * Parser utility functions
  * ********************************************************************** */

--- a/src/support/parse.h
+++ b/src/support/parse.h
@@ -70,6 +70,9 @@ typedef struct {
 /** Varrays of parse rules */
 DECLARE_VARRAY(parserule, parserule)
 
+/** Macro to check return of a bool function */
+#define PARSE_CHECK(f) if (!(f)) return false;
+
 /* -------------------------------------------------------
  * Define a Parser
  * ------------------------------------------------------- */


### PR DESCRIPTION
New help system added to morpho library for centralized usage. Loaded lazily on first use. Interface

/** Resolve a query to a help topic. Fills *out and returns true if found; otherwise returns false and *out is unchanged. */
bool morpho_helpastopic(const char *query, help_topic *out);

/** Look up help for query and write plain-text result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topictotext.) */
bool morpho_helpastext(char *query, varray_char *result);

/** Look up help for query and write raw markdown into result. Returns true if topic found. (Convenience wrapper for morpho_helpastopic + help_topicrawmd.) */
bool morpho_helpasmd(char *query, varray_char *result);