### PR TITLE
Allow user to capture output from system().

### DIFF
--- a/src/builtin/functiondefs.c
+++ b/src/builtin/functiondefs.c
@@ -35,13 +35,8 @@
 
 /** Call the operating system */
 value builtin_system(vm *v, int nargs, value *args) {
-    if (nargs==1) {
-        value arg=MORPHO_GETARG(args, 0);
-        if (MORPHO_ISSTRING(arg)) {
-            return MORPHO_INTEGER(system(MORPHO_GETCSTRING(arg)));
-        }
-    }
-    return MORPHO_NIL;
+    char *cmd=MORPHO_GETCSTRING(MORPHO_GETARG(args, 0));
+    return MORPHO_INTEGER(system(cmd));
 }
 
 /** Clock */

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -88,10 +88,10 @@ value System_sleep(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
-value System_sleep__err(vm *v, int nargs, value *args) {
-    morpho_runtimeerror(v, SLEEP_ARGS);
-    return MORPHO_NIL;
-}
+// value System_sleep__err(vm *v, int nargs, value *args) {
+//     morpho_runtimeerror(v, SLEEP_ARGS);
+//     return MORPHO_NIL;
+// }
 
 /** Readline */
 value System_readline(vm *v, int nargs, value *args) {
@@ -129,10 +129,10 @@ value System_setworkingfolder(vm *v, int nargs, value *args) {
     return MORPHO_NIL;
 }
 
-value System_setworkingfolder__err(vm *v, int nargs, value *args) {
-    morpho_runtimeerror(v, STWRKDR_ARGS);
-    return MORPHO_NIL;
-}
+// value System_setworkingfolder__err(vm *v, int nargs, value *args) {
+//     morpho_runtimeerror(v, STWRKDR_ARGS);
+//     return MORPHO_NIL;
+// }
 
 /** Get working folder */
 value System_workingfolder(vm *v, int nargs, value *args) {
@@ -164,7 +164,30 @@ value System_homefolder(vm *v, int nargs, value *args) {
             morpho_bindobjects(v, 1, &out);
         } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
     } else morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
-    
+
+    return out;
+}
+
+/** Runs a console command and then returns the printed output of the function */
+value System_readoutput(vm *v, int nargs, value *args) {
+    value out = MORPHO_NIL;
+
+    char *cmd = MORPHO_GETCSTRING(MORPHO_GETARG(args, 0));
+
+    varray_char output;
+    varray_charinit(&output);
+
+    FILE *fp = popen(cmd, "r");
+    if (fp) {
+        int c;
+        while ((c = fgetc(fp)) != EOF) varray_charwrite(&output, c);
+        int exit_code = pclose(fp);
+
+        out = object_stringfromvarraychar(&output);
+        if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
+    } else morpho_runtimeerror(v, SYS_POPNFLD);
+    varray_charclear(&output);
+
     return out;
 }
 
@@ -192,14 +215,15 @@ MORPHO_METHOD_SIGNATURE(SYSTEM_CLOCK_METHOD, "Float ()", System_clock, MORPHO_FN
 MORPHO_METHOD(MORPHO_PRINT_METHOD, System_print, MORPHO_FN_IO),
 MORPHO_METHOD_SIGNATURE(SYSTEM_SLEEP_METHOD, "Nil (Int)", System_sleep, MORPHO_FN_IO),
 MORPHO_METHOD_SIGNATURE(SYSTEM_SLEEP_METHOD, "Nil (Float)", System_sleep, MORPHO_FN_IO),
-MORPHO_METHOD_SIGNATURE(SYSTEM_SLEEP_METHOD, "Nil (...)", System_sleep__err, MORPHO_FN_THROWS),
+// MORPHO_METHOD_SIGNATURE(SYSTEM_SLEEP_METHOD, "Nil (...)", System_sleep__err, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(SYSTEM_READLINE_METHOD, "String ()", System_readline, MORPHO_FN_IO|MORPHO_FN_ALLOCATES),
 MORPHO_METHOD_SIGNATURE(SYSTEM_ARGUMENTS_METHOD, "List ()", System_arguments, MORPHO_FN_IO),
 MORPHO_METHOD_SIGNATURE(SYSTEM_EXIT_METHOD, "Nil ()", System_exit, MORPHO_FN_IO|MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(SYSTEM_SETWORKINGFOLDER_METHOD, "Nil (String)", System_setworkingfolder, MORPHO_FN_IO|MORPHO_FN_THROWS),
-MORPHO_METHOD_SIGNATURE(SYSTEM_SETWORKINGFOLDER_METHOD, "Nil (...)", System_setworkingfolder__err, MORPHO_FN_THROWS),
+// MORPHO_METHOD_SIGNATURE(SYSTEM_SETWORKINGFOLDER_METHOD, "Nil (...)", System_setworkingfolder__err, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(SYSTEM_WORKINGFOLDER_METHOD, "String ()", System_workingfolder, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
 MORPHO_METHOD_SIGNATURE(SYSTEM_HOMEFOLDER_METHOD, "String ()", System_homefolder, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
+MORPHO_METHOD_SIGNATURE(SYSTEM_READOUTPUT_METHOD, "String (String)",System_readoutput, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
 MORPHO_METHOD_SIGNATURE(SYSTEM_HELP_METHOD, "String (String)", System_help__string, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES)
 MORPHO_ENDCLASS
 
@@ -212,10 +236,11 @@ void system_initialize(void) {
     
     builtin_addclass(SYSTEM_CLASSNAME, MORPHO_GETCLASSDEFINITION(System), objclass);
     
-    morpho_defineerror(SLEEP_ARGS, ERROR_HALT, SLEEP_ARGS_MSG);
+    // morpho_defineerror(SLEEP_ARGS, ERROR_HALT, SLEEP_ARGS_MSG);
     morpho_defineerror(VM_EXIT, ERROR_EXIT, VM_EXIT_MSG);
     morpho_defineerror(SYS_STWRKDR, ERROR_EXIT, SYS_STWRKDR_MSG);
-    morpho_defineerror(STWRKDR_ARGS, ERROR_EXIT, STWRKDR_ARGS_MSG);
+    // morpho_defineerror(STWRKDR_ARGS, ERROR_EXIT, STWRKDR_ARGS_MSG);
+    morpho_defineerror(SYS_POPNFLD, ERROR_EXIT, SYS_POPNFLD_MSG);
     
     objectlist *alist = object_newlist(0, NULL);
     if (alist) arglist = MORPHO_OBJECT(alist);

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -177,11 +177,11 @@ value System_readoutput(vm *v, int nargs, value *args) {
     varray_char output;
     varray_charinit(&output);
 
-    FILE *fp = popen(cmd, "r");
+    FILE *fp = platform_popen(cmd, "r");
     if (fp) {
         int c;
         while ((c = fgetc(fp)) != EOF) varray_charwrite(&output, c);
-        int exit_code = pclose(fp);
+        int exit_code = platform_pclose(fp);
 
         out = object_stringfromvarraychar(&output);
         if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -195,14 +195,16 @@ value System_subprocess(vm *v, int nargs, value *args) {
         int c;
         while ((c = fgetc(fp)) != EOF) varray_charwrite(&output, c);
         // Strip the trailing newline
-        if (varray_charpop(&output, (char *) &c) && c != '\n') varray_charwrite(&output, c);
+        if (varray_charpop(&output, (char *) &c) && (char) c != '\n') varray_charwrite(&output, c);
         
         dictionary_insertintern(&new->dict, exit_key, MORPHO_INTEGER(platform_pclose(fp)));
         dictionary_insertintern(&new->dict, out_key, object_stringfromvarraychar(&output));
+
+        out = morpho_wrapandbindrecursive(v, (object *) new);
     } else morpho_runtimeerror(v, SYS_POPNFLD);
     varray_charclear(&output);
 
-    return morpho_wrapandbindrecursive(v, (object *) new);
+    return out;
 }
 
 /** Help query */

--- a/src/classes/system.c
+++ b/src/classes/system.c
@@ -11,6 +11,7 @@
 #include "system.h"
 #include "platform.h"
 #include "help.h"
+#include "dict.h"
 
 /* **********************************************************************
  * System utility functions
@@ -168,11 +169,23 @@ value System_homefolder(vm *v, int nargs, value *args) {
     return out;
 }
 
-/** Runs a console command and then returns the printed output of the function */
-value System_readoutput(vm *v, int nargs, value *args) {
+/** Runs a console command and then returns output data of the process in a dictionary */
+value System_subprocess(vm *v, int nargs, value *args) {
     value out = MORPHO_NIL;
 
-    char *cmd = MORPHO_GETCSTRING(MORPHO_GETARG(args, 0));
+    // Create and initialize a dictionary to store the process data
+    objectdictionary *new = object_newdictionary();
+    if (!new) {
+        morpho_runtimeerror(v, ERROR_ALLOCATIONFAILED);
+        return out;
+    }
+    value args_key = dictionary_intern(&new->dict, object_stringfromcstring("args", 4));
+    value exit_key = dictionary_intern(&new->dict, object_stringfromcstring("exitstatus", 10));
+    value out_key  = dictionary_intern(&new->dict, object_stringfromcstring("stdout", 6));
+
+    value cmdv = MORPHO_GETARG(args, 0);
+    dictionary_insertintern(&new->dict, args_key, cmdv);
+    char *cmd = MORPHO_GETCSTRING(cmdv);
 
     varray_char output;
     varray_charinit(&output);
@@ -181,14 +194,15 @@ value System_readoutput(vm *v, int nargs, value *args) {
     if (fp) {
         int c;
         while ((c = fgetc(fp)) != EOF) varray_charwrite(&output, c);
-        int exit_code = platform_pclose(fp);
-
-        out = object_stringfromvarraychar(&output);
-        if (MORPHO_ISOBJECT(out)) morpho_bindobjects(v, 1, &out);
+        // Strip the trailing newline
+        if (varray_charpop(&output, (char *) &c) && c != '\n') varray_charwrite(&output, c);
+        
+        dictionary_insertintern(&new->dict, exit_key, MORPHO_INTEGER(platform_pclose(fp)));
+        dictionary_insertintern(&new->dict, out_key, object_stringfromvarraychar(&output));
     } else morpho_runtimeerror(v, SYS_POPNFLD);
     varray_charclear(&output);
 
-    return out;
+    return morpho_wrapandbindrecursive(v, (object *) new);
 }
 
 /** Help query */
@@ -223,7 +237,7 @@ MORPHO_METHOD_SIGNATURE(SYSTEM_SETWORKINGFOLDER_METHOD, "Nil (String)", System_s
 // MORPHO_METHOD_SIGNATURE(SYSTEM_SETWORKINGFOLDER_METHOD, "Nil (...)", System_setworkingfolder__err, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(SYSTEM_WORKINGFOLDER_METHOD, "String ()", System_workingfolder, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
 MORPHO_METHOD_SIGNATURE(SYSTEM_HOMEFOLDER_METHOD, "String ()", System_homefolder, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
-MORPHO_METHOD_SIGNATURE(SYSTEM_READOUTPUT_METHOD, "String (String)",System_readoutput, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
+MORPHO_METHOD_SIGNATURE(SYSTEM_SUBPROCESS_METHOD, "Dictionary (String)",System_subprocess, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES),
 MORPHO_METHOD_SIGNATURE(SYSTEM_HELP_METHOD, "String (String)", System_help__string, MORPHO_FN_IO|MORPHO_FN_THROWS|MORPHO_FN_ALLOCATES)
 MORPHO_ENDCLASS
 

--- a/src/classes/system.h
+++ b/src/classes/system.h
@@ -29,7 +29,7 @@
 #define SYSTEM_WORKINGFOLDER_METHOD   "workingfolder"
 #define SYSTEM_SETWORKINGFOLDER_METHOD "setworkingfolder"
 
-#define SYSTEM_READOUTPUT_METHOD      "readoutput"
+#define SYSTEM_SUBPROCESS_METHOD      "subprocess"
 
 /* -------------------------------------------------------
  * System error messages

--- a/src/classes/system.h
+++ b/src/classes/system.h
@@ -29,18 +29,23 @@
 #define SYSTEM_WORKINGFOLDER_METHOD   "workingfolder"
 #define SYSTEM_SETWORKINGFOLDER_METHOD "setworkingfolder"
 
+#define SYSTEM_READOUTPUT_METHOD      "readoutput"
+
 /* -------------------------------------------------------
  * System error messages
  * ------------------------------------------------------- */
 
-#define SLEEP_ARGS                    "SystmSlpArgs"
-#define SLEEP_ARGS_MSG                "Sleep method expects a time in seconds."
+// #define SLEEP_ARGS                    "SystmSlpArgs"
+// #define SLEEP_ARGS_MSG                "Sleep method expects a time in seconds."
 
-#define STWRKDR_ARGS                  "SystmStWrkDrArgs"
-#define STWRKDR_ARGS_MSG              "Setworkingdirectory method expects a path name."
+// #define STWRKDR_ARGS                  "SystmStWrkDrArgs"
+// #define STWRKDR_ARGS_MSG              "Setworkingdirectory method expects a path name."
 
 #define SYS_STWRKDR                   "SystmStWrkDr"
 #define SYS_STWRKDR_MSG               "Couldn't set working directory."
+
+#define SYS_POPNFLD                    "SystmPOpnFld"
+#define SYS_POPNFLD_MSG                "Failed to open pipe to terminal."
 
 void system_initialize(void);
 void system_finalize(void);

--- a/src/support/platform.c
+++ b/src/support/platform.c
@@ -369,6 +369,26 @@ void *platform_dlsym(MorphoDLHandle handle, const char *symbol) {
 }
 
 /* **********************************************************************
+ * System command execution
+ * ********************************************************************** */
+
+FILE *platform_popen(const char *cmd, const char *mode) {
+#ifdef _WIN32
+    return _popen(cmd, mode);
+#else
+    return popen(cmd, mode);
+#endif
+}
+
+int platform_pclose(FILE *pipe) {
+#ifdef _WIN32
+    return _pclose(pipe);
+#else
+    return pclose(pipe);
+#endif
+}
+
+/* **********************************************************************
  * Threads
  * ********************************************************************** */
 

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <complex.h>
+#include <stdio.h>
 #include "varray.h"
 
 #ifdef _WIN32
@@ -118,6 +119,9 @@ typedef void* MorphoDLHandle;
 MorphoDLHandle platform_dlopen(const char *path);
 void platform_dlclose(MorphoDLHandle handle);
 void *platform_dlsym(MorphoDLHandle handle, const char *symbol);
+
+FILE *platform_popen(const char *cmd, const char *mode);
+int platform_pclose(FILE *pipe);
 
 bool morpho_isdirectory(const char *path);
 

--- a/test/system/subprocess.morpho
+++ b/test/system/subprocess.morpho
@@ -1,0 +1,10 @@
+var out = System.subprocess("echo \"Hello world\"")
+
+print out["stdout"]
+// expect: Hello World
+
+print out["args"]
+// expect: echo "Hello world"
+
+print out["exitstatus"]
+// expect: 0

--- a/test/system/subprocess.morpho
+++ b/test/system/subprocess.morpho
@@ -1,7 +1,7 @@
 var out = System.subprocess("echo \"Hello world\"")
 
 print out["stdout"]
-// expect: Hello World
+// expect: Hello world
 
 print out["args"]
 // expect: echo "Hello world"


### PR DESCRIPTION
Feature for request #208. Allows for the user to capture the output of a system call. This is done with an extension of the System class, `System.subprocess()`. This function takes a command string and runs it in a new environment, capturing the string output to stdout, exit status, and input args. Returns this output as a dictionary with the keys `"stdout"`, `"exitstatus"`, and `"args"` for the respective outputs.