### PR TITLE
Added hint datastructure to error blocks

### DIFF
--- a/src/build.h
+++ b/src/build.h
@@ -135,6 +135,9 @@
 /** @brief Build with new help system */
 #define MORPHO_INCLUDE_HELP
 
+/** @brief Build with new hint system */
+#define MORPHO_INCLUDE_HINT
+
 /* **********************************************************************
  * Libraries
  * ********************************************************************** */

--- a/src/classes/json.c
+++ b/src/classes/json.c
@@ -578,6 +578,7 @@ value JSON_parse(vm *v, int nargs, value *args) {
         morpho_runtimeerror(v, err.id);
     }
     varray_valueclear(&objects);
+    error_clear(&err);
     
     return out;
 }

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -1325,18 +1325,16 @@ void metafunction_writeerrorhint(error *err, objectmetafunction *fn, int nargs, 
         sig = metafunction_getsignature(fn->fns.data[i]);
         varray_charadd(&siglist, "   ", 3);
         varray_charadd(&siglist, name->string, (int) name->length);
-        varray_charadd(&siglist, "(", 1);
-        metafunction_formatarglist(sig->types.count, sig->types.data, &siglist);
-        if (sig->varg) varray_charadd(&siglist, ", ...", 5);
-        varray_charadd(&siglist, ")\n", 2);
+        signature_printbuffer(sig, &siglist, false);
+        varray_charwrite(&siglist, '\n');
     }
-    // Replace final endline with null
+    // Replace final newline with null char
     siglist.data[siglist.count-1]='\0';
 
     varray_char inputsig;
     varray_charinit(&inputsig);
     metafunction_formatarglist(nargs, args, &inputsig);
-    varray_charadd(&inputsig, "\0", 1);
+    varray_charwrite(&inputsig, '\0');
 
     error_addhintmsg(err, "The function \'%s\' is not defined for the signature \'(%s)\'. The defined signatures are:\n%s", 
                     name->string, inputsig.data, siglist.data);

--- a/src/classes/metafunction.c
+++ b/src/classes/metafunction.c
@@ -433,6 +433,8 @@ void mfresolutionset_filterbyspecificity(mfresolutionset *set, int nargs, value 
     mfresolutionset_collapse(set);
 }
 
+void metafunction_writeerrorhint(error *err, objectmetafunction *fn, int nargs, value *args);
+
 /** @brief Find a resolution, if any exists, for given arguments by direct comparison.
  @details Slow direct comparison acts as a source of truth for metafunction compiler.
  @param[in] fn - the metafunction to resolve
@@ -458,7 +460,7 @@ static bool metafunction_resolveslow(objectmetafunction *fn, int nargs, value *a
     mfresolutionset_filterbyspecificity(&set, nargs, args);
     
     switch (set.count) {
-        case 0: if (err) error_writewithid(err, VM_MLTPLDSPTCHFLD); return false;
+        case 0: if (err) { error_writewithid(err, VM_MLTPLDSPTCHFLD); metafunction_writeerrorhint(err, fn, nargs, args); } return false;
         case 1: if (out) *out = set.data[0].fn; return true;
         default: if (err) error_writewithid(err, METAFUNCTION_CMPLAMBGS); return false;
     }
@@ -1298,6 +1300,51 @@ void metafunction_disassemble(objectmetafunction *fn) {
     }
 }
 
+bool metafunction_formatarglist(int nargs, value *args, varray_char *buffer) {
+    value argtype;
+    objectstring *s;
+    for (int i=0; i<nargs; ++i) {
+        if (MORPHO_ISCLASS(args[i])) argtype = args[i];
+        else value_type(args[i], &argtype);
+        
+        s = MORPHO_GETSTRING(MORPHO_GETCLASS(argtype)->name);
+        varray_charadd(buffer, s->string, (int) s->length);
+        if (i<nargs-1) varray_charadd(buffer, ", ", 2);
+    }
+    return true;
+}
+
+void metafunction_writeerrorhint(error *err, objectmetafunction *fn, int nargs, value *args) {
+    objectstring *name = MORPHO_GETSTRING(fn->name);
+    
+    // Translate the list of available functions into a string
+    varray_char siglist;
+    varray_charinit(&siglist);
+    signature *sig;
+    for (int i = 0; i < fn->fns.count; ++i) {
+        sig = metafunction_getsignature(fn->fns.data[i]);
+        varray_charadd(&siglist, "   ", 3);
+        varray_charadd(&siglist, name->string, (int) name->length);
+        varray_charadd(&siglist, "(", 1);
+        metafunction_formatarglist(sig->types.count, sig->types.data, &siglist);
+        if (sig->varg) varray_charadd(&siglist, ", ...", 5);
+        varray_charadd(&siglist, ")\n", 2);
+    }
+    // Replace final endline with null
+    siglist.data[siglist.count-1]='\0';
+
+    varray_char inputsig;
+    varray_charinit(&inputsig);
+    metafunction_formatarglist(nargs, args, &inputsig);
+    varray_charadd(&inputsig, "\0", 1);
+
+    error_addhintmsg(err, "The function \'%s\' is not defined for the signature \'(%s)\'. The defined signatures are:\n%s", 
+                    name->string, inputsig.data, siglist.data);
+
+    varray_charclear(&siglist);
+    varray_charclear(&inputsig);
+}
+
 /* --------------------------
  * Fast resolver VM
  * -------------------------- */
