### PR TITLE
Forced metafunction resolver to check arity on monoarity functions

### DIFF
--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -1175,6 +1175,14 @@ static bool mfcompiler_emitresolver(mfcompiler *compiler, int nresolutions, mfco
         exactpath.knownarity = resolutions[0].nparams;
         exactpath.aritychecked = true;
         path = &exactpath;
+
+        // Add a sparse to verify that nargs matches the known arity
+        mfindx deflt;
+        mfcompiler_emitfail(compiler, &deflt);
+        mfcompilersparseentry correctarity;
+        correctarity.value = path->knownarity;
+        ERR_CHECK_RETURN(mfcompiler_emitresolver(compiler, nresolutions, resolutions, path, &correctarity.target));
+        return mfcompiler_emitsparse(compiler, 1, &correctarity, deflt, entry);
     }
 
     /* For exact arity without typed params, emit the lone fixed-arity winner. */
@@ -1298,7 +1306,7 @@ void metafunction_disassemble(objectmetafunction *fn) {
 static bool metafunction_runresolver(objectmetafunction *fn, int nargs, value *args, error *err, value *out) {
     mfinstruction *instructions = fn->resolver.data;
     if (!instructions) return metafunction_resolveslow(fn, nargs, args, err, out);
-    
+
     mfindx pc = fn->entry;
     int reg = nargs; // Single register initialized with nargs
     
@@ -1307,7 +1315,7 @@ static bool metafunction_runresolver(objectmetafunction *fn, int nargs, value *a
             case MFOP_SLOW:
                 return metafunction_resolveslow(fn, nargs, args, err, out);
             case MFOP_RESOLVE: {
-                pc++; *out=fn->fns.data[instructions[pc]];
+                *out=fn->fns.data[instructions[++pc]];
                 return true;
             }
             case MFOP_FAIL:

--- a/test/matrix/identity.morpho
+++ b/test/matrix/identity.morpho
@@ -12,4 +12,4 @@ print a
 // expect: [ 0 0 1 ]
 
 a = IdentityMatrix()
-// expect error 'MtrxIdnttyCns'
+// expect error 'MltplDsptchFld'

--- a/test/string/err_split_args2.morpho
+++ b/test/string/err_split_args2.morpho
@@ -1,0 +1,3 @@
+
+print "Hello world".split(2)
+// expect error 'MltplDsptchFld'

--- a/test/string/err_split_args3.morpho
+++ b/test/string/err_split_args3.morpho
@@ -1,0 +1,4 @@
+// You can not add extra arguments to a function
+
+print "Hello world".split(" ", 2)
+// expect error 'MltplDsptchFld'

--- a/test/string/err_split_args4.morpho
+++ b/test/string/err_split_args4.morpho
@@ -1,0 +1,5 @@
+print "Hello world".split(" ")
+// expect: [ Hello, world ]
+
+print "Hello world".split()
+// expect error 'MltplDsptchFld'


### PR DESCRIPTION
Fix for issue #322. 
This forces the metafunction resolution compiler to add a step to the beginning of the multiple dispatch resolver of all mono-arity functions(functions whose implementations all take the same number of arguments) which ensures that the function was passed the correct number of arguments. This check was already in place for multi-arity functions so this fix just affects the mono-arity case.

**Note**
This fix has the side effect of rendering an error inside the matrix class obsolete, this is because this class would manually check the types of its arguments, but with multiple dispatch fixed, the error will be caught before it ever reaches the matrix class.