### PR TITLE
Initial Shortstring Commit

### DIFF
--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -488,9 +488,7 @@ void builtin_initialize(void) {
     int_initialize();
     bool_initialize();
     nil_initialize();
-#ifdef MORPHO_NAN_BOXING
     shortstring_initialize();
-#endif
     
     string_initialize();  // Classes
     function_initialize();

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -298,7 +298,7 @@ bool morpho_addfunction(char *name, char *signature, builtinfunction func, built
     if (MORPHO_ISNIL(selector)) goto morpho_addfunction_cleanup;
     if (!MORPHO_ISSAME(selector, new->name)) morpho_freeobject(new->name);
     new->name=selector;
-    builtin_bindobject(MORPHO_GETOBJECT(selector));
+    if (MORPHO_ISOBJECT(selector)) builtin_bindobject(MORPHO_GETOBJECT(selector));
     
     value newfn = MORPHO_OBJECT(new);
     
@@ -345,7 +345,7 @@ bool builtin_finalizemetafunctions(void) {
  * @returns true on success */
 bool morpho_addclass(char *name, builtinclassentry desc[], int nparents, value *parents, value *out) {
     value label = object_stringfromcstring(name, strlen(name));
-    builtin_bindobject(MORPHO_GETOBJECT(label));
+    if (MORPHO_ISOBJECT(label)) builtin_bindobject(MORPHO_GETOBJECT(label));
     objectclass *new = object_newclass(label);
     builtin_bindobject((object *) new);
     bool success=true;
@@ -393,7 +393,7 @@ bool morpho_addclass(char *name, builtinclassentry desc[], int nparents, value *
             }
             if (!MORPHO_ISSAME(selector, newmethod->name)) morpho_freeobject(newmethod->name);
             newmethod->name=selector;
-            builtin_bindobject(MORPHO_GETOBJECT(selector));
+            if (MORPHO_ISOBJECT(selector)) builtin_bindobject(MORPHO_GETOBJECT(selector));
             value method = MORPHO_OBJECT(newmethod);
             
             builtin_bindobject((object *) newmethod);
@@ -444,7 +444,7 @@ value builtin_internsymbol(value symbol) {
 /** Interns a symbol given as a C string. */
 value builtin_internsymbolascstring(char *symbol) {
     value selector = object_stringfromcstring(symbol, strlen(symbol));
-    builtin_bindobject(MORPHO_GETOBJECT(selector));
+    if (MORPHO_ISOBJECT(selector)) builtin_bindobject(MORPHO_GETOBJECT(selector));
     value internselector = builtin_internsymbol(selector);
     return internselector;
 }

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -77,7 +77,7 @@ bool builtin_enumerateloop(vm *v, value obj, builtin_loopfunction fn, void *ref)
             in=MORPHO_INTEGER(i);
             
             if (!morpho_invoke(v, obj, enumerate, 1, &in, &val)) return false;
-            
+
             if (!(*fn) (v, i, val, ref)) return false;
         }
     }
@@ -488,6 +488,9 @@ void builtin_initialize(void) {
     int_initialize();
     bool_initialize();
     nil_initialize();
+#ifdef MORPHO_NAN_BOXING
+    shortstring_initialize();
+#endif
     
     string_initialize();  // Classes
     function_initialize();

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(morpho
         nil.c          nil.h
         range.c        range.h
         strng.c        strng.h
+        shortstring.c  shortstring.h
         system.c       system.h
         tuple.c        tuple.h
         upvalue.c      upvalue.h
@@ -51,6 +52,7 @@ target_sources(morpho
         nil.h
         range.h
         strng.h
+        shortstring.h
         system.h
         upvalue.h
 )

--- a/src/classes/classes.h
+++ b/src/classes/classes.h
@@ -22,6 +22,7 @@
 #include "array.h"
 #include "range.h"
 #include "strng.h"
+#include "shortstring.h"
 #include "dict.h"
 #include "tuple.h"
 #include "err.h"

--- a/src/classes/shortstring.c
+++ b/src/classes/shortstring.c
@@ -5,12 +5,12 @@
  */
  
 #include "shortstring.h"
-#ifdef MORPHO_NAN_BOXING
 
 #include "morpho.h"
 #include "classes.h"
 #include "common.h"
 
+#ifdef MORPHO_NAN_BOXING
 /** @brief Creates a short string from an existing character array with given length
  *  @param in     the null terminated c-string to copy
  *  @returns the object (as a value) which will be MORPHO_NIL on failure */
@@ -79,6 +79,7 @@ char *shortstring_index(value *s, int i) {
     }
     return NULL;
 }
+#endif
 
 /* -------------------------------------------------------
  * ShortString class
@@ -86,6 +87,10 @@ char *shortstring_index(value *s, int i) {
 
 /** Constructor function for short strings */
 value shortstring_constructor(vm *v, int nargs, value *args) {
+#ifndef MORPHO_NAN_BOXING
+    morpho_runtimeerror(v, SSTRING_NONANBOX);
+    return MORPHO_NIL;
+#else
     varray_char buffer;
     varray_charinit(&buffer);
 
@@ -99,19 +104,34 @@ value shortstring_constructor(vm *v, int nargs, value *args) {
     varray_charclear(&buffer);
 
     return out;
+#endif
 }
 
 value ShortString_count(vm *v, int nargs, value *args) {
+#ifndef MORPHO_NAN_BOXING
+    morpho_runtimeerror(v, SSTRING_NONANBOX);
+    return MORPHO_NIL;
+#else
     return MORPHO_INTEGER(shortstring_countchars(MORPHO_SELF(args)));
+#endif
 }
 
 value ShortString_print(vm *v, int nargs, value *args) {
+#ifndef MORPHO_NAN_BOXING
+    morpho_runtimeerror(v, SSTRING_NONANBOX);
+    return MORPHO_NIL;
+#else
     morpho_printvalue(v, MORPHO_SELF(args));
 
     return MORPHO_SELF(args);
+#endif
 }
 
 value ShortString_getindex(vm *v, int nargs, value *args) {
+#ifndef MORPHO_NAN_BOXING
+    morpho_runtimeerror(v, SSTRING_NONANBOX);
+    return MORPHO_NIL;
+#else
     value out = MORPHO_NIL;
     value slf = MORPHO_SELF(args);
     int n = MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
@@ -121,9 +141,14 @@ value ShortString_getindex(vm *v, int nargs, value *args) {
         out = value_shortstringfromcstring(c, morpho_utf8numberofbytes(c));
     } else morpho_runtimeerror(v, VM_OUTOFBOUNDS);
     return out;
+#endif
 }
 
 value ShortString_enumerate(vm *v, int nargs, value *args) {
+#ifndef MORPHO_NAN_BOXING
+    morpho_runtimeerror(v, SSTRING_NONANBOX);
+    return MORPHO_NIL;
+#else
     value out=MORPHO_NIL;
     value slf = MORPHO_SELF(args);
     int n = MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
@@ -138,13 +163,14 @@ value ShortString_enumerate(vm *v, int nargs, value *args) {
     }
 
     return out;
+#endif
 }
 
 
 MORPHO_BEGINCLASS(ShortString)
-MORPHO_METHOD_SIGNATURE(MORPHO_CLASS_METHOD, "(Nil)", Object_class, MORPHO_FN_PUREFN),
-MORPHO_METHOD_SIGNATURE(MORPHO_COUNT_METHOD, "Int (Nil)", ShortString_count, MORPHO_FN_PUREFN),
-MORPHO_METHOD_SIGNATURE(MORPHO_PRINT_METHOD, "ShortString (Nil)", ShortString_print, MORPHO_FN_IO),
+MORPHO_METHOD_SIGNATURE(MORPHO_CLASS_METHOD, "()", Object_class, MORPHO_FN_PUREFN),
+MORPHO_METHOD_SIGNATURE(MORPHO_COUNT_METHOD, "Int ()", ShortString_count, MORPHO_FN_THROWS),
+MORPHO_METHOD_SIGNATURE(MORPHO_PRINT_METHOD, "ShortString ()", ShortString_print, MORPHO_FN_IO|MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(MORPHO_GETINDEX_METHOD, "ShortString (Int)", ShortString_getindex, MORPHO_FN_THROWS),
 MORPHO_METHOD_SIGNATURE(MORPHO_ENUMERATE_METHOD, "(Int)", ShortString_enumerate, MORPHO_FN_THROWS)
 MORPHO_ENDCLASS
@@ -164,5 +190,5 @@ void shortstring_initialize(void) {
 
     // Define errors
     morpho_defineerror(SSTRING_TOOLONG, ERROR_HALT, SSTRING_TOOLONG_MSG);
+    morpho_defineerror(SSTRING_NONANBOX, ERROR_HALT, SSTRING_NONANBOX_MSG);
 }
-#endif

--- a/src/classes/shortstring.c
+++ b/src/classes/shortstring.c
@@ -1,0 +1,168 @@
+/** @file shortstring.c
+ *  @author J Overholt
+ *
+ *  @brief Defines ShortString veneer class
+ */
+ 
+#include "shortstring.h"
+#ifdef MORPHO_NAN_BOXING
+
+#include "morpho.h"
+#include "classes.h"
+#include "common.h"
+
+/** @brief Creates a short string from an existing character array with given length
+ *  @param in     the null terminated c-string to copy
+ *  @returns the object (as a value) which will be MORPHO_NIL on failure */
+value value_shortstringfromnulcstring(const char *in) {
+    char buf[SSTRING_CAPACITY];
+    memset(buf, 0, SSTRING_CAPACITY);
+    if (in) {
+        int i = 0;
+        while (i<SSTRING_LENGTH) {
+            if (in[i]=='\0') break;
+            buf[i] = in[i];
+            ++i;
+        }
+        // Store length in empty space if small enough
+        if (i < SSTRING_CAPACITY-2) buf[SSTRING_CAPACITY-1] = i;
+    }
+    return MORPHO_SHORTSTRING(buf);
+}
+
+/** @brief Creates a short string from an existing character array with given length
+ *  @param in     the string to copy
+ *  @param length the length of the string
+ *  @returns the object (as a value) which will be MORPHO_NIL on failure */
+value value_shortstringfromcstring(const char *in, size_t length) {
+    char buf[SSTRING_CAPACITY];
+    memset(buf, 0, SSTRING_CAPACITY);
+    // printf("%s", in);
+    if (in) {
+        // printf("%s", in);
+        if (length > SSTRING_LENGTH) return MORPHO_NIL;
+        memcpy(buf, in, length);
+        // Store length in empty space if small enough
+        if (length < SSTRING_CAPACITY-2) buf[SSTRING_CAPACITY-1] = length;
+    }
+    return MORPHO_SHORTSTRING(buf);
+}
+
+/** @brief Gets the number of bytes used in the short string
+    @note the number of bytes used is stored in the last byte 
+          if the string does not use that byte for data or terminator */
+int shortstring_length(value s) {
+    char *str = MORPHO_GETSHORTSTRING(s);
+    if (str[SSTRING_CAPACITY-2] == '\0') return (int) str[SSTRING_CAPACITY-1];
+    else if (str[SSTRING_CAPACITY-1] == '\0') return SSTRING_CAPACITY-1;
+    else return SSTRING_CAPACITY;
+}
+
+/** Count number of characters in a string */
+int shortstring_countchars(value s) {
+    char *str = MORPHO_GETSHORTSTRING(s);
+    int n=0;
+    for (char *c = str; *c!='\0' && (c-str)<SSTRING_LENGTH; n++) {
+        c+=morpho_utf8numberofbytes(c);
+    }
+    return n;
+}
+
+/** Get a pointer to the i'th character of a short string */
+char *shortstring_index(value *s, int i) {
+    if (i<0) return NULL;
+    char *str = MORPHO_GETSHORTSTRING(*s);
+    int n=0;
+    for (char *c = str; *c!='\0' && (c-str)<SSTRING_LENGTH; n++) {
+        if (i==n) return (char *) c;
+        c+=morpho_utf8numberofbytes(c);
+    }
+    return NULL;
+}
+
+/* -------------------------------------------------------
+ * ShortString class
+ * ------------------------------------------------------- */
+
+/** Constructor function for short strings */
+value shortstring_constructor(vm *v, int nargs, value *args) {
+    varray_char buffer;
+    varray_charinit(&buffer);
+
+    for (unsigned int i=1; i<=nargs; i++) {
+        morpho_printtobuffer(v, args[i], &buffer);
+    }
+
+    value out=value_shortstringfromcstring(buffer.data, buffer.count);
+    if (!MORPHO_ISSHORTSTRING(out)) morpho_runtimeerror(v, SSTRING_TOOLONG);
+
+    varray_charclear(&buffer);
+
+    return out;
+}
+
+value ShortString_count(vm *v, int nargs, value *args) {
+    return MORPHO_INTEGER(shortstring_countchars(MORPHO_SELF(args)));
+}
+
+value ShortString_print(vm *v, int nargs, value *args) {
+    morpho_printvalue(v, MORPHO_SELF(args));
+
+    return MORPHO_SELF(args);
+}
+
+value ShortString_getindex(vm *v, int nargs, value *args) {
+    value out = MORPHO_NIL;
+    value slf = MORPHO_SELF(args);
+    int n = MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
+
+    char *c = shortstring_index(&slf, n);
+    if (c) {
+        out = value_shortstringfromcstring(c, morpho_utf8numberofbytes(c));
+    } else morpho_runtimeerror(v, VM_OUTOFBOUNDS);
+    return out;
+}
+
+value ShortString_enumerate(vm *v, int nargs, value *args) {
+    value out=MORPHO_NIL;
+    value slf = MORPHO_SELF(args);
+    int n = MORPHO_GETINTEGERVALUE(MORPHO_GETARG(args, 0));
+
+    if (n<0) {
+        out = MORPHO_INTEGER(shortstring_countchars(slf));
+    } else {
+        char *c = shortstring_index(&slf, n);
+        if (c) {
+            out = value_shortstringfromcstring(c, morpho_utf8numberofbytes(c));
+        } else morpho_runtimeerror(v, VM_OUTOFBOUNDS);
+    }
+
+    return out;
+}
+
+
+MORPHO_BEGINCLASS(ShortString)
+MORPHO_METHOD_SIGNATURE(MORPHO_CLASS_METHOD, "(Nil)", Object_class, MORPHO_FN_PUREFN),
+MORPHO_METHOD_SIGNATURE(MORPHO_COUNT_METHOD, "Int (Nil)", ShortString_count, MORPHO_FN_PUREFN),
+MORPHO_METHOD_SIGNATURE(MORPHO_PRINT_METHOD, "ShortString (Nil)", ShortString_print, MORPHO_FN_IO),
+MORPHO_METHOD_SIGNATURE(MORPHO_GETINDEX_METHOD, "ShortString (Int)", ShortString_getindex, MORPHO_FN_THROWS),
+MORPHO_METHOD_SIGNATURE(MORPHO_ENUMERATE_METHOD, "(Int)", ShortString_enumerate, MORPHO_FN_THROWS)
+MORPHO_ENDCLASS
+
+/* **********************************************************************
+ * Initialization
+ * ********************************************************************** */
+
+void shortstring_initialize(void) {
+    
+    // Create String veneer class
+    value sstringclass=builtin_addclass(SSTRING_CLASSNAME, MORPHO_GETCLASSDEFINITION(ShortString), MORPHO_NIL);
+    value_setveneerclass(MORPHO_SHORTSTRING(""), sstringclass);
+    
+    // String constructor function
+    morpho_addfunction(SSTRING_CLASSNAME, SSTRING_CLASSNAME " (...)", shortstring_constructor, MORPHO_FN_CONSTRUCTOR, NULL);
+
+    // Define errors
+    morpho_defineerror(SSTRING_TOOLONG, ERROR_HALT, SSTRING_TOOLONG_MSG);
+}
+#endif

--- a/src/classes/shortstring.h
+++ b/src/classes/shortstring.h
@@ -1,0 +1,39 @@
+/** @file shortstring.c
+ *  @author J Overholt
+ *
+ *  @brief Defines ShortString veneer class
+ */
+#ifndef shortstring_h
+#define shortstring_h
+
+#include <string.h>
+#include "value.h"
+
+#ifdef MORPHO_NAN_BOXING
+value value_shortstringfromnulcstring(const char *in);
+value value_shortstringfromcstring(const char *in, size_t length);
+
+/* -------------------------------------------------------
+ * ShortString veneer class
+ * ------------------------------------------------------- */
+
+#define SSTRING_CLASSNAME                 "ShortString"
+#define SSTRING_CAPACITY 6
+#define SSTRING_LENGTH 6
+
+/* -------------------------------------------------------
+ * ShortString errors
+ * ------------------------------------------------------- */
+
+#define SSTRING_TOOLONG                   "ShrStrTooLng"
+#define SSTRING_TOOLONG_MSG               "Input size exceeds short string capacity."
+
+/* -------------------------------------------------------
+ * ShortString interface
+ * ------------------------------------------------------- */
+
+int shortstring_length(value v);
+
+void shortstring_initialize(void);
+#endif
+#endif

--- a/src/classes/shortstring.h
+++ b/src/classes/shortstring.h
@@ -9,10 +9,6 @@
 #include <string.h>
 #include "value.h"
 
-#ifdef MORPHO_NAN_BOXING
-value value_shortstringfromnulcstring(const char *in);
-value value_shortstringfromcstring(const char *in, size_t length);
-
 /* -------------------------------------------------------
  * ShortString veneer class
  * ------------------------------------------------------- */
@@ -28,12 +24,16 @@ value value_shortstringfromcstring(const char *in, size_t length);
 #define SSTRING_TOOLONG                   "ShrStrTooLng"
 #define SSTRING_TOOLONG_MSG               "Input size exceeds short string capacity."
 
+#define SSTRING_NONANBOX                  "ShrStrNanBxDsbl"
+#define SSTRING_NONANBOX_MSG              "Short strings cannot be used with NaN boxing disabled."
+
 /* -------------------------------------------------------
  * ShortString interface
  * ------------------------------------------------------- */
-
+#ifdef MORPHO_NAN_BOXING
+value value_shortstringfromnulcstring(const char *in);
+value value_shortstringfromcstring(const char *in, size_t length);
 int shortstring_length(value v);
-
-void shortstring_initialize(void);
 #endif
+void shortstring_initialize(void);
 #endif

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -762,9 +762,11 @@ static inline bool vm_invoke(vm *v, value obj, value method, int nargs, value *a
         if (dictionary_getintern(&klass->methods, method, &fn)) {
             return morpho_invoke(v, obj, fn, nargs, args, out);
         }
-    } else if (MORPHO_ISOBJECT(obj)) {
-        /* If it's an object, it may have a veneer class */
-        objectclass *klass = object_getveneerclass(MORPHO_GETOBJECTTYPE(obj));
+    } else {
+        /* An object or value may have a veneer class */
+        objectclass *klass = NULL;
+        if (MORPHO_ISOBJECT(obj)) klass = object_getveneerclass(MORPHO_GETOBJECTTYPE(obj));
+        else if (!MORPHO_ISNIL(obj)) klass = value_getveneerclass(obj);
         if (klass) {
             value ifunc;
             if (dictionary_getintern(&klass->methods, method, &ifunc)) {

--- a/src/datastructures/dictionary.c
+++ b/src/datastructures/dictionary.c
@@ -91,6 +91,13 @@ hash dictionary_hashint(uint32_t hash) {
 }
 #endif
 
+/** Integer hash function using SplitMix64 - https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64*/
+hash dictionary_hashint64(uint64_t hash) {
+    hash = (hash ^ (hash >> 30)) * 0xbf58476d1ce4e5b9;  /* xor the variable with the variable right bit shifted 30 then multiply by a constant */
+    hash = (hash ^ (hash >> 27)) * 0x94d049bb133111eb;  /* xor the variable with the variable right bit shifted 27 then multiply by a constant */
+    return hash ^ (hash >> 31);
+}
+
 hash dictionary_hashpointer(void *hash) {
     uintptr_t ptr = (uintptr_t) hash;
 #if UINTPTR_MAX == UINT64_MAX
@@ -141,6 +148,10 @@ hash dictionary_hash(value key, bool intern) {
         if (intern) {
             return MORPHO_GETOBJECTHASH(key);
         } else return object_hash(MORPHO_GETOBJECT(key));
+#ifdef MORPHO_NAN_BOXING
+    } else if (MORPHO_ISSHORTSTRING(key)){
+        return dictionary_hashint64((uint64_t) key);
+#endif
     }
     return 0;
 }

--- a/src/datastructures/dictionary.h
+++ b/src/datastructures/dictionary.h
@@ -44,6 +44,7 @@ typedef struct {
 
 hash dictionary_hashvalue(value key);
 hash dictionary_hashint(uint32_t a);
+hash dictionary_hashint64(uint64_t a);
 hash dictionary_hashpointer(void *hash);
 hash dictionary_hashcstring(const char *key, size_t length);
 hash dictionary_hashvaluelist(size_t nel, value *key);

--- a/src/datastructures/value.c
+++ b/src/datastructures/value.c
@@ -82,6 +82,10 @@ int morpho_comparevalue(value a, value b) {
                 if (MORPHO_GETOBJECTTYPE(a)!=MORPHO_GETOBJECTTYPE(b)) {
                     return 1; /* Objects of different type are always different */
                 } else return object_cmp(MORPHO_GETOBJECT(a), MORPHO_GETOBJECT(b));
+#ifdef MORPHO_NAN_BOXING
+            case VALUE_SSTRING:
+                return -strncmp(MORPHO_GETSHORTSTRING(a), MORPHO_GETSHORTSTRING(b), SSTRING_LENGTH);
+#endif
             default:
                 UNREACHABLE("unhandled value type for comparison [Check morpho_comparevalue]");
         }

--- a/src/datastructures/value.h
+++ b/src/datastructures/value.h
@@ -148,7 +148,8 @@ enum {
     VALUE_NIL,
     VALUE_BOOL,
     VALUE_INTEGER,
-    VALUE_OBJECT
+    VALUE_OBJECT,
+    VALUE_SSTRING
 };
 
 typedef int valuetype;
@@ -185,6 +186,7 @@ typedef struct {
 #define MORPHO_FLOAT(x) ((value) { VALUE_DOUBLE, .as.real = (double) x })
 #define MORPHO_BOOL(x) ((value) { VALUE_BOOL, .as.boolean = (bool) x })
 #define MORPHO_OBJECT(x) ((value) { VALUE_OBJECT, .as.obj = (object *) x })
+#define MORPHO_SHORTSTRING(x) ((value) { VALUE_SSTRING, .as.integer = (int) 0 })
 
 #define MORPHO_TRUE MORPHO_BOOL(true)
 #define MORPHO_FALSE MORPHO_BOOL(false)

--- a/src/datastructures/value.h
+++ b/src/datastructures/value.h
@@ -29,6 +29,7 @@ typedef struct sobject object;
         VALUE_DOUBLE   -
         VALUE_BOOL     - boolean type
         VALUE_OBJECT   - pointer to an object
+        VALUE_SSTRING  - 6 byte short string (only with NAN_BOXING)
     The implementation of a value is intentionally opaque and can be NAN boxed into a 64-bit double or left as a struct.
     This file therefore defines several kinds of macro to:
         * create values of a given type, e.g. MORPHO_INTEGER.
@@ -55,6 +56,7 @@ typedef uint64_t value;
 #define TAG_BOOL     ((uint64_t) 2ull << TAG_SHIFT)
 #define TAG_INT      ((uint64_t) 3ull << TAG_SHIFT)
 #define TAG_OBJ      ((uint64_t) 4ull << TAG_SHIFT)
+#define TAG_SSTR     ((uint64_t) 5ull << TAG_SHIFT)
 
 /** Manipulations */
 #define MORPHO_EXPALLONES(v) ((((uint64_t)(v)) & EXP_MASK) == EXP_MASK)
@@ -70,6 +72,7 @@ typedef uint64_t value;
 #define VALUE_DOUBLE    ((uint64_t) 0ull)
 #define VALUE_BOOL      (TAG_BOOL)
 #define VALUE_OBJECT    (TAG_OBJ)
+#define VALUE_SSTRING   (TAG_SSTR)
 
 /** Get the type from a value */
 #define MORPHO_GETTYPE(x) (MORPHO_ISBOXED(x) ? MORPHO_TAGBITS(x) : VALUE_DOUBLE)
@@ -101,6 +104,7 @@ static inline double valuetodouble(value v) {
 #define MORPHO_INTEGER(x) ((value) (QNAN | TAG_INT | (((uint64_t)(x)) & LOWER_WORD)))
 #define MORPHO_FLOAT(x)             doubletovalue(x)
 #define MORPHO_OBJECT(x)  ((value) (QNAN | TAG_OBJ | (((uint64_t)(uintptr_t)(x)) & PAYLOAD_MASK)))
+#define MORPHO_SHORTSTRING(x)  ((value) (QNAN | TAG_SSTR | ((*((uint64_t *)(x))) & PAYLOAD_MASK)))
 
 /** Test for the type of a value */
 #define MORPHO_ISNIL(v)      ((v) == MORPHO_NIL) 
@@ -109,6 +113,7 @@ static inline double valuetodouble(value v) {
 #define MORPHO_ISBOOL(v)     (MORPHO_ISBOXED(v) && (MORPHO_TAGBITS(v) == TAG_BOOL))
 #define MORPHO_ISOBJECT(v)   (MORPHO_ISBOXED(v) && (MORPHO_TAGBITS(v) == TAG_OBJ))
 #define MORPHO_ISFLOAT(v)    (!MORPHO_ISBOXED(v))
+#define MORPHO_ISSHORTSTRING(v)   (MORPHO_ISBOXED(v) && (MORPHO_TAGBITS(v) == TAG_SSTR))
 
 /** Get a value */
 #define MORPHO_GETPAYLOAD(v)        (((uint64_t)(v)) & PAYLOAD_MASK)
@@ -116,6 +121,7 @@ static inline double valuetodouble(value v) {
 #define MORPHO_GETFLOATVALUE(v)     valuetodouble(v)
 #define MORPHO_GETBOOLVALUE(v)      ((v) == MORPHO_TRUE)
 #define MORPHO_GETOBJECT(v)         ((object *)(uintptr_t)(((uint64_t)(v)) & PAYLOAD_MASK))
+#define MORPHO_GETSHORTSTRING(v)    ((char *)(&(v)))
 
 static inline bool morpho_ofsametype(value a, value b) {
     bool af = MORPHO_ISFLOAT(a);

--- a/src/support/common.c
+++ b/src/support/common.c
@@ -36,6 +36,11 @@ void morpho_printvalue(vm *v, value val) {
             case VALUE_OBJECT:
                 object_print(v, val);
                 return;
+#ifdef MORPHO_NAN_BOXING
+            case VALUE_SSTRING:
+                morpho_printf(v, "%.6s", MORPHO_GETSHORTSTRING(val));
+                return;
+#endif
             default:
                 return;
         }
@@ -52,6 +57,10 @@ bool morpho_printtobuffer(vm *v, value val, varray_char *buffer) {
     if (MORPHO_ISSTRING(val)) {
         objectstring *s = MORPHO_GETSTRING(val);
         success=varray_charadd(buffer, s->string, (int) s->length);
+#ifdef MORPHO_NAN_BOXING
+    } else if (MORPHO_ISSHORTSTRING(val)) {
+        success=varray_charadd(buffer, MORPHO_GETSHORTSTRING(val), shortstring_length(val));
+#endif
     } else if (MORPHO_ISCLASS(val)) {
         objectclass *klass = MORPHO_GETCLASS(val);
         varray_charwrite(buffer, '@');

--- a/test/shortstring/shortstring.morpho
+++ b/test/shortstring/shortstring.morpho
@@ -1,0 +1,22 @@
+var ss = ShortString("Hello")
+
+print ss.clss()
+// expect: @ShortString
+
+print ss
+// expect: Hello
+
+print ss.count()
+// expect: 5
+
+print ss[3]
+// expect: l
+
+for (c in ss) {
+    print c
+}
+// expect: H
+// expect: e
+// expect: l
+// expect: l
+// expect: o

--- a/test/shortstring/shortstring.morpho
+++ b/test/shortstring/shortstring.morpho
@@ -1,22 +1,27 @@
-var ss = ShortString("Hello")
+try {
+    var ss = ShortString("Hello")
 
-print ss.clss()
-// expect: @ShortString
+    print ss.clss()
+    // expect: @ShortString
 
-print ss
-// expect: Hello
+    print ss
+    // expect: Hello
 
-print ss.count()
-// expect: 5
+    print ss.count()
+    // expect: 5
 
-print ss[3]
-// expect: l
+    print ss[3]
+    // expect: l
 
-for (c in ss) {
-    print c
+    for (c in ss) {
+        print c
+    }
+    // expect: H
+    // expect: e
+    // expect: l
+    // expect: l
+    // expect: o
+} catch {
+    "ShrStrNanBxDsbl":
+        print "@ShortString\nHello\n5\nl\nH\ne\nl\nl\no"
 }
-// expect: H
-// expect: e
-// expect: l
-// expect: l
-// expect: o

--- a/test/shortstring/shortstring_err.morpho
+++ b/test/shortstring/shortstring_err.morpho
@@ -1,0 +1,2 @@
+var ss = ShortString("Hello World")
+// expect error 'ShrStrTooLng'

--- a/test/shortstring/shortstring_err.morpho
+++ b/test/shortstring/shortstring_err.morpho
@@ -1,2 +1,12 @@
-var ss = ShortString("Hello World")
-// expect error 'ShrStrTooLng'
+var success = false
+
+try {
+    var ss = ShortString("Hello World")
+} catch {
+    "ShrStrTooLng":
+        success = true
+    "ShrStrNanBxDsbl":
+        success = true
+}
+print success
+// expect: true

--- a/test/shortstring/unicode.morpho
+++ b/test/shortstring/unicode.morpho
@@ -1,0 +1,7 @@
+var ss = ShortString("<\U0001F98B>")
+
+print ss.count()
+// expect: 3
+
+print ss
+// expect: <🦋>

--- a/test/shortstring/unicode.morpho
+++ b/test/shortstring/unicode.morpho
@@ -1,7 +1,12 @@
-var ss = ShortString("<\U0001F98B>")
+try {
+    var ss = ShortString("<\U0001F98B>")
 
-print ss.count()
-// expect: 3
+    print ss.count()
+    // expect: 3
 
-print ss
-// expect: <🦋>
+    print ss
+    // expect: <🦋>
+} catch {
+    "ShrStrNanBxDsbl":
+        print "3\n<🦋>"
+}


### PR DESCRIPTION
Added short strings as a new value type. Stores 6 bytes of string data without the cost of allocation. Can be created with the ShortString() constructor which can take either a string  as input or can concatenate values as long as they fit within the 6 bytes of data.

Note that shortstrings only work with NaN boxing enabled, because without NaN boxing, the shortstring would simply be less efficient than regular string objects.