@@ -1318,8 +1365,11 @@ static bool metafunction_runresolver(objectmetafunction *fn, int nargs, value *a
                 *out=fn->fns.data[instructions[++pc]];
                 return true;
             }
-            case MFOP_FAIL:
-                error_writewithid(err, VM_MLTPLDSPTCHFLD); return false;
+            case MFOP_FAIL: {
+                error_writewithid(err, VM_MLTPLDSPTCHFLD); 
+                metafunction_writeerrorhint(err, fn, nargs, args);
+                return false;
+            }
             case MFOP_GETUID: {
                 int arg = instructions[++pc];
                 value type;
@@ -1327,7 +1377,9 @@ static bool metafunction_runresolver(objectmetafunction *fn, int nargs, value *a
                     reg = MORPHO_GETCLASS(type)->uid;
                     break;
                 }
-                error_writewithid(err, VM_MLTPLDSPTCHFLD); return false;
+                error_writewithid(err, VM_MLTPLDSPTCHFLD); 
+                metafunction_writeerrorhint(err, fn, nargs, args);
+                return false;
             }
             case MFOP_SPARSE: {
                 int ncases=instructions[pc+1];
@@ -1372,7 +1424,9 @@ bool metafunction_reduce(objectmetafunction *fn, int nargs, value *args, error *
     mfresolutionset_filterbyspecificity(&set, nargs, args);
 
     if (set.count<=0) { // No resolutions left
-        error_writewithid(err, VM_MLTPLDSPTCHFLD); return false;
+        error_writewithid(err, VM_MLTPLDSPTCHFLD); 
+        metafunction_writeerrorhint(err, fn, nargs, args);
+        return false;
     } else if (set.count==1 &&
                mfresolution_isterminal(set.data[0].sig, nargs, args)) { // Resolution is completely specified
         *out = set.data[0].fn; return true;

--- a/src/classes/strng.c
+++ b/src/classes/strng.c
@@ -160,6 +160,7 @@ bool string_tonumber(objectstring *string, value *out) {
         }
     }
     lex_clear(&l);
+    error_clear(&err);
 
     return false;
 }

--- a/src/core/compile.c
+++ b/src/core/compile.c
@@ -4919,6 +4919,7 @@ void compiler_init(const char *source, program *out, compiler *c) {
  *  @param[in]  c        compiler to clear */
 void compiler_clear(compiler *c) {
     lex_clear(&c->lex);
+    error_clear(&c->err);
     parse_clear(&c->parse);
     compiler_fstackclear(c);
     syntaxtree_clear(&c->tree);

--- a/src/core/vm.c
+++ b/src/core/vm.c
@@ -92,6 +92,7 @@ static void vm_clear(vm *v) {
     varray_valueclear(&v->retain);
     vm_graylistclear(&v->gray);
     varray_charclear(&v->buffer);
+    error_clear(&v->err);
     vm_freeobjects(v);
     
     for (int i=0; i<v->subkernels.count; i++) {

--- a/src/datastructures/CMakeLists.txt
+++ b/src/datastructures/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(morpho
         dictionary.c        dictionary.h
         debugannotation.c   debugannotation.h
         error.c             error.h
+        hint.c              hint.h
         object.c            object.h
         program.c           program.h
         signature.c         signature.h
@@ -20,6 +21,7 @@ target_sources(morpho
         dictionary.h
         debugannotation.h
         error.h
+        hint.h
         object.h
         program.h
         signature.h

--- a/src/datastructures/error.c
+++ b/src/datastructures/error.c
@@ -50,7 +50,7 @@ void error_clear(error *err) {
     err->id=NULL;
     err->file=NULL;
     err->line=ERROR_POSNUNIDENTIFIABLE; err->posn=ERROR_POSNUNIDENTIFIABLE;
-    if (err->hnt) { hint_free(err->hnt); err->hnt=NULL; }
+    if (err->hnt) hint_free(&err->hnt);
 }
 
 /** Clears an error structure
@@ -130,6 +130,7 @@ void error_writewithid(error *err, errorid id, ... ) {
  *  @param msg  The hint message
  *  @param ...  Additional parameters (the data for the printf commands in the message) */
 void error_addhintmsg(error *err, const char *msg, ...) {
+    if (err->hnt) hint_free(&err->hnt);
     va_list args;
     va_start(args, msg);
     err->hnt = hint_createfromformatstringvalist(msg, args);

--- a/src/datastructures/error.c
+++ b/src/datastructures/error.c
@@ -50,11 +50,13 @@ void error_clear(error *err) {
     err->id=NULL;
     err->file=NULL;
     err->line=ERROR_POSNUNIDENTIFIABLE; err->posn=ERROR_POSNUNIDENTIFIABLE;
+    if (err->hnt) { hint_free(err->hnt); err->hnt=NULL; }
 }
 
 /** Clears an error structure
  *  @param err      Error struct to fill out */
 void error_init(error *err) {
+    err->hnt=NULL;
     error_clear(err);
 }
 
@@ -120,6 +122,17 @@ void error_writewithid(error *err, errorid id, ... ) {
     va_list args;
     va_start(args, id);
     morpho_writeerrorwithidvalist(err, id, NULL, ERROR_POSNUNIDENTIFIABLE, ERROR_POSNUNIDENTIFIABLE, args);
+    va_end(args);
+}
+
+/** @brief Adds a hint blurb to the error structure
+ *  @param err  The error structure
+ *  @param msg  The hint message
+ *  @param ...  Additional parameters (the data for the printf commands in the message) */
+void error_addhintmsg(error *err, const char *msg, ...) {
+    va_list args;
+    va_start(args, msg);
+    err->hnt = hint_createfromformatstringvalist(msg, args);
     va_end(args);
 }
 

--- a/src/datastructures/error.h
+++ b/src/datastructures/error.h
@@ -10,6 +10,7 @@
 #include <stdarg.h>
 #include "build.h"
 #include "varray.h"
+#include "hint.h"
 
 /* -------------------------------------------------------
  * Error type definitions
@@ -67,6 +68,7 @@ typedef struct {
     errorid id;
     char *file; 
     int line, posn;
+    hint *hnt;
     char msg[MORPHO_ERRORSTRINGSIZE];
 } error;
 
@@ -201,6 +203,7 @@ void error_clear(error *err);
 void morpho_writeerrorwithidvalist(error *err, errorid id, char *file, int line, int posn, va_list args);
 void morpho_writeerrorwithid(error *err, errorid id, char *file, int line, int posn, ...);
 void error_writewithid(error *err, errorid id, ... );
+void error_addhintmsg(error *err, const char *msg, ...);
 void morpho_writeusererror(error *err, errorid id, char *message);
 void morpho_defineerror(errorid id, errorcategory cat, char *message);
 

--- a/src/datastructures/hint.c
+++ b/src/datastructures/hint.c
@@ -49,7 +49,8 @@ hint *hint_createfromformatstring(const char *format, ...) {
     return out;
 }
 
-void hint_free(hint *hnt) {
-    MORPHO_FREE(hnt);
+void hint_free(hint **hnt) {
+    MORPHO_FREE(*hnt);
+    *hnt = NULL;
 }
 

--- a/src/datastructures/hint.c
+++ b/src/datastructures/hint.c
@@ -1,0 +1,55 @@
+/** @file hint.c
+ *  @author J Overholt
+ *
+ *  @brief Morpho hint data structure
+*/
+#include "hint.h"
+
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include "memory.h"
+
+hint *hint_createfromcstring(const char *str, size_t len) {
+    hint *new = MORPHO_MALLOC(sizeof(hint) + sizeof(char)*(len+1));
+
+    if (new) {
+        new->msg = new->data;
+        memcpy(new->msg, str, len);
+        new->msg[len] = '\0';
+        new->length = len;
+        return new;
+    }
+    return NULL;
+}
+
+hint *hint_createfromformatstringvalist(const char *format, va_list args) {
+    // Initial guess allocation
+    char *buffer = MORPHO_MALLOC(sizeof(char)*HINT_BUFFERSIZE);
+    if (!buffer) return NULL;
+    size_t n = vsnprintf(buffer, HINT_BUFFERSIZE, format, args);
+    if (n > HINT_BUFFERSIZE) { // Fix if underallocated
+        MORPHO_FREE(buffer);
+        buffer = MORPHO_MALLOC(sizeof(char)*(n+1));
+        if (!buffer) return NULL;
+        vsnprintf(buffer, n+1, format, args);
+    }
+    hint *out = hint_createfromcstring(buffer, n);
+    MORPHO_FREE(buffer);
+
+    return out;
+}
+
+hint *hint_createfromformatstring(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    hint *out = hint_createfromformatstringvalist(format, args);
+    va_end(args);
+
+    return out;
+}
+
+void hint_free(hint *hnt) {
+    MORPHO_FREE(hnt);
+}
+

--- a/src/datastructures/hint.h
+++ b/src/datastructures/hint.h
@@ -22,6 +22,6 @@ typedef struct {
 hint *hint_createfromcstring(const char *str, size_t len);
 hint *hint_createfromformatstring(const char *format, ...);
 hint *hint_createfromformatstringvalist(const char *format, va_list args);
-void hint_free(hint *hnt);
+void hint_free(hint **hnt);
 
 #endif

--- a/src/datastructures/hint.h
+++ b/src/datastructures/hint.h
@@ -1,0 +1,27 @@
+/** @file hint.h
+ *  @author J Overholt
+ *
+ *  @brief Morpho hint data structure
+*/
+
+#ifndef hint_h
+#define hint_h
+
+#include <stdarg.h>
+#include "varray.h"
+
+typedef struct {
+    int type;
+    size_t length;
+    char *msg;
+    char data[];
+} hint;
+
+#define HINT_BUFFERSIZE 255
+
+hint *hint_createfromcstring(const char *str, size_t len);
+hint *hint_createfromformatstring(const char *format, ...);
+hint *hint_createfromformatstringvalist(const char *format, va_list args);
+void hint_free(hint *hnt);
+
+#endif

--- a/src/datastructures/signature.c
+++ b/src/datastructures/signature.c
@@ -194,6 +194,7 @@ bool signature_parse(const char *sig, signature *out) {
     
     parse_clear(&p);
     lex_clear(&l);
+    error_clear(&err);
     
     return success;
 }

--- a/src/datastructures/signature.c
+++ b/src/datastructures/signature.c
@@ -214,3 +214,27 @@ void signature_print(signature *s) {
     }
     printf(")");
 }
+
+/** Print a signature to a varray buffer */
+void signature_printbuffer(signature *s, varray_char *buffer, bool incl_ret) {
+    objectstring *str;
+    if (incl_ret && MORPHO_ISCLASS(s->ret)) { // Print return type
+        str = MORPHO_GETSTRING(MORPHO_GETCLASS(s->ret)->name);
+        varray_charadd(buffer, str->string, (int) str->length);
+        varray_charwrite(buffer, ' ');
+    }
+    varray_charwrite(buffer, '(');
+    for (int i = 0; i < s->types.count; ++i) { // Print arguments
+        value type=s->types.data[i];
+
+        if (s->varg && i==s->types.count-1) varray_charadd(buffer, "...", 3);
+        else if (MORPHO_ISNIL(type)) varray_charwrite(buffer, '_');
+        else if (MORPHO_ISCLASS(type)) {
+            str = MORPHO_GETSTRING(MORPHO_GETCLASS(type)->name);
+            varray_charadd(buffer, str->string, (int) str->length);
+        }
+
+        if (i<s->types.count-1) varray_charadd(buffer, ", ", 2);
+    }
+    varray_charwrite(buffer, ')');
+}

--- a/src/datastructures/signature.h
+++ b/src/datastructures/signature.h
@@ -34,5 +34,6 @@ void signature_set(signature *s, int nparam, value *types);
 bool signature_parse(const char *sig, signature *out);
 
 void signature_print(signature *s);
+void signature_printbuffer(signature *s, varray_char *buffer, bool incl_ret);
 
 #endif

--- a/src/geometry/mesh.c
+++ b/src/geometry/mesh.c
@@ -1026,6 +1026,7 @@ meshload_cleanup:
     varray_charclear(&line);
     dictionary_clear(&vdict);
     varray_doubleclear(&vert);
+    error_clear(&err);
 
     return out;
 }

--- a/src/support/help.c
+++ b/src/support/help.c
@@ -1173,6 +1173,7 @@ bool help_parse(md_file *file, int file_index) {
         if (file->filename) fprintf(stderr, " in %s", file->filename);
         fprintf(stderr, "\n");
     }
+    error_clear(&err);
     return ok;
 }
 

--- a/src/support/parse.c
+++ b/src/support/parse.c
@@ -1850,6 +1850,7 @@ bool parse_value(const char *in, value *out) {
     }
     
     syntaxtree_clear(&tree);
+    error_clear(&err);
     return success;
 }
 

--- a/test/test.py
+++ b/test/test.py
@@ -16,7 +16,7 @@ import colored
 from colored import stylize
 
 # define what command to use to invoke the interpreter
-command = 'morpho6'
+command = 'morpho6 --no-hints'
 
 # define the file extension to test
 ext = 'morpho'


### PR DESCRIPTION
Created the foundations for a hint system, and added one hint message to the multiple dispatch failure error. Hints are supplied alongside errors with `error_addhintmsg(error *err, const char *msg, ...)`, and will be displayed after error messages are handled by the cli or whichever interface is being used. 
The other interfaces like the notebook interface will require updates to work with this change.

Also this changes the python test script to pass the `--no-hints` flag to ignore hints in test cases (This also causes every one of the tests on this pr to fail until the pr for the cli is accepted). 