### PR TITLE
Metafunction fast-resolver compilation bug-fixes

### DIFF
--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -253,7 +253,16 @@ bool builtin_addfunctiontodict(dictionary *dict, value name, value fn, bool forc
     objectclass *klass = builtin_getparentclass(fn);
 
     if (dictionary_get(dict, selector, &prev) && klass != builtin_getparentclass(prev)) { // Override superclass methods for now
-        entry=fn;
+        if (forcewrap) { // If forcewrap is on create a mf, otherwise just use regular fn
+            if (!metafunction_wrap(name, fn, &entry)) return false;
+        } else {
+            entry=fn;
+        }
+
+        if (MORPHO_ISMETAFUNCTION(entry)) {
+            metafunction_setclass(MORPHO_GETMETAFUNCTION(entry), klass);
+            builtin_bindobject(MORPHO_GETOBJECT(entry));
+        }
         success=dictionary_insert(dict, selector, entry);
     } else {
         if (MORPHO_ISNIL(prev) && forcewrap) {

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -1163,7 +1163,7 @@ static bool mfcompiler_emitresolver(mfcompiler *compiler, int nresolutions, mfco
     if (nresolutions<=0) return mfcompiler_emitfail(compiler, entry);
 
     /* A single fully-determined resolution can be emitted directly. */
-    if (nresolutions==1 && mfcompiler_resolutionisterminal(&resolutions[0], path->nparams, path->known)) {
+    if (nresolutions==1 && mfcompiler_resolutionisterminal(&resolutions[0], path->nparams, path->known) && path->aritychecked) {
         return mfcompiler_emitresolve(compiler, resolutions[0].fnindex, entry);
     }
 

--- a/test/complex/constructor_error.morpho
+++ b/test/complex/constructor_error.morpho
@@ -2,7 +2,7 @@
 try {
     var X = Complex(1)    
 } catch {
-    "CmplxCns" : print "ok"
+    "MltplDsptchFld" : print "ok"
 // expect: ok
 }    
 

--- a/test/list/mf_too_many.morpho
+++ b/test/list/mf_too_many.morpho
@@ -1,0 +1,15 @@
+var l = [1,2,3,4]
+
+try {
+    print l.order("text")
+} catch {
+    "MltplDsptchFld" : print "ok"
+// expect: ok
+}
+
+try {
+    print l.count("text")
+} catch {
+    "MltplDsptchFld" : print "ok"
+// expect: ok
+}


### PR DESCRIPTION
Fix for #328. Forces the metafunction compiler to check the arity before declaring fully-determined resolution. This ensures that built-in functions which take no arguments get the correct metafunction fast resolution bytecode, meaning that an error will be correctly thrown when invalid arguments are passed into the function.