### PR TITLE
Fix string negative indexing

### DIFF
--- a/src/classes/strng.c
+++ b/src/classes/strng.c
@@ -176,6 +176,7 @@ int string_countchars(objectstring *s) {
 
 /** Get a pointer to the i'th character of a string */
 char *string_index(objectstring *s, int i) {
+    if (i<0) return NULL;
     int n=0;
     for (char *c = s->string; *c!='\0'; ) {
         if (i==n) return (char *) c;
@@ -216,6 +217,20 @@ value String_clone(vm *v, int nargs, value *args) {
     value out = object_stringfromcstring(slf->string, slf->length);
     if (MORPHO_ISNIL(out)) morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
     morpho_bindobjects(v, 1, &out);
+    return out;
+}
+
+/** Gets a specified character from a string */
+value String_getindex(vm *v, int nargs, value *args) {
+    objectstring *slf = MORPHO_GETSTRING(MORPHO_SELF(args));
+    value out=MORPHO_NIL;
+    int n=MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
+
+    char *c = string_index(slf, n);
+    if (c) {
+        out=object_stringfromcstring(c, morpho_utf8numberofbytes(c));
+        morpho_bindobjects(v, 1, &out);
+    } else morpho_runtimeerror(v, VM_OUTOFBOUNDS);
     return out;
 }
 
@@ -292,7 +307,7 @@ MORPHO_BEGINCLASS(String)
 MORPHO_METHOD_SIGNATURE(MORPHO_COUNT_METHOD, "Int ()", String_count, MORPHO_FN_PUREFN),
 MORPHO_METHOD_SIGNATURE(MORPHO_PRINT_METHOD, "String ()", String_print, MORPHO_FN_IO),
 MORPHO_METHOD_SIGNATURE(MORPHO_CLONE_METHOD, "String ()", String_clone, MORPHO_FN_PUREFN|MORPHO_FN_ALLOCATES),
-MORPHO_METHOD_SIGNATURE(MORPHO_GETINDEX_METHOD, "(Int)", String_enumerate, MORPHO_FN_THROWS),
+MORPHO_METHOD_SIGNATURE(MORPHO_GETINDEX_METHOD, "String (Int)", String_getindex, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(MORPHO_GETINDEX_METHOD, "Nil (...)", String_enumerate__err, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(MORPHO_ENUMERATE_METHOD, "(Int)", String_enumerate, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(MORPHO_ENUMERATE_METHOD, "Nil (...)", String_enumerate__err, MORPHO_FN_THROWS),

--- a/test/string/index_neg.morpho
+++ b/test/string/index_neg.morpho
@@ -1,0 +1,5 @@
+var s = "Hello"
+
+print s[-1]
+// expect Error 'IndxBnds'
+


### PR DESCRIPTION
Fix for bug #321. Strings now throw an error if the user attempts to index them negatively. Added a test to the suite to check for this behavior. 

Internally, this bug appeared because the string index operation was calling the enumerate function instead of a dedicated get index function.