### PR TITLE
Improved function signature enforcement for built-in functions that take no arguments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ dkms.conf
 .vscode/
 
 test/FailedTests*.txt
+examples/FailedExamples*.txt
 *.png
 *.out
 manual/src/manual.lyx~

--- a/examples/elementtypes/qtensorCG2.morpho
+++ b/examples/elementtypes/qtensorCG2.morpho
@@ -30,7 +30,7 @@ class QTensor {
 
   initialField() { 
     self.q_tensor = Field(self.mesh, 
-                          fn(x,y,z) Matrix([0.01*random(1), 0.01*random(1)]),
+                          fn(x,y,z) Matrix([0.01*random(), 0.01*random()]),
                           finiteelementspace=FiniteElementSpace("CG2", grade=2)
                           )
   }

--- a/examples/qtensor/qtensor.morpho
+++ b/examples/qtensor/qtensor.morpho
@@ -42,7 +42,7 @@ bnd.addgrade(0) // add point elements
 Since a 2D Q-tensor for a uniaxial nematic is symmetric and traceless, there are only two independent components, Qxx and Qxy. We thus define the q_tensor to be a 2D vector, with its components being Qxx and Qxy. We initialize it to be zero and add a random noise of 1% strength as a perturbation to start the gradient descent. The Q-tensor usually takes values of order 1, so we can use 0.01*random(1) as the initial 1% noise.
 */
 
-var q_tensor = Field(m, fn(x,y,z) Matrix([0.01*random(1), 0.01*random(1)]))
+var q_tensor = Field(m, fn(x,y,z) Matrix([0.01*random(), 0.01*random()]))
 
 // Define various components of the energy.
 // Since these functions are meant to be arguments to AreaIntegral and LineIntegral, their first input argument has to be the position vector `x`. The field argument (the q-tensor in our case) comes after.

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -253,7 +253,16 @@ bool builtin_addfunctiontodict(dictionary *dict, value name, value fn, bool forc
     objectclass *klass = builtin_getparentclass(fn);
 
     if (dictionary_get(dict, selector, &prev) && klass != builtin_getparentclass(prev)) { // Override superclass methods for now
-        entry=fn;
+        if (forcewrap) { // If forcewrap is on create a mf, otherwise just use regular fn
+            if (!metafunction_wrap(name, fn, &entry)) return false;
+        } else {
+            entry=fn;
+        }
+
+        if (MORPHO_ISMETAFUNCTION(entry)) {
+            metafunction_setclass(MORPHO_GETMETAFUNCTION(entry), klass);
+            builtin_bindobject(MORPHO_GETOBJECT(entry));
+        }
         success=dictionary_insert(dict, selector, entry);
     } else {
         if (MORPHO_ISNIL(prev) && forcewrap) {

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -1214,7 +1214,7 @@ static bool mfcompiler_emitresolver(mfcompiler *compiler, int nresolutions, mfco
      * impls with required leading args still need a minarity check first. */
     if (nresolutions==1 &&
         mfcompiler_resolutionisterminal(&resolutions[0], path->nparams, path->known) &&
-        (path->aritychecked || !resolutions[0].varg || resolutions[0].minarity<=0)) {
+        path->aritychecked && (!resolutions[0].varg || resolutions[0].minarity<=0)) {
         return mfcompiler_emitresolve(compiler, resolutions[0].fnindex, entry);
     }
 

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -1212,9 +1212,8 @@ static bool mfcompiler_emitresolver(mfcompiler *compiler, int nresolutions, mfco
 
     /* A single fully-determined resolution can be emitted directly. Variadic
      * impls with required leading args still need a minarity check first. */
-    if (nresolutions==1 &&
-        mfcompiler_resolutionisterminal(&resolutions[0], path->nparams, path->known) &&
-        path->aritychecked && (!resolutions[0].varg || resolutions[0].minarity<=0)) {
+    if (nresolutions==1 && path->aritychecked &&
+        mfcompiler_resolutionisterminal(&resolutions[0], path->nparams, path->known)) {
         return mfcompiler_emitresolve(compiler, resolutions[0].fnindex, entry);
     }
 

--- a/test/complex/constructor_error.morpho
+++ b/test/complex/constructor_error.morpho
@@ -2,7 +2,7 @@
 try {
     var X = Complex(1)    
 } catch {
-    "CmplxCns" : print "ok"
+    "MltplDsptchFld" : print "ok"
 // expect: ok
 }    
 

--- a/test/list/mf_too_many.morpho
+++ b/test/list/mf_too_many.morpho
@@ -1,0 +1,15 @@
+var l = [1,2,3,4]
+
+try {
+    print l.order("text")
+} catch {
+    "MltplDsptchFld" : print "ok"
+// expect: ok
+}
+
+try {
+    print l.count("text")
+} catch {
+    "MltplDsptchFld" : print "ok"
+// expect: ok
+}


### PR DESCRIPTION
Fix for issue #328. Ensures that built-in functions are forced to be made as metafunctions even when overriding superclass functions. Made resolution for the metafunction compiler stricter. 

Also created tests and fixed some bugs in qtensor example codes